### PR TITLE
✨ タスク並び替え機能を追加

### DIFF
--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -42,6 +42,8 @@ function TasksPageContent() {
   const {
     viewMode,
     setViewMode,
+    sortMode,
+    setSortMode,
     selectedProjectType,
     setSelectedProjectType,
     selectedTaskId,
@@ -144,6 +146,7 @@ function TasksPageContent() {
     filters,
     activeTaskId: activeSessionValue?.taskId,
     mountTime,
+    sortMode,
   });
 
   // ページネーション管理
@@ -344,6 +347,8 @@ function TasksPageContent() {
               kobetsuLabelId={kobetsuLabelId}
               currentUserId={user?.id || null}
               emptyMessage={effectiveEmptyMessage}
+              sortMode={sortMode}
+              onSortModeChange={setSortMode}
             />
 
             <Box

--- a/components/tasks/SortableTableRow.tsx
+++ b/components/tasks/SortableTableRow.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { TableRow, TableCell, Box, Typography } from '@mui/material';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { Task, Label, User } from '@/types';
+import { FLOW_STATUS_LABELS } from '@/constants/taskConstants';
+import { Badge } from '@/components/ui/badge';
+import { UnreadBadge } from '@/components/ui/UnreadBadge';
+import { ProgressStatusBadge } from '@/components/ui/ProgressStatusBadge';
+import { TaskTimerButton } from '@/components/tasks/TaskTimerButton';
+import { format } from 'date-fns';
+import { ProjectType } from '@/constants/projectTypes';
+
+interface SortableTableRowProps {
+  task: Task & { projectType: ProjectType };
+  onTaskSelect: (taskId: string) => void;
+  shouldShowProjectType: boolean;
+  allUsers?: User[];
+  allLabels?: Label[];
+  activeSession: { projectType: ProjectType; taskId: string; sessionId: string } | null;
+  onStartTimer: (projectType: ProjectType, taskId: string) => void;
+  onStopTimer: () => void;
+  isStoppingTimer: boolean;
+  currentUserId?: string | null;
+  unreadTaskIds?: Set<string>;
+  isNewTask: boolean;
+  isDragDisabled?: boolean;
+}
+
+export function SortableTableRow({
+  task,
+  onTaskSelect,
+  shouldShowProjectType,
+  allUsers,
+  allLabels,
+  activeSession,
+  onStartTimer,
+  onStopTimer,
+  isStoppingTimer,
+  currentUserId,
+  unreadTaskIds,
+  isNewTask,
+  isDragDisabled = false,
+}: SortableTableRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: task.id,
+    disabled: isDragDisabled,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    backgroundColor: isDragging ? 'rgba(0, 0, 0, 0.04)' : undefined,
+  };
+
+  const isActive = activeSession?.taskId === task.id;
+  const isStartDisabled = !!activeSession && activeSession.taskId !== task.id;
+
+  const getAssigneeNames = (assigneeIds: string[]) => {
+    if (!allUsers || assigneeIds.length === 0) return '-';
+    return (
+      assigneeIds
+        .map((id) => allUsers.find((u) => u.id === id)?.displayName)
+        .filter(Boolean)
+        .join(', ') || '-'
+    );
+  };
+
+  const getLabelName = (labelId: string) => {
+    if (!allLabels || !labelId) return '-';
+    const label = allLabels.find((l) => l.id === labelId);
+    return label?.name || '-';
+  };
+
+  return (
+    <TableRow
+      ref={setNodeRef}
+      style={style}
+      onClick={() => onTaskSelect(task.id)}
+      sx={{
+        cursor: 'pointer',
+        '&:hover': { bgcolor: 'action.hover' },
+      }}
+    >
+      {/* ドラッグハンドル */}
+      <TableCell
+        sx={{ width: 40, p: 0.5, cursor: isDragDisabled ? 'default' : 'grab' }}
+        onClick={(e) => e.stopPropagation()}
+        {...attributes}
+        {...listeners}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: isDragDisabled ? 'text.disabled' : 'text.secondary',
+          }}
+        >
+          <DragIndicatorIcon fontSize="small" />
+        </Box>
+      </TableCell>
+      <TableCell sx={{ maxWidth: '400px' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {isNewTask && <Badge variant="error">New</Badge>}
+          {currentUserId &&
+            task.assigneeIds.includes(currentUserId) &&
+            unreadTaskIds?.has(task.id) && <UnreadBadge size="sm" />}
+          <Typography
+            sx={{
+              fontWeight: 'medium',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: 1,
+            }}
+          >
+            {task.title}
+          </Typography>
+        </Box>
+        {shouldShowProjectType && (
+          <Typography
+            variant="caption"
+            sx={{
+              display: 'block',
+              color: 'text.secondary',
+              mt: 0.5,
+            }}
+          >
+            {task.projectType || ''}
+          </Typography>
+        )}
+      </TableCell>
+      <TableCell
+        sx={{
+          maxWidth: '200px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {getAssigneeNames(task.assigneeIds)}
+      </TableCell>
+      <TableCell>{task.itUpDate ? format(task.itUpDate, 'yyyy-MM-dd') : '-'}</TableCell>
+      <TableCell>{FLOW_STATUS_LABELS[task.flowStatus]}</TableCell>
+      <TableCell>
+        {task.progressStatus ? <ProgressStatusBadge status={task.progressStatus} /> : '-'}
+      </TableCell>
+      <TableCell>{getLabelName(task.kubunLabelId)}</TableCell>
+      <TableCell onClick={(e) => e.stopPropagation()}>
+        <TaskTimerButton
+          isActive={isActive}
+          onStart={() => onStartTimer(task.projectType, task.id)}
+          onStop={onStopTimer}
+          isStopping={isStoppingTimer}
+          startDisabled={isStartDisabled}
+          stopButtonSize="small"
+          startButtonSize="sm"
+          displayMode="icon"
+        />
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/hooks/useTasksList.ts
+++ b/hooks/useTasksList.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Task } from '@/types';
 import { ListTasksUseCase } from '@/lib/application/usecases/listTasks.usecase';
 import { TaskFiltersDTO } from '@/lib/presentation/dtos/task.dto';
+import { SortMode } from '@/stores/taskStore';
 
 /**
  * タスク一覧のカスタムフック
@@ -12,12 +13,14 @@ export function useTasksList(params: {
   filters?: TaskFiltersDTO;
   activeTaskId?: string;
   mountTime?: number;
+  sortMode?: SortMode;
 }) {
   const {
     tasks,
     filters = { status: 'not-completed' },
     activeTaskId,
     mountTime = Date.now(),
+    sortMode = 'order',
   } = params;
 
   const useCase = useMemo(() => new ListTasksUseCase(), []);
@@ -29,8 +32,9 @@ export function useTasksList(params: {
       filters,
       activeTaskId,
       mountTime,
+      sortMode,
     });
-  }, [tasks, filters, activeTaskId, mountTime, useCase]);
+  }, [tasks, filters, activeTaskId, mountTime, sortMode, useCase]);
 
   return {
     sortedTasks,

--- a/hooks/useUpdateTasksOrder.ts
+++ b/hooks/useUpdateTasksOrder.ts
@@ -1,0 +1,160 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { writeBatch, doc, Timestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase/config';
+import { Task } from '@/types';
+import { ProjectType } from '@/constants/projectTypes';
+
+interface TaskOrderUpdate {
+  taskId: string;
+  projectType: ProjectType;
+  newOrder: number;
+}
+
+/**
+ * 複数タスクのorder値を一括更新するmutation
+ * D&D並び替え時に使用
+ */
+export function useUpdateTasksOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (updates: TaskOrderUpdate[]) => {
+      if (!db) throw new Error('Firestore is not initialized');
+      if (updates.length === 0) return;
+
+      const batch = writeBatch(db);
+      const now = Timestamp.fromDate(new Date());
+
+      updates.forEach(({ taskId, projectType, newOrder }) => {
+        const taskRef = doc(db!, 'projects', projectType, 'tasks', taskId);
+        batch.update(taskRef, {
+          order: newOrder,
+          updatedAt: now,
+        });
+      });
+
+      await batch.commit();
+    },
+    // 楽観的更新
+    onMutate: async (updates) => {
+      // 関連するクエリをキャンセル（tasksとdashboard-tasks）
+      const queryPredicate = (query: { queryKey: readonly unknown[] }) =>
+        query.queryKey[0] === 'tasks' || query.queryKey[0] === 'dashboard-tasks';
+
+      await queryClient.cancelQueries({ predicate: queryPredicate });
+
+      // 現在のキャッシュを保存（ロールバック用）
+      const previousData = queryClient.getQueriesData({ predicate: queryPredicate });
+
+      // キャッシュを楽観的に更新
+      queryClient.setQueriesData({ predicate: queryPredicate }, (old: unknown) => {
+        if (!old) return old;
+
+        // 無限スクロールのデータ構造に対応
+        if (typeof old === 'object' && old !== null && 'pages' in old) {
+          const pagesData = old as { pages: { tasks: Task[] }[]; pageParams: unknown[] };
+          return {
+            ...pagesData,
+            pages: pagesData.pages.map((page) => ({
+              ...page,
+              tasks: page.tasks.map((task: Task) => {
+                const update = updates.find((u) => u.taskId === task.id);
+                if (update) {
+                  return { ...task, order: update.newOrder };
+                }
+                return task;
+              }),
+            })),
+          };
+        }
+
+        // 通常の配列データに対応
+        if (Array.isArray(old)) {
+          return old.map((task: Task) => {
+            const update = updates.find((u) => u.taskId === task.id);
+            if (update) {
+              return { ...task, order: update.newOrder };
+            }
+            return task;
+          });
+        }
+
+        return old;
+      });
+
+      return { previousData };
+    },
+    // エラー時にロールバック
+    onError: (_err, _variables, context) => {
+      if (context?.previousData) {
+        context.previousData.forEach(([queryKey, data]) => {
+          queryClient.setQueryData(queryKey, data);
+        });
+      }
+    },
+    // 成功・エラー後にクエリを再フェッチ
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'tasks' || query.queryKey[0] === 'dashboard-tasks',
+      });
+    },
+  });
+}
+
+/**
+ * ドラッグ後の新しいorder値を計算するユーティリティ
+ * @param tasks ソート済みタスク配列
+ * @param activeId ドラッグ中のタスクID
+ * @param overId ドロップ先のタスクID
+ * @returns 更新が必要なタスクのorder情報
+ */
+export function calculateNewOrder(
+  tasks: (Task & { projectType: ProjectType })[],
+  activeId: string,
+  overId: string
+): TaskOrderUpdate[] {
+  const oldIndex = tasks.findIndex((t) => t.id === activeId);
+  const newIndex = tasks.findIndex((t) => t.id === overId);
+
+  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+    return [];
+  }
+
+  const movedTask = tasks[oldIndex];
+
+  // 移動先の前後のタスクを取得
+  let prevOrder: number;
+  let nextOrder: number;
+
+  if (newIndex === 0) {
+    // 先頭に移動
+    prevOrder = 0;
+    nextOrder = tasks[0].order;
+  } else if (newIndex >= tasks.length - 1) {
+    // 末尾に移動
+    prevOrder = tasks[tasks.length - 1].order;
+    nextOrder = prevOrder + 2000;
+  } else if (oldIndex < newIndex) {
+    // 下に移動
+    prevOrder = tasks[newIndex].order;
+    nextOrder = tasks[newIndex + 1]?.order ?? prevOrder + 2000;
+  } else {
+    // 上に移動
+    prevOrder = tasks[newIndex - 1]?.order ?? 0;
+    nextOrder = tasks[newIndex].order;
+  }
+
+  // 中間値を計算
+  const newOrder = (prevOrder + nextOrder) / 2;
+
+  return [
+    {
+      taskId: movedTask.id,
+      projectType: movedTask.projectType,
+      newOrder,
+    },
+  ];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "chumo-task-management-tool",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.5",
@@ -372,6 +375,59 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "mcp:serena": "uvx --from git+https://github.com/oraios/serena serena start-mcp-server"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.5",

