### PR TITLE
✨ feat(tasks): カード表示にITアップ日を追加

### DIFF
--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -390,7 +390,6 @@ function TasksPageContent() {
             <TaskPersonalView
               tasks={sortedTasks || []}
               onTaskSelect={handleTaskSelect}
-              selectedProjectType={selectedProjectType}
               allUsers={allUsers}
               allLabels={allLabels}
               currentUserId={user?.id || null}

--- a/components/tasks/PersonalTaskSection.tsx
+++ b/components/tasks/PersonalTaskSection.tsx
@@ -22,7 +22,6 @@ interface PersonalTaskSectionProps {
   onTaskSelect: (taskId: string) => void;
   allLabels?: Label[];
   currentUserId?: string | null;
-  showProjectType?: boolean;
   unreadTaskIds?: Set<string>;
   oneWeekAgo: number;
   defaultExpanded?: boolean;
@@ -33,7 +32,6 @@ export function PersonalTaskSection({
   onTaskSelect,
   allLabels,
   currentUserId,
-  showProjectType = false,
   unreadTaskIds,
   oneWeekAgo,
   defaultExpanded = true,
@@ -109,7 +107,6 @@ export function PersonalTaskSection({
               onTaskSelect={onTaskSelect}
               allLabels={allLabels}
               currentUserId={currentUserId}
-              showProjectType={showProjectType}
               unreadTaskIds={unreadTaskIds}
               oneWeekAgo={oneWeekAgo}
               defaultExpanded={true}

--- a/components/tasks/StatusBlock.tsx
+++ b/components/tasks/StatusBlock.tsx
@@ -21,7 +21,6 @@ interface StatusBlockProps {
   onTaskSelect: (taskId: string) => void;
   allLabels?: Label[];
   currentUserId?: string | null;
-  showProjectType?: boolean;
   unreadTaskIds?: Set<string>;
   oneWeekAgo: number;
   defaultExpanded?: boolean;
@@ -32,7 +31,6 @@ export function StatusBlock({
   onTaskSelect,
   allLabels,
   currentUserId,
-  showProjectType = false,
   unreadTaskIds,
   oneWeekAgo,
   defaultExpanded = true,
@@ -90,7 +88,6 @@ export function StatusBlock({
               onTaskSelect={onTaskSelect}
               allLabels={allLabels}
               currentUserId={currentUserId}
-              showProjectType={showProjectType}
               hasUnreadComment={unreadTaskIds?.has(task.id)}
               isNewTask={isNewTask(task)}
             />

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -5,7 +5,9 @@ import { Badge } from '@/components/ui/badge';
 import { UnreadBadge } from '@/components/ui/UnreadBadge';
 import { ProgressStatusBadge } from '@/components/ui/ProgressStatusBadge';
 import { Paper, Typography, Box, Chip } from '@mui/material';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import { ProjectType } from '@/constants/projectTypes';
+import { format } from 'date-fns';
 
 interface TaskCardProps {
   task: Task & { projectType: ProjectType };
@@ -68,7 +70,7 @@ export function TaskCard({
           display: 'flex',
           alignItems: 'flex-start',
           gap: 0.5,
-          mb: label || showProjectType ? 1 : 0,
+          mb: label || showProjectType || task.itUpDate ? 1 : 0,
         }}
       >
         {isNewTask && <Badge variant="error">New</Badge>}
@@ -92,11 +94,35 @@ export function TaskCard({
         </Typography>
       </Box>
 
-      {/* メタ情報行（区分ラベル、進捗ステータス、またはプロジェクトタイプがある場合のみ表示） */}
+      {/* メタ情報行（区分ラベル、進捗ステータス、プロジェクトタイプ、またはITアップ日がある場合のみ表示） */}
       {(label ||
         (showProgressStatus && task.progressStatus) ||
-        (showProjectType && task.projectType)) && (
+        (showProjectType && task.projectType) ||
+        task.itUpDate) && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+          {/* ITアップ日 */}
+          {task.itUpDate && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.25,
+                color: 'text.secondary',
+              }}
+            >
+              <CalendarTodayIcon sx={{ fontSize: '0.75rem' }} />
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: '0.7rem',
+                  fontWeight: 'medium',
+                }}
+              >
+                {format(task.itUpDate, 'MM/dd')}
+              </Typography>
+            </Box>
+          )}
+
           {/* 区分ラベル（バッジスタイル） */}
           {label && (
             <Chip

--- a/components/tasks/TaskCard.tsx
+++ b/components/tasks/TaskCard.tsx
@@ -14,7 +14,6 @@ interface TaskCardProps {
   onTaskSelect: (taskId: string) => void;
   allLabels?: Label[];
   currentUserId?: string | null;
-  showProjectType?: boolean;
   showProgressStatus?: boolean;
   hasUnreadComment?: boolean;
   isNewTask?: boolean;
@@ -25,7 +24,6 @@ export function TaskCard({
   onTaskSelect,
   allLabels,
   currentUserId,
-  showProjectType = false,
   showProgressStatus = false,
   hasUnreadComment = false,
   isNewTask = false,
@@ -70,7 +68,7 @@ export function TaskCard({
           display: 'flex',
           alignItems: 'flex-start',
           gap: 0.5,
-          mb: label || showProjectType || task.itUpDate ? 1 : 0,
+          mb: label || task.itUpDate ? 1 : 0,
         }}
       >
         {isNewTask && <Badge variant="error">New</Badge>}
@@ -94,12 +92,29 @@ export function TaskCard({
         </Typography>
       </Box>
 
-      {/* メタ情報行（区分ラベル、進捗ステータス、プロジェクトタイプ、またはITアップ日がある場合のみ表示） */}
-      {(label ||
-        (showProgressStatus && task.progressStatus) ||
-        (showProjectType && task.projectType) ||
-        task.itUpDate) && (
+      {/* メタ情報行（区分ラベル、進捗ステータス、またはITアップ日がある場合のみ表示） */}
+      {(label || (showProgressStatus && task.progressStatus) || task.itUpDate) && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+          {/* 区分ラベル（バッジスタイル） */}
+          {label && (
+            <Chip
+              label={label.name}
+              size="small"
+              sx={{
+                height: 20,
+                fontSize: '0.7rem',
+                fontWeight: 'medium',
+                bgcolor: `${label.color}20`,
+                color: label.color,
+                border: '1px solid',
+                borderColor: `${label.color}40`,
+                '& .MuiChip-label': {
+                  px: 1,
+                },
+              }}
+            />
+          )}
+
           {/* ITアップ日 */}
           {task.itUpDate && (
             <Box
@@ -123,42 +138,9 @@ export function TaskCard({
             </Box>
           )}
 
-          {/* 区分ラベル（バッジスタイル） */}
-          {label && (
-            <Chip
-              label={label.name}
-              size="small"
-              sx={{
-                height: 20,
-                fontSize: '0.7rem',
-                fontWeight: 'medium',
-                bgcolor: `${label.color}20`,
-                color: label.color,
-                border: '1px solid',
-                borderColor: `${label.color}40`,
-                '& .MuiChip-label': {
-                  px: 1,
-                },
-              }}
-            />
-          )}
-
           {/* 進捗ステータス */}
           {showProgressStatus && task.progressStatus && (
             <ProgressStatusBadge status={task.progressStatus} />
-          )}
-
-          {/* プロジェクトタイプ */}
-          {showProjectType && task.projectType && (
-            <Typography
-              variant="caption"
-              sx={{
-                color: 'text.disabled',
-                fontSize: '0.65rem',
-              }}
-            >
-              {task.projectType}
-            </Typography>
           )}
         </Box>
       )}

--- a/components/tasks/TaskCardGrid.tsx
+++ b/components/tasks/TaskCardGrid.tsx
@@ -134,7 +134,6 @@ export function TaskCardGrid({
                 onTaskSelect={onTaskSelect}
                 allLabels={allLabels}
                 currentUserId={currentUserId}
-                showProgressStatus={true}
                 hasUnreadComment={!!(currentUserId && unreadTaskIds?.has(task.id))}
                 isNewTask={isNewTask(task)}
               />

--- a/components/tasks/TaskCardGrid.tsx
+++ b/components/tasks/TaskCardGrid.tsx
@@ -29,7 +29,6 @@ interface StatusGroup {
 interface TaskCardGridProps {
   tasks: (Task & { projectType: ProjectType })[];
   onTaskSelect: (taskId: string) => void;
-  selectedProjectType?: ProjectType | 'all';
   allLabels?: Label[];
   currentUserId?: string | null;
   emptyMessage?: string;
@@ -38,7 +37,6 @@ interface TaskCardGridProps {
 export function TaskCardGrid({
   tasks,
   onTaskSelect,
-  selectedProjectType,
   allLabels,
   currentUserId,
   emptyMessage = 'タスクがありません',
@@ -63,9 +61,6 @@ export function TaskCardGrid({
     },
     [oneWeekAgo]
   );
-
-  // 全プロジェクト表示時にプロジェクトタイプを表示
-  const shouldShowProjectType = selectedProjectType === 'all';
 
   // タスクをステータス別にグルーピング
   const statusGroups = useMemo(() => {
@@ -139,7 +134,6 @@ export function TaskCardGrid({
                 onTaskSelect={onTaskSelect}
                 allLabels={allLabels}
                 currentUserId={currentUserId}
-                showProjectType={shouldShowProjectType}
                 showProgressStatus={true}
                 hasUnreadComment={!!(currentUserId && unreadTaskIds?.has(task.id))}
                 isNewTask={isNewTask(task)}

--- a/components/tasks/TaskPersonalView.tsx
+++ b/components/tasks/TaskPersonalView.tsx
@@ -11,7 +11,6 @@ import { ProjectType } from '@/constants/projectTypes';
 interface TaskPersonalViewProps {
   tasks: (Task & { projectType: ProjectType })[];
   onTaskSelect: (taskId: string) => void;
-  selectedProjectType?: ProjectType | 'all';
   allUsers?: User[];
   allLabels?: Label[];
   currentUserId?: string | null;
@@ -21,7 +20,6 @@ interface TaskPersonalViewProps {
 export function TaskPersonalView({
   tasks,
   onTaskSelect,
-  selectedProjectType,
   allUsers,
   allLabels,
   currentUserId,
@@ -37,9 +35,6 @@ export function TaskPersonalView({
   const oneWeekAgo = useMemo(() => {
     return mountTime - 7 * 24 * 60 * 60 * 1000;
   }, [mountTime]);
-
-  // プロジェクトタイプを表示するかどうか
-  const showProjectType = selectedProjectType === 'all' || selectedProjectType === undefined;
 
   // タスクを担当者別→ステータス別にグルーピング
   const sections = useMemo(() => {
@@ -82,7 +77,6 @@ export function TaskPersonalView({
           onTaskSelect={onTaskSelect}
           allLabels={allLabels}
           currentUserId={currentUserId}
-          showProjectType={showProjectType}
           unreadTaskIds={unreadTaskIds}
           oneWeekAgo={oneWeekAgo}
           defaultExpanded={section.assigneeId === currentUserId || sortedSections.length <= 3}


### PR DESCRIPTION
## Summary

- タスクカード表示にITアップ日（カレンダーアイコン + MM/dd形式）を追加
- プロジェクトタイプの表示を削除
- 区分ラベルとITアップ日の位置を調整（区分→ITアップ日の順）
- ダッシュボードのカードから進捗ラベルを削除

## Test plan

- [ ] ダッシュボードでカード表示に切り替え、ITアップ日が表示されることを確認
- [ ] タスク一覧でカード表示に切り替え、ITアップ日が表示されることを確認
- [ ] ITアップ日が設定されていないタスクでは日付が表示されないことを確認
- [ ] プロジェクトタイプが表示されなくなっていることを確認

Closes #90

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * タスクカードにITアップ日を表示するようにしました。カレンダーアイコン付きで日付が表示されます。

* **改善**
  * プロジェクトタイプの表示オプションを削除し、UIを簡潔にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->