### PR TITLE
🐛 fix(functions): 課題名の重複出力を修正

### DIFF
--- a/functions/src/drive/create.ts
+++ b/functions/src/drive/create.ts
@@ -122,8 +122,11 @@ export const createDriveFolder = onRequest(
 
       // 既存フォルダを検索
       // フォルダ名の構成: issueKey + タイトル（backlogProjectKeyは使用しない）
+      // task.titleが既にissueKeyで始まっている場合は、issueKeyを追加しない（重複防止）
       const parts: string[] = [];
-      if (task.external?.issueKey) {
+      const titleStartsWithIssueKey =
+        task.external?.issueKey && task.title.startsWith(task.external.issueKey);
+      if (task.external?.issueKey && !titleStartsWithIssueKey) {
         parts.push(task.external.issueKey);
       }
       parts.push(task.title);

--- a/functions/src/github/create.ts
+++ b/functions/src/github/create.ts
@@ -109,7 +109,13 @@ export const createFireIssue = onRequest(
       }
 
       // Issue作成
-      const issueTitle = `${task.external?.issueKey || ''} ${task.title}`;
+      // task.titleが既にissueKeyで始まっている場合は、issueKeyを追加しない（重複防止）
+      const titleStartsWithIssueKey =
+        task.external?.issueKey && task.title.startsWith(task.external.issueKey);
+      const issueTitle =
+        task.external?.issueKey && !titleStartsWithIssueKey
+          ? `${task.external.issueKey} ${task.title}`
+          : task.title;
       const issueBody = [
         task.external?.url ? `Backlog: ${task.external.url}` : '',
         task.description || '',


### PR DESCRIPTION
## Summary
- ドライブフォルダ作成時に課題番号が重複する問題を修正
- GitHub Issue作成時に課題番号が重複する問題を修正
- `task.title`が既に`issueKey`で始まっている場合は追加しないロジックを実装

## 問題
ドライブ作成時に、課題名が「BRGREG-2921 BRGREG-2921 あああああ」のように課題番号が2回表示されていた。

## 原因
- Backlog Webhookでタイトルに課題番号を接頭辞として追加済み
- ドライブ/GitHub Issue作成時に再度`issueKey`を追加していた

## 修正内容
| ファイル | 修正内容 |
|---------|---------|
| `functions/src/drive/create.ts` | フォルダ名生成ロジックに重複チェックを追加 |
| `functions/src/github/create.ts` | Issueタイトル生成ロジックに重複チェックを追加 |

## Test plan
- [x] `bun run lint` - 成功
- [x] `bun run functions:build` - 成功
- [x] `chumo-3506a`にデプロイ済み

Closes #77

🤖 Generated with [Claude Code](https://claude.ai/code)