### PR TITLE
🐛 fix(notifications): コメント通知の遷移先をlocalhostから本番URLに修正

### DIFF
--- a/docs/setup/ENV.md
+++ b/docs/setup/ENV.md
@@ -134,3 +134,35 @@ Vercelで環境変数を設定する前に、Google Cloud Consoleでリダイレ
 Google Drive連携で問題が発生する場合は、以下のドキュメントを参照してください:
 
 - `docs/troubleshooting/GOOGLE_DRIVE_OAUTH_DEBUG.md`: エラーのデバッグガイド
+
+---
+
+## Step 4: Cloud Functions用のSecret Manager設定
+
+Cloud Functionsで使用するシークレットはGoogle Cloud Secret Managerで管理します。
+
+### 必要なシークレット
+
+| シークレット名            | 説明                              | 設定例                               |
+| ------------------------- | --------------------------------- | ------------------------------------ |
+| `GOOGLE_CHAT_WEBHOOK_URL` | Google Chat Webhookの送信先URL    | Google Chatスペースの設定から取得    |
+| `GOOGLE_CHAT_SPACE_URL`   | Google ChatスペースのベースURL    | `https://chat.google.com/room/XXXXX` |
+| `APP_ORIGIN`              | アプリの本番URL（通知のリンク用） | `https://chumo-task.vercel.app`      |
+
+### シークレットの追加方法
+
+```bash
+# Secret Managerにシークレットを追加
+gcloud secrets create <シークレット名> --project=chumo-3506a
+
+# 値を設定
+echo -n "<値>" | gcloud secrets versions add <シークレット名> --data-file=- --project=chumo-3506a
+```
+
+### 注意事項
+
+- シークレットの追加・変更後はCloud Functionsの再デプロイが必要です
+  ```bash
+  npm run functions:deploy
+  ```
+- Secret Managerへのアクセス権限が必要です（Cloud Functionsのサービスアカウントに`Secret Manager Secret Accessor`ロールを付与）

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -52,9 +52,15 @@ self.addEventListener('notificationclick', (event) => {
   const data = event.notification.data;
   let targetUrl = '/';
 
-  // タスク詳細ページへのURLを構築
-  if (data?.projectType && data?.taskId) {
-    targetUrl = `/tasks/${data.taskId}`;
+  // clickActionから遷移先URLを取得
+  // 完全URL（httpで始まる）の場合はそのまま使用、相対パスの場合はoriginを付与
+  if (data?.clickAction) {
+    targetUrl = data.clickAction.startsWith('http')
+      ? data.clickAction
+      : `${self.location.origin}${data.clickAction}`;
+  } else if (data?.projectType && data?.taskId) {
+    // 後方互換: clickActionがない場合はtaskIdから構築
+    targetUrl = `${self.location.origin}/tasks/${data.taskId}`;
   }
 
   // ウィンドウにフォーカスまたは新しいタブを開く


### PR DESCRIPTION
## Summary

- コメント通知クリック時の遷移先が localhost になる問題を修正
- Cloud Functions で Secret Manager から `APP_ORIGIN` を取得し、完全URLで通知を送信
- Service Worker で完全URL対応（httpで始まる場合はそのまま使用）

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `functions/src/notifications/onCommentCreate.ts` | Secret Managerから`APP_ORIGIN`取得、完全URLで通知送信 |
| `public/firebase-messaging-sw.js` | 完全URL対応（httpで始まる場合そのまま使用、相対パスの場合はorigin付与） |
| `docs/setup/ENV.md` | Secret Manager設定ドキュメント追加 |

## Test plan

- [ ] Cloud Functionsをデプロイ: `npm run functions:deploy`
- [ ] コメントでメンションして通知をトリガー
- [ ] 通知クリック時に `https://chumo-task.vercel.app/tasks/{taskId}` に遷移することを確認

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 通知リンクが環境に応じた完全な URL をサポートするようになりました

* **改善**
  * 通知クリック時の URL 処理を改善し、相対パスと絶対パスの両方に対応しました
  * 古いペイロード形式についても後方互換性を保持しています

* **ドキュメント**
  * Cloud Functions 向けの Secret Manager 設定手順を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->