--- a/stores/taskStore.ts
+++ b/stores/taskStore.ts
@@ -6,6 +6,7 @@ import { TASK_STORAGE_KEY } from '@/constants/timer';
 
 export type ViewMode = 'table' | 'personal';
 export type DashboardViewMode = 'table' | 'card';
+export type SortMode = 'order' | 'itUpDate-asc' | 'itUpDate-desc';
 
 interface TaskStore {
   // ビューモード（タスク一覧）
@@ -15,6 +16,10 @@ interface TaskStore {
   // ダッシュボードビューモード
   dashboardViewMode: DashboardViewMode;
   setDashboardViewMode: (_mode: DashboardViewMode) => void;
+
+  // ソートモード（タスク一覧）
+  sortMode: SortMode;
+  setSortMode: (_mode: SortMode) => void;
 
   // 選択中のタスクID
   selectedTaskId: string | null;
@@ -61,6 +66,9 @@ export const useTaskStore = create<TaskStore>()(
       dashboardViewMode: 'table',
       setDashboardViewMode: (mode) => set({ dashboardViewMode: mode }),
 
+      sortMode: 'order',
+      setSortMode: (mode) => set({ sortMode: mode }),
+
       selectedTaskId: null,
       setSelectedTaskId: (taskId) => set({ selectedTaskId: taskId }),
 
@@ -103,14 +111,16 @@ export const useTaskStore = create<TaskStore>()(
     {
       name: TASK_STORAGE_KEY, // ストレージのキー名
       storage: createJSONStorage(() => localStorage), // localStorageを使用
-      // activeSession、viewMode、dashboardViewModeを永続化
+      // activeSession、viewMode、dashboardViewMode、sortModeを永続化
       // activeSession: ページリロード時に実行中のタイマー状態を復元するため
       // viewMode: タスク一覧の表示モード選択を維持するため
       // dashboardViewMode: ダッシュボードの表示モード選択を維持するため
+      // sortMode: タスク一覧のソートモード選択を維持するため
       partialize: (state) => ({
         activeSession: state.activeSession,
         viewMode: state.viewMode,
         dashboardViewMode: state.dashboardViewMode,
+        sortMode: state.sortMode,
       }),
     }
   )


### PR DESCRIPTION
## Summary

- ダッシュボードでドラッグ&ドロップによるタスク並び替えが可能に
- タスク一覧・ダッシュボードでITアップ日による昇順/降順ソートが可能に
- 楽観的更新（Optimistic Update）による即座のUI反映

## 変更内容

### 新規ファイル
- `hooks/useUpdateTasksOrder.ts` - Firestoreバッチ更新 + 楽観的更新
- `components/tasks/SortableTableRow.tsx` - D&D対応テーブル行

### 主な変更
- `stores/taskStore.ts` - sortMode状態追加
- `components/tasks/TaskListTable.tsx` - D&D機能（オプショナル）、ヘッダーソート
- `app/(dashboard)/dashboard/page.tsx` - D&D + ITアップ日ソート対応
- `app/(dashboard)/tasks/page.tsx` - ITアップ日ソート対応

## 動作

### ダッシュボード
- テーブル表示時、行左端のドラッグハンドルで並び替え可能
- 「ITアップ」ヘッダークリックで昇順→降順→手動並び替えを切り替え
- ITアップ日ソート中はD&D無効

### タスク一覧
- 「ITアップ」ヘッダークリックで昇順→降順→手動並び替えを切り替え

## Test plan

- [ ] ダッシュボード：D&Dで順番変更 → リロードしても保持される
- [ ] ダッシュボード：ITアップヘッダークリックでソート切り替え
- [ ] タスク一覧：ITアップヘッダークリックでソート切り替え
- [ ] ITアップ日ソート時、nullは末尾に配置される

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * タスクのドラッグ・アンド・ドロップによる並び替え機能を追加
  * 複数のソートモード（順序、IT更新日の昇順・降順）に対応

* **改善**
  * タスク一覧表示のソート機能とUIを拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->