### PR TITLE
🚀 perf(reports): レポートページの時間計算を最適化

### DIFF
--- a/functions/src/reports/time.ts
+++ b/functions/src/reports/time.ts
@@ -71,7 +71,9 @@ async function fetchReportData(
   const labelsSnapshot = await db.collection('labels').where('projectId', '==', null).get();
   const unyoLabel = labelsSnapshot.docs.find((doc) => doc.data().name === '運用');
   if (!unyoLabel) {
-    return { items: [], totalDurationSec: 0 };
+    throw new Error(
+      `「運用」ラベルが見つかりません。ラベルの初期設定を確認してください (type: ${type}, from: ${fromDate.toISOString()}, to: ${toDate.toISOString()})`
+    );
   }
   const unyoLabelId = unyoLabel.id;
 


### PR DESCRIPTION
## Summary
- レポートページの時間計算処理を大幅に最適化
- N+1クエリ問題を解消（約910クエリ → 約18クエリ）
- Promise.allによる並列処理を導入
- 重複ロジックを共通関数に統合

## Changes
- `functions/src/reports/time.ts`: クエリ最適化と共通関数化

## Performance Improvement
| 項目 | 改善前 | 改善後 |
|------|--------|--------|
| クエリ方式 | 順次処理（N+1問題） | 並列処理（Promise.all） |
| タスク取得 | 全タスク取得→フィルタ | kubunLabelIdでDB側フィルタ |
| セッション取得 | タスクごとに個別クエリ | プロジェクトごとに日付範囲クエリ |
| 推定クエリ数 | ~910 | ~18 |

## Test plan
- [x] Cloud Functionsのビルド成功
- [x] デプロイ完了
- [x] ブラウザでレポートページの動作確認
- [x] データが正しく表示されることを確認

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * レポート集計処理を内部で整理・統合し、一貫性と効率を向上しました。
* **Bug Fixes**
  * バックエンドの検証を強化し、欠損データがある場合に明確なエラーを返すようにしました。
* **ユーザー向け影響**
  * UIや操作に直接の変更はなく、既存のレポート機能の挙動は維持されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->