### PR TITLE
フロントエンドスタック移行: Vite+React+Tailwind v4 ダッシュボード実装

### DIFF
--- a/.agents/skills/neon-postgres/SKILL.md
+++ b/.agents/skills/neon-postgres/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: neon-postgres
+description: Guides and best practices for working with Neon Serverless Postgres. Covers getting started, local development with Neon, choosing a connection method, Neon features, authentication (@neondatabase/auth), PostgREST-style data API (@neondatabase/neon-js), Neon CLI, and Neon's Platform API/SDKs. Use for any Neon-related questions.
+---
+
+# Neon Serverless Postgres
+
+Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
+
+## Neon Documentation
+
+The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
+
+### Fetching Docs as Markdown
+
+Any Neon doc page can be fetched as markdown in two ways:
+
+1. **Append `.md` to the URL** (simplest): https://neon.com/docs/introduction/branching.md
+2. **Request `text/markdown`** on the standard URL: `curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching`
+
+Both return the same markdown content. Use whichever method your tools support.
+
+### Finding the Right Page
+
+The docs index lists every available page with its URL and a short description:
+
+```
+https://neon.com/docs/llms.txt
+```
+
+Common doc URLs are organized in the topic links below. If you need a page not listed here, search the docs index: https://neon.com/docs/llms.txt — don't guess URLs.
+
+## What Is Neon
+
+Use this for architecture explanations and terminology (organizations, projects, branches, endpoints) before giving implementation advice.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/what-is-neon.md
+
+## Getting Started
+
+Use this for first-time setup: org/project selection, connection strings, driver installation, optional auth, and initial schema setup.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md
+
+## Connection Methods & Drivers
+
+Use this when you need to pick the correct transport and driver based on runtime constraints (TCP, HTTP, WebSocket, edge, serverless, long-running).
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md
+
+### Serverless Driver
+
+Use this for `@neondatabase/serverless` patterns, including HTTP queries, WebSocket transactions, and runtime-specific optimizations.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md
+
+### Neon JS SDK
+
+Use this for combined Neon Auth + Data API workflows with PostgREST-style querying and typed client setup.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md
+
+## Developer Tools
+
+Use this for local development enablement with `npx neonctl@latest init`, VSCode extension setup, and Neon MCP server configuration.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md
+
+### Neon CLI
+
+Use this for terminal-first workflows, scripts, and CI/CD automation with `neonctl`.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md
+
+## Neon Admin API
+
+The Neon Admin API can be used to manage Neon resources programmatically. It is used behind the scenes by the Neon CLI and MCP server, but can also be used directly for more complex automation workflows or when embedding Neon in other applications.
+
+### Neon REST API
+
+Use this for direct HTTP automation, endpoint-level control, API key auth, rate-limit handling, and operation polling.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-rest-api.md
+
+### Neon TypeScript SDK
+
+Use this when implementing typed programmatic control of Neon resources in TypeScript via `@neondatabase/api-client`.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-typescript-sdk.md
+
+### Neon Python SDK
+
+Use this when implementing programmatic Neon management in Python with the `neon-api` package.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-python-sdk.md
+
+## Neon Auth
+
+Use this for managed user authentication setup, UI components, auth methods, and Neon Auth integration pitfalls in Next.js and React apps.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md
+
+Neon Auth is also embedded in the Neon JS SDK - so depending on your use case, you may want to use the Neon JS SDK instead of Neon Auth. See https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md for more details.
+
+## Branching
+
+Use this when the user is planning isolated environments, schema migration testing, preview deployments, or branch lifecycle automation.
+
+Key points:
+
+- Branches are instant, copy-on-write clones (no full data copy).
+- Each branch has its own compute endpoint.
+- Use the neonctl CLI or MCP server to create, inspect, and compare branches.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/branching.md
+
+## Autoscaling
+
+Use this when the user needs compute to scale automatically with workload and wants guidance on CU sizing and runtime behavior.
+
+Link: https://neon.com/docs/introduction/autoscaling.md
+
+## Scale to Zero
+
+Use this when optimizing idle costs and discussing suspend/resume behavior, including cold-start trade-offs.
+
+Key points:
+
+- Idle computes suspend automatically (default 5 minutes, configurable) (unless disabled - launch & scale plan only)
+- First query after suspend typically has a cold-start penalty (around hundreds of ms)
+- Storage remains active while compute is suspended.
+
+Link: https://neon.com/docs/introduction/scale-to-zero.md
+
+## Instant Restore
+
+Use this when the user needs point-in-time recovery or wants to restore data state without traditional backup restore workflows.
+
+Key points:
+
+- Restore windows depend on plan limits.
+- Users can create branches from historical points-in-time.
+- Time Travel queries can be used for historical inspection workflows.
+
+Link: https://neon.com/docs/introduction/branch-restore.md
+
+## Read Replicas
+
+Use this for read-heavy workloads where the user needs dedicated read-only compute without duplicating storage.
+
+Key points:
+
+- Replicas are read-only compute endpoints sharing the same storage.
+- Creation is fast and scaling is independent from primary compute.
+- Typical use cases: analytics, reporting, and read-heavy APIs.
+
+Link: https://neon.com/docs/introduction/read-replicas.md
+
+## Connection Pooling
+
+Use this when the user is in serverless or high-concurrency environments and needs safe, scalable Postgres connection management.
+
+Key points:
+
+- Neon pooling uses PgBouncer.
+- Add `-pooler` to endpoint hostnames to use pooled connections.
+- Pooling is especially important in serverless runtimes with bursty concurrency.
+
+Link: https://neon.com/docs/connect/connection-pooling.md
+
+## IP Allow Lists
+
+Use this when the user needs to restrict database access by trusted networks, IPs, or CIDR ranges.
+
+Link: https://neon.com/docs/introduction/ip-allow.md
+
+## Logical Replication
+
+Use this when integrating CDC pipelines, external Postgres sync, or replication-based data movement.
+
+Key points:
+
+- Neon supports native logical replication workflows.
+- Useful for replicating to/from external Postgres systems.
+
+Link: https://neon.com/docs/guides/logical-replication-guide.md

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,0 +1,137 @@
+# design-review
+
+PencilデザインとPlaywright CLIスクリーンショットを比較して、実装をデザインに一致させるための反復修正ワークフロー。
+
+## When to use
+
+- ユーザーが「デザインと比較して」「デザインに合わせて」「見た目を直して」と言った時
+- 新しいコンポーネントやページのデザイン検証時
+- デザインレビュー/QA時
+
+## Workflow
+
+### Step 1: デザインスクリーンショット取得
+
+Pencil MCPの `get_screenshot` ツールでデザインファイルのノードIDを指定してスクリーンショットを取得する。
+
+- デザインファイルパス: `designs/design.pen`
+- ノードIDはMEMORY.mdまたは `batch_get` で特定
+- reusableコンポーネントのIDはプロジェクトメモリに記録済み
+
+### Step 2: 実装スクリーンショット取得
+
+**必ずPlaywright CLIを使う**（Chrome DevTools MCPではない）。
+
+```bash
+# サイドバー単体
+npx playwright screenshot --viewport-size="240,900" http://localhost:5173/PATH /tmp/COMPONENT-vN.png
+
+# フルページ
+npx playwright screenshot --viewport-size="1440,900" http://localhost:5173/PATH /tmp/PAGE-vN.png
+
+# ドロワー（480px幅 = ドロワー幅で要素だけ表示）
+npx playwright screenshot --viewport-size="480,1100" --wait-for-timeout=1000 "http://localhost:5173/dashboard?task=task-1" /tmp/drawer-vN.png
+
+# アニメーション待ち
+npx playwright screenshot --wait-for-timeout=1000 --viewport-size="1440,900" URL /tmp/OUTPUT.png
+```
+
+### Step 3: 差分分析
+
+両方のスクリーンショットを `Read` ツールで開いて視覚比較する。
+
+**チェック項目:**
+
+- レイアウト構造（flex方向、配置、gap）
+- カラー（背景、テキスト、ボーダー、アイコン）
+- フォント（サイズ、ウェイト、行間）
+- スペーシング（padding、margin、gap）
+- 角丸（radius）
+- ボーダー（太さ、色、位置）
+- アイコン（種類、サイズ、色）
+- コンポーネント固有（バッジ、アバター、トグル等）
+
+### Step 4: デザイン詳細取得
+
+差分が見つかったら `batch_get` でノードの詳細プロパティを取得する。
+
+```
+mcp__pencil__batch_get({
+  filePath: "designs/design.pen",
+  nodeIds: ["NODE_ID"],
+  readDepth: 3
+})
+```
+
+- `readDepth: 3` で子要素の構造も確認
+- `resolveVariables: true` で変数の実際の値も確認可能
+- `patterns` で名前検索も可能: `[{"name": "Header|Toolbar"}]`
+
+### Step 5: 実装修正
+
+Tailwindクラスをデザイントークンに合わせて修正する。
+
+**トークンマッピング:**
+
+- セマンティック: `bg-bg-primary`, `text-text-secondary`, `border-border-default`
+- プリミティブ: `bg-teal-600`, `text-neutral-400`
+- ステータス: `bg-error-bg`, `text-warning-text`, `bg-success-bg`
+
+**Pencil→Tailwind変換例:**
+| Pencil | Tailwind |
+|--------|----------|
+| `fill: "$--color-text-primary"` | `text-text-primary` |
+| `fill: "$--color-bg-secondary"` | `bg-bg-secondary` |
+| `cornerRadius: "$--radius-md"` | `rounded-md` |
+| `fontSize: "$--font-size-sm"` | `text-sm` |
+| `fontWeight: "$--font-weight-bold"` | `font-bold` |
+| `gap: 8` | `gap-2` |
+| `padding: [10, 16]` | `px-4 py-2.5` |
+| `padding: 12` | `p-3` |
+| `height: 40` | `h-10` |
+| `width: "fill_container"` | `w-full` / `flex-1` |
+| `justifyContent: "space_between"` | `justify-between` |
+| `layout: "vertical"` | `flex flex-col` |
+| `stroke: {thickness: {bottom: 1}}` | `border-b border-border-default` |
+| `stroke: {thickness: {left: 3}}` | `border-l-[3px] border-l-ERROR_COLOR` |
+
+### Step 6: 型チェック
+
+```bash
+npx tsc --noEmit
+```
+
+### Step 7: 再スクショ → Step 3に戻る
+
+- 修正後にPlaywright CLIで再スクリーンショット
+- デザインと再比較
+- 差分がなくなるまで繰り返す（通常2〜4イテレーション）
+
+## Important notes
+
+- **Chrome DevTools MCPではなく、必ずPlaywright CLIを使う**
+- `.pen`ファイルは暗号化 → Read/Grepではなく必ずPencil MCPツール経由
+- dev serverが起動していない場合: `npx vite --port 5173 &disown`
+- Pencilノードの主要IDはMEMORY.mdに記録済み
+- デザイントークンは `frontend/src/index.css` の `@theme` ブロックで定義
+- ダークモード: `.dark` クラスでCSS変数オーバーライド
+- Pencil変数参照: `$--variable-name` 形式
+
+## Design file reference
+
+| コンポーネント            | ノードID |
+| ------------------------- | -------- |
+| Dashboard Light           | `wGdx6`  |
+| Side Menu (reusable)      | `1jZQ4`  |
+| Side Menu Dark            | `yw6wW`  |
+| Task Drawer Light         | `v8BBk`  |
+| Task Drawer Dark          | `oerwx`  |
+| Task Drawer Comment Light | `58DXP`  |
+| Task Drawer Comment Dark  | `sSZeN`  |
+| Table Header Light        | `VuRiA`  |
+| Table Header Dark         | `VBUXj`  |
+| Row - Normal Light        | `hgZUq`  |
+| Row - Error Light         | `4pl5P`  |
+| Row - Warning Light       | `QMu0M`  |
+
+その他のIDはMEMORY.mdを参照。

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -114,3 +114,7 @@ symbol_info_budget:
 # Note: the backend is fixed at startup. If a project with a different backend
 # is activated post-init, an error will be returned.
 language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -183,5 +183,29 @@ export default [
       'no-undef': 'off',
     },
   },
+  {
+    files: [
+      'frontend/src/**/*.ts',
+      'frontend/src/**/*.tsx',
+    ],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        project: ['./frontend/tsconfig.app.json'],
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      'no-unused-vars': 'off',
+      'no-undef': 'off',
+    },
+  },
   // functionsはignoresで除外しているため、この設定は不要
 ];

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Clerk
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_xxx
+
+# API (dev時はViteプロキシ経由のため空でOK、本番時はバックエンドURL)
+# VITE_API_URL=https://api.example.com

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,25 @@
+# Dependencies
+node_modules/
+
+# Build
+dist/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,0 +1,641 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "chumo-frontend",
+      "dependencies": {
+        "@clerk/clerk-react": "^5",
+        "@tanstack/react-query": "^5",
+        "clsx": "^2",
+        "framer-motion": "^11",
+        "lucide-react": "^0.468",
+        "react": "^19",
+        "react-aria-components": "^1",
+        "react-dom": "^19",
+        "react-router-dom": "^7",
+        "tailwind-merge": "^2",
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^4",
+        "postcss": "^8",
+        "tailwindcss": "^4",
+        "typescript": "^5.7",
+        "vite": "^6",
+      },
+    },
+  },
+  "packages": {
+    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.6", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@clerk/clerk-react": ["@clerk/clerk-react@5.61.3", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg=="],
+
+    "@clerk/shared": ["@clerk/shared@3.47.2", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@formatjs/ecma402-abstract": ["@formatjs/ecma402-abstract@2.3.6", "", { "dependencies": { "@formatjs/fast-memoize": "2.2.7", "@formatjs/intl-localematcher": "0.6.2", "decimal.js": "^10.4.3", "tslib": "^2.8.0" } }, "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw=="],
+
+    "@formatjs/fast-memoize": ["@formatjs/fast-memoize@2.2.7", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ=="],
+
+    "@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@2.11.4", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/icu-skeleton-parser": "1.8.16", "tslib": "^2.8.0" } }, "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw=="],
+
+    "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@1.8.16", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "tslib": "^2.8.0" } }, "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ=="],
+
+    "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
+
+    "@internationalized/date": ["@internationalized/date@3.12.0", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ=="],
+
+    "@internationalized/message": ["@internationalized/message@3.1.8", "", { "dependencies": { "@swc/helpers": "^0.5.0", "intl-messageformat": "^10.1.0" } }, "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA=="],
+
+    "@internationalized/number": ["@internationalized/number@3.6.5", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g=="],
+
+    "@internationalized/string": ["@internationalized/string@3.2.7", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@react-aria/autocomplete": ["@react-aria/autocomplete@3.0.0-rc.6", "", { "dependencies": { "@react-aria/combobox": "^3.15.0", "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/listbox": "^3.15.3", "@react-aria/searchfield": "^3.8.12", "@react-aria/textfield": "^3.18.5", "@react-aria/utils": "^3.33.1", "@react-stately/autocomplete": "3.0.0-beta.4", "@react-stately/combobox": "^3.13.0", "@react-types/autocomplete": "3.0.0-alpha.38", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-uymUNJ8NW+dX7lmgkHE+SklAbxwktycAJcI5lBBw6KPZyc0EdMHC+/Fc5CUz3enIAhNwd2oxxogcSHknquMzQA=="],
+
+    "@react-aria/breadcrumbs": ["@react-aria/breadcrumbs@3.5.32", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/link": "^3.8.9", "@react-aria/utils": "^3.33.1", "@react-types/breadcrumbs": "^3.7.19", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-S61vh5DJ2PXiXUwD7gk+pvS/b4VPrc3ZJOUZ0yVRLHkVESr5LhIZH+SAVgZkm1lzKyMRG+BH+fiRH/DZRSs7SA=="],
+
+    "@react-aria/button": ["@react-aria/button@3.14.5", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/toolbar": "3.0.0-beta.24", "@react-aria/utils": "^3.33.1", "@react-stately/toggle": "^3.9.5", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-ZuLx+wQj9VQhH9BYe7t0JowmKnns2XrFHFNvIVBb5RwxL+CIycIOL7brhWKg2rGdxvlOom7jhVbcjSmtAaSyaQ=="],
+
+    "@react-aria/calendar": ["@react-aria/calendar@3.9.5", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/utils": "^3.33.1", "@react-stately/calendar": "^3.9.3", "@react-types/button": "^3.15.1", "@react-types/calendar": "^3.8.3", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-k0kvceYdZZu+DoeqephtlmIvh1CxqdFyoN52iqVzTz9O0pe5Xfhq7zxPGbeCp4pC61xzp8Lu/6uFA/YNfQQNag=="],
+
+    "@react-aria/checkbox": ["@react-aria/checkbox@3.16.5", "", { "dependencies": { "@react-aria/form": "^3.1.5", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/toggle": "^3.12.5", "@react-aria/utils": "^3.33.1", "@react-stately/checkbox": "^3.7.5", "@react-stately/form": "^3.2.4", "@react-stately/toggle": "^3.9.5", "@react-types/checkbox": "^3.10.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-ZhUT7ELuD52hb+Zpzw0ElLQiVOd5sKYahrh+PK3vq13Wk5TedBscALpjuXetI4pwFfdmAM1Lhgcsrd8+6AmyvA=="],
+
+    "@react-aria/collections": ["@react-aria/collections@3.0.3", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/ssr": "^3.9.10", "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-lbC5DEbHeVFvVr4ke9y8D9Nynnr8G8UjVEBoFGRylpAaScU7SX1TN84QI+EjMbsdZ0/5P2H7gUTS+MYd+6U3Rg=="],
+
+    "@react-aria/color": ["@react-aria/color@3.1.5", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/numberfield": "^3.12.5", "@react-aria/slider": "^3.8.5", "@react-aria/spinbutton": "^3.7.2", "@react-aria/textfield": "^3.18.5", "@react-aria/utils": "^3.33.1", "@react-aria/visually-hidden": "^3.8.31", "@react-stately/color": "^3.9.5", "@react-stately/form": "^3.2.4", "@react-types/color": "^3.1.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-eysWdBRzE8WDhBzh1nfjyUgzseMokXGHjIoJo880T7IPJ8tTavfQni49pU1B2qWrNOWPyrwx4Bd9pzHyboxJSA=="],
+
+    "@react-aria/combobox": ["@react-aria/combobox@3.15.0", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/listbox": "^3.15.3", "@react-aria/live-announcer": "^3.4.4", "@react-aria/menu": "^3.21.0", "@react-aria/overlays": "^3.31.2", "@react-aria/selection": "^3.27.2", "@react-aria/textfield": "^3.18.5", "@react-aria/utils": "^3.33.1", "@react-stately/collections": "^3.12.10", "@react-stately/combobox": "^3.13.0", "@react-stately/form": "^3.2.4", "@react-types/button": "^3.15.1", "@react-types/combobox": "^3.14.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-qSjQTFwKl3x1jCP2NRSJ6doZqAp6c2GTfoiFwWjaWg1IewwLsglaW6NnzqRDFiqFbDGgXPn4MqtC1VYEJ3NEjA=="],
+
+    "@react-aria/datepicker": ["@react-aria/datepicker@3.16.1", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@internationalized/number": "^3.6.5", "@internationalized/string": "^3.2.7", "@react-aria/focus": "^3.21.5", "@react-aria/form": "^3.1.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/spinbutton": "^3.7.2", "@react-aria/utils": "^3.33.1", "@react-stately/datepicker": "^3.16.1", "@react-stately/form": "^3.2.4", "@react-types/button": "^3.15.1", "@react-types/calendar": "^3.8.3", "@react-types/datepicker": "^3.13.5", "@react-types/dialog": "^3.5.24", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-6BltCVWt09yefTkGjb2gViGCwoddx9HKJiZbY9u6Es/Q+VhwNJQRtczbnZ3K32p262hIknukNf/5nZaCOI1AKA=="],
+
+    "@react-aria/dialog": ["@react-aria/dialog@3.5.34", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/overlays": "^3.31.2", "@react-aria/utils": "^3.33.1", "@react-types/dialog": "^3.5.24", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-/x53Q5ynpW5Kv9637WYu7SrDfj3woSp6jJRj8l6teGnWW/iNZWYJETgzHfbxx+HPKYATCZesRoIeO2LnYIXyEA=="],
+
+    "@react-aria/disclosure": ["@react-aria/disclosure@3.1.3", "", { "dependencies": { "@react-aria/ssr": "^3.9.10", "@react-aria/utils": "^3.33.1", "@react-stately/disclosure": "^3.0.11", "@react-types/button": "^3.15.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-S3k7Wqrj+x0sWcP88Z1stSr5TIZmKEmx2rU7RB1O1/jPpbw5mgKnjtiriOlTh+kwdK11FkeqgxyHzAcBAR+FMQ=="],
+
+    "@react-aria/dnd": ["@react-aria/dnd@3.11.6", "", { "dependencies": { "@internationalized/string": "^3.2.7", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/overlays": "^3.31.2", "@react-aria/utils": "^3.33.1", "@react-stately/collections": "^3.12.10", "@react-stately/dnd": "^3.7.4", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-4YLHUeYJleF+moAYaYt8UZqujudPvpoaHR+QMkWIFzhfridVUhCr6ZjGWrzpSZY3r68k46TG7YCsi4IEiNnysw=="],
+
+    "@react-aria/focus": ["@react-aria/focus@3.21.5", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q=="],
+
+    "@react-aria/form": ["@react-aria/form@3.1.5", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-stately/form": "^3.2.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-BWlONgHn8hmaMkcS6AgMSLQeNqVBwqPNLhdqjDO/PCfzvV7O8NZw/dFeIzJwfG4aBfSpbHHRdXGdfrk3d8dylQ=="],
+
+    "@react-aria/grid": ["@react-aria/grid@3.14.8", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/collections": "^3.12.10", "@react-stately/grid": "^3.11.9", "@react-stately/selection": "^3.20.9", "@react-types/checkbox": "^3.10.4", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-X6rRFKDu/Kh6Sv8FBap3vjcb+z4jXkSOwkYnexIJp5kMTo5/Dqo55cCBio5B70Tanfv32Ev/6SpzYG7ryxnM9w=="],
+
+    "@react-aria/gridlist": ["@react-aria/gridlist@3.14.4", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/grid": "^3.14.8", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/list": "^3.13.4", "@react-stately/tree": "^3.9.6", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-C/SbwC0qagZatoBrCjx8iZUex9apaJ8o8iRJ9eVHz0cpj7mXg6HuuotYGmDy9q67A2hve4I693RM1Cuwqwm+PQ=="],
+
+    "@react-aria/i18n": ["@react-aria/i18n@3.12.16", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@internationalized/message": "^3.1.8", "@internationalized/number": "^3.6.5", "@internationalized/string": "^3.2.7", "@react-aria/ssr": "^3.9.10", "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA=="],
+
+    "@react-aria/interactions": ["@react-aria/interactions@3.27.1", "", { "dependencies": { "@react-aria/ssr": "^3.9.10", "@react-aria/utils": "^3.33.1", "@react-stately/flags": "^3.1.2", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw=="],
+
+    "@react-aria/label": ["@react-aria/label@3.7.25", "", { "dependencies": { "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-oNK3Pqj4LDPwEbQaoM/uCip4QvQmmwGOh08VeW+vzSi6TAwf+KoWTyH/tiAeB0CHWNDK0k3e1iTygTAt4wzBmg=="],
+
+    "@react-aria/landmark": ["@react-aria/landmark@3.0.10", "", { "dependencies": { "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-GpNjJaI8/a6WxYDZgzTCLYSzPM6xp2pxCIQ4udiGbTCtxx13Trmm0cPABvPtzELidgolCf05em9Phr+3G0eE8A=="],
+
+    "@react-aria/link": ["@react-aria/link@3.8.9", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-types/link": "^3.6.7", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-UaAFBfs84/Qq6TxlMWkREqqNY6SFLukot+z2Aa1kC+VyStv1kWG6sE5QLjm4SBn1Q3CGRsefhB/5+taaIbB4Pw=="],
+
+    "@react-aria/listbox": ["@react-aria/listbox@3.15.3", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/collections": "^3.12.10", "@react-stately/list": "^3.13.4", "@react-types/listbox": "^3.7.6", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-C6YgiyrHS5sbS5UBdxGMhEs+EKJYotJgGVtl9l0ySXpBUXERiHJWLOyV7a8PwkUOmepbB4FaLD7Y9EUzGkrGlw=="],
+
+    "@react-aria/live-announcer": ["@react-aria/live-announcer@3.4.4", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA=="],
+
+    "@react-aria/menu": ["@react-aria/menu@3.21.0", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/overlays": "^3.31.2", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/collections": "^3.12.10", "@react-stately/menu": "^3.9.11", "@react-stately/selection": "^3.20.9", "@react-stately/tree": "^3.9.6", "@react-types/button": "^3.15.1", "@react-types/menu": "^3.10.7", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-CKTVZ4izSE1eKIti6TbTtzJAUo+WT8O4JC0XZCYDBpa0f++lD19Kz9aY+iY1buv5xGI20gAfpO474E9oEd4aQA=="],
+
+    "@react-aria/meter": ["@react-aria/meter@3.4.30", "", { "dependencies": { "@react-aria/progress": "^3.4.30", "@react-types/meter": "^3.4.15", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-ZmANKW7s/Z4QGylHi46nhwtQ47T1bfMsU9MysBu7ViXXNJ03F4b6JXCJlKL5o2goQ3NbfZ68GeWamIT0BWSgtw=="],
+
+    "@react-aria/numberfield": ["@react-aria/numberfield@3.12.5", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/spinbutton": "^3.7.2", "@react-aria/textfield": "^3.18.5", "@react-aria/utils": "^3.33.1", "@react-stately/form": "^3.2.4", "@react-stately/numberfield": "^3.11.0", "@react-types/button": "^3.15.1", "@react-types/numberfield": "^3.8.18", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-Fi41IUWXEHLFIeJ/LHuZ9Azs8J/P563fZi37GSBkIq5P1pNt1rPgJJng5CNn4KsHxwqadTRUlbbZwbZraWDtRg=="],
+
+    "@react-aria/overlays": ["@react-aria/overlays@3.31.2", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/ssr": "^3.9.10", "@react-aria/utils": "^3.33.1", "@react-aria/visually-hidden": "^3.8.31", "@react-stately/flags": "^3.1.2", "@react-stately/overlays": "^3.6.23", "@react-types/button": "^3.15.1", "@react-types/overlays": "^3.9.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q=="],
+
+    "@react-aria/progress": ["@react-aria/progress@3.4.30", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/label": "^3.7.25", "@react-aria/utils": "^3.33.1", "@react-types/progress": "^3.5.18", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-S6OWVGgluSWYSd/A6O8CVjz83eeMUfkuWSra0ewAV9bmxZ7TP9pUmD3bGdqHZEl97nt5vHGjZ3eq/x8eCmzKhA=="],
+
+    "@react-aria/radio": ["@react-aria/radio@3.12.5", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/form": "^3.1.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/utils": "^3.33.1", "@react-stately/radio": "^3.11.5", "@react-types/radio": "^3.9.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-8CCJKJzfozEiWBPO9QAATG1rBGJEJ+xoqvHf9LKU2sPFGsA2/SRnLs6LB9fCG5R3spvaK1xz0any1fjWPl7x8A=="],
+
+    "@react-aria/searchfield": ["@react-aria/searchfield@3.8.12", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/textfield": "^3.18.5", "@react-aria/utils": "^3.33.1", "@react-stately/searchfield": "^3.5.19", "@react-types/button": "^3.15.1", "@react-types/searchfield": "^3.6.8", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-kYlUHD/+mWzNroHoR8ojUxYBoMviRZn134WaKPFjfNUGZDOEuh4XzOoj+cjdJfe6N3mwTaYu6rJQtunSHIAfhA=="],
+
+    "@react-aria/select": ["@react-aria/select@3.17.3", "", { "dependencies": { "@react-aria/form": "^3.1.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/listbox": "^3.15.3", "@react-aria/menu": "^3.21.0", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-aria/visually-hidden": "^3.8.31", "@react-stately/select": "^3.9.2", "@react-types/button": "^3.15.1", "@react-types/select": "^3.12.2", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-u0UFWw0S7q9oiSbjetDpRoLLIcC+L89uYlm+YfCrdT8ntbQgABNiJRxdVvxnhR0fR6MC9ASTTvuQnNHNn52+1A=="],
+
+    "@react-aria/selection": ["@react-aria/selection@3.27.2", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-stately/selection": "^3.20.9", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-GbUSSLX/ciXix95KW1g+SLM9np7iXpIZrFDSXkC6oNx1uhy18eAcuTkeZE25+SY5USVUmEzjI3m/3JoSUcebbg=="],
+
+    "@react-aria/separator": ["@react-aria/separator@3.4.16", "", { "dependencies": { "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-RCUtQhDGnPxKzyG8KM79yOB0fSiEf8r/rxShidOVnGLiBW2KFmBa22/Gfc4jnqg/keN3dxvkSGoqmeXgctyp6g=="],
+
+    "@react-aria/slider": ["@react-aria/slider@3.8.5", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/utils": "^3.33.1", "@react-stately/slider": "^3.7.5", "@react-types/shared": "^3.33.1", "@react-types/slider": "^3.8.4", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-gqkJxznk141mE0JamXF5CXml9PDbPkBz8dyKlihtWHWX4yhEbVYdC9J0otE7iCR3zx69Bm7WHoTGL0BsdpKzVA=="],
+
+    "@react-aria/spinbutton": ["@react-aria/spinbutton@3.7.2", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/live-announcer": "^3.4.4", "@react-aria/utils": "^3.33.1", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-adjE1wNCWlugvAtVXlXWPtIG9JWurEgYVn1Eeyh19x038+oXGvOsOAoKCXM+SnGleTWQ9J7pEZITFoEI3cVfAw=="],
+
+    "@react-aria/ssr": ["@react-aria/ssr@3.9.10", "", { "dependencies": { "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ=="],
+
+    "@react-aria/switch": ["@react-aria/switch@3.7.11", "", { "dependencies": { "@react-aria/toggle": "^3.12.5", "@react-stately/toggle": "^3.9.5", "@react-types/shared": "^3.33.1", "@react-types/switch": "^3.5.17", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-dYVX71HiepBsKyeMaQgHbhqI+MQ3MVoTd5EnTbUjefIBnmQZavYj1/e4NUiUI4Ix+/C0HxL8ibDAv4NlSW3eLQ=="],
+
+    "@react-aria/table": ["@react-aria/table@3.17.11", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/grid": "^3.14.8", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/utils": "^3.33.1", "@react-aria/visually-hidden": "^3.8.31", "@react-stately/collections": "^3.12.10", "@react-stately/flags": "^3.1.2", "@react-stately/table": "^3.15.4", "@react-types/checkbox": "^3.10.4", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@react-types/table": "^3.13.6", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-GkYmWPiW3OM+FUZxdS33teHXHXde7TjHuYgDDaG9phvg6cQTQjGilJozrzA3OfftTOq5VB8XcKTIQW3c0tpYsQ=="],
+
+    "@react-aria/tabs": ["@react-aria/tabs@3.11.1", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/tabs": "^3.8.9", "@react-types/shared": "^3.33.1", "@react-types/tabs": "^3.3.22", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-3Ppz7yaEDW9L7p9PE9yNOl5caLwNnnLQqI+MX/dwbWlw9HluHS7uIjb21oswNl6UbSxAWyENOka45+KN4Fkh7A=="],
+
+    "@react-aria/tag": ["@react-aria/tag@3.8.1", "", { "dependencies": { "@react-aria/gridlist": "^3.14.4", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/list": "^3.13.4", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-VonpO++F8afXGDWc9VUxAc2wefyJpp1n9OGpbnB7zmqWiuPwO/RixjUdcH7iJkiC4vADwx9uLnhyD6kcwGV2ig=="],
+
+    "@react-aria/textfield": ["@react-aria/textfield@3.18.5", "", { "dependencies": { "@react-aria/form": "^3.1.5", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/utils": "^3.33.1", "@react-stately/form": "^3.2.4", "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@react-types/textfield": "^3.12.8", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-ttwVSuwoV3RPaG2k2QzEXKeQNQ3mbdl/2yy6I4Tjrn1ZNkYHfVyJJ26AjenfSmj1kkTQoSAfZ8p+7rZp4n0xoQ=="],
+
+    "@react-aria/toast": ["@react-aria/toast@3.0.11", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/landmark": "^3.0.10", "@react-aria/utils": "^3.33.1", "@react-stately/toast": "^3.1.3", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-2DjZjBAvm8/CWbnZ6s7LjkYCkULKtjMve6GvhPTq98AthuEDLEiBvM1wa3xdecCRhZyRT1g6DXqVca0EfZ9fJA=="],
+
+    "@react-aria/toggle": ["@react-aria/toggle@3.12.5", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-stately/toggle": "^3.9.5", "@react-types/checkbox": "^3.10.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-XXVFLzcV8fr9mz7y/wfxEAhWvaBZ9jSfhCMuxH2bsivO7nTcMJ1jb4g2xJNwZgne17bMWNc7mKvW5dbsdlI6BA=="],
+
+    "@react-aria/toolbar": ["@react-aria/toolbar@3.0.0-beta.24", "", { "dependencies": { "@react-aria/focus": "^3.21.5", "@react-aria/i18n": "^3.12.16", "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-B2Rmpko7Ghi2RbNfsGdbR7I+RQBDhPGVE4bU3/EwHz+P/vNe5LyGPTeSwqaOMsQTF9lKNCkY8424dVTCr6RUMg=="],
+
+    "@react-aria/tooltip": ["@react-aria/tooltip@3.9.2", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-stately/tooltip": "^3.5.11", "@react-types/shared": "^3.33.1", "@react-types/tooltip": "^3.5.2", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-VrgkPwHiEnAnBhoQ4W7kfry/RfVuRWrUPaJSp0+wKM6u0gg2tmn7OFRDXTxBAm/omQUguIdIjRWg7sf3zHH82A=="],
+
+    "@react-aria/tree": ["@react-aria/tree@3.1.7", "", { "dependencies": { "@react-aria/gridlist": "^3.14.4", "@react-aria/i18n": "^3.12.16", "@react-aria/selection": "^3.27.2", "@react-aria/utils": "^3.33.1", "@react-stately/tree": "^3.9.6", "@react-types/button": "^3.15.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-C54yH5NmsOFa2Q+cg6B1BPr5KUlU9vLIoBnVrgrH237FRSXQPIbcM4VpmITAHq1VR7w6ayyS1hgTwFxo67ykWQ=="],
+
+    "@react-aria/utils": ["@react-aria/utils@3.33.1", "", { "dependencies": { "@react-aria/ssr": "^3.9.10", "@react-stately/flags": "^3.1.2", "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w=="],
+
+    "@react-aria/virtualizer": ["@react-aria/virtualizer@4.1.13", "", { "dependencies": { "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-stately/virtualizer": "^4.4.6", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-d5KS+p8GXGNRbGPRE/N6jtth3et3KssQIz52h2+CAoAh7C3vvR64kkTaGdeywClvM+fSo8FxJuBrdfQvqC2ktQ=="],
+
+    "@react-aria/visually-hidden": ["@react-aria/visually-hidden@3.8.31", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-RTOHHa4n56a9A3criThqFHBifvZoV71+MCkSuNP2cKO662SUWjqKkd0tJt/mBRMEJPkys8K7Eirp6T8Wt5FFRA=="],
+
+    "@react-stately/autocomplete": ["@react-stately/autocomplete@3.0.0-beta.4", "", { "dependencies": { "@react-stately/utils": "^3.11.0", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-K2Uy7XEdseFvgwRQ8CyrYEHMupjVKEszddOapP8deNz4hntYvT1aRm0m+sKa5Kl/4kvg9c/3NZpQcrky/vRZIg=="],
+
+    "@react-stately/calendar": ["@react-stately/calendar@3.9.3", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@react-stately/utils": "^3.11.0", "@react-types/calendar": "^3.8.3", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-uw7fCZXoypSBBUsVkbNvJMQWTihZReRbyLIGG3o/ZM630N3OCZhb/h4Uxke4pNu7n527H0V1bAnZgAldIzOYqg=="],
+
+    "@react-stately/checkbox": ["@react-stately/checkbox@3.7.5", "", { "dependencies": { "@react-stately/form": "^3.2.4", "@react-stately/utils": "^3.11.0", "@react-types/checkbox": "^3.10.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-K5R5ted7AxLB3sDkuVAazUdyRMraFT1imVqij2GuAiOUFvsZvbuocnDuFkBVKojyV3GpqLBvViV8IaCMc4hNIw=="],
+
+    "@react-stately/collections": ["@react-stately/collections@3.12.10", "", { "dependencies": { "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-wmF9VxJDyBujBuQ76vXj2g/+bnnj8fx5DdXgRmyfkkYhPB46+g2qnjbVGEvipo7bJuGxDftCUC4SN7l7xqUWfg=="],
+
+    "@react-stately/color": ["@react-stately/color@3.9.5", "", { "dependencies": { "@internationalized/number": "^3.6.5", "@internationalized/string": "^3.2.7", "@react-stately/form": "^3.2.4", "@react-stately/numberfield": "^3.11.0", "@react-stately/slider": "^3.7.5", "@react-stately/utils": "^3.11.0", "@react-types/color": "^3.1.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-8pZxzXWDRuglzDwyTG7mLw2LQMCHIVNbVc9YmbsxbOjAL+lOqszo60KzyaFKVxeDQczSvrNTHcQZqlbNIC0eyQ=="],
+
+    "@react-stately/combobox": ["@react-stately/combobox@3.13.0", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/form": "^3.2.4", "@react-stately/list": "^3.13.4", "@react-stately/overlays": "^3.6.23", "@react-stately/utils": "^3.11.0", "@react-types/combobox": "^3.14.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-dX9g/cK1hjLRjcbWVF6keHxTQDGhKGB2QAgPhWcBmOK3qJv+2dQqsJ6YCGWn/Y2N2acoEseLrAA7+Qe4HWV9cg=="],
+
+    "@react-stately/data": ["@react-stately/data@3.15.2", "", { "dependencies": { "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-BsmeeGgFwOGwo0g9Waprdyt+846n3KhKggZfpEnp5+sC4dE4uW1VIYpdyupMfr3bQcmX123q6TegfNP3eszrUA=="],
+
+    "@react-stately/datepicker": ["@react-stately/datepicker@3.16.1", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@internationalized/number": "^3.6.5", "@internationalized/string": "^3.2.7", "@react-stately/form": "^3.2.4", "@react-stately/overlays": "^3.6.23", "@react-stately/utils": "^3.11.0", "@react-types/datepicker": "^3.13.5", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-BtAMDvxd1OZxkxjqq5tN5TYmp6Hm8+o3+IDA4qmem2/pfQfVbOZeWS2WitcPBImj4n4T+W1A5+PI7mT/6DUBVg=="],
+
+    "@react-stately/disclosure": ["@react-stately/disclosure@3.0.11", "", { "dependencies": { "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-/KjB/0HkxGWbhFAPztCP411LUKZCx9k8cKukrlGqrUWyvrcXlmza90j0g/CuxACBoV+DJP9V+4q+8ide0x750A=="],
+
+    "@react-stately/dnd": ["@react-stately/dnd@3.7.4", "", { "dependencies": { "@react-stately/selection": "^3.20.9", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-YD0TVR5JkvTqskc1ouBpVKs6t/QS4RYCIyu8Ug8RgO122iIizuf2pfKnRLjYMdu5lXzBXGaIgd49dvnLzEXHIw=="],
+
+    "@react-stately/flags": ["@react-stately/flags@3.1.2", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg=="],
+
+    "@react-stately/form": ["@react-stately/form@3.2.4", "", { "dependencies": { "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-qNBzun8SbLdgahryhKLqL1eqP+MXY6as82sVXYOOvUYLzgU5uuN8mObxYlxJgMI5akSdQJQV3RzyfVobPRE7Kw=="],
+
+    "@react-stately/grid": ["@react-stately/grid@3.11.9", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/selection": "^3.20.9", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-qQY6F+27iZRn30dt0ZOrSetUmbmNJ0pLe9Weuqw3+XDVSuWT+2O/rO1UUYeK+mO0Acjzdv+IWiYbu9RKf2wS9w=="],
+
+    "@react-stately/layout": ["@react-stately/layout@4.6.0", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/table": "^3.15.4", "@react-stately/virtualizer": "^4.4.6", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@react-types/table": "^3.13.6", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-kBenEsP03nh5rKgfqlVMPcoKTJv0v92CTvrAb5gYY8t9g8LOwzdL89Yannq7f5xv8LFck/MmRQlotpMt2InETg=="],
+
+    "@react-stately/list": ["@react-stately/list@3.13.4", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/selection": "^3.20.9", "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-HHYSjA9VG7FPSAtpXAjQyM/V7qFHWGg88WmMrDt5QDlTBexwPuH0oFLnW0qaVZpAIxuWIsutZfxRAnme/NhhAA=="],
+
+    "@react-stately/menu": ["@react-stately/menu@3.9.11", "", { "dependencies": { "@react-stately/overlays": "^3.6.23", "@react-types/menu": "^3.10.7", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-vYkpO9uV2OUecsIkrOc+Urdl/s1xw/ibNH/UXsp4PtjMnS6mK9q2kXZTM3WvMAKoh12iveUO+YkYCZQshmFLHQ=="],
+
+    "@react-stately/numberfield": ["@react-stately/numberfield@3.11.0", "", { "dependencies": { "@internationalized/number": "^3.6.5", "@react-stately/form": "^3.2.4", "@react-stately/utils": "^3.11.0", "@react-types/numberfield": "^3.8.18", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-rxfC047vL0LP4tanjinfjKAriAvdVL57Um5RUL5nHML8IOWCB3TBxegQkJ6to6goScC/oZhd0/Y2LSaiRuKbNw=="],
+
+    "@react-stately/overlays": ["@react-stately/overlays@3.6.23", "", { "dependencies": { "@react-stately/utils": "^3.11.0", "@react-types/overlays": "^3.9.4", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-RzWxots9A6gAzQMP4s8hOAHV7SbJRTFSlQbb6ly1nkWQXacOSZSFNGsKOaS0eIatfNPlNnW4NIkgtGws5UYzfw=="],
+
+    "@react-stately/radio": ["@react-stately/radio@3.11.5", "", { "dependencies": { "@react-stately/form": "^3.2.4", "@react-stately/utils": "^3.11.0", "@react-types/radio": "^3.9.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-QxA779S4ea5icQ0ja7CeiNzY1cj7c9G9TN0m7maAIGiTSinZl2Ia8naZJ0XcbRRp+LBll7RFEdekne15TjvS/w=="],
+
+    "@react-stately/searchfield": ["@react-stately/searchfield@3.5.19", "", { "dependencies": { "@react-stately/utils": "^3.11.0", "@react-types/searchfield": "^3.6.8", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-URllgjbtTQEaOCfddbHpJSPKOzG3pE3ajQHJ7Df8qCoHTjKfL6hnm/vp7X5sxPaZaN7VLZ5kAQxTE8hpo6s0+A=="],
+
+    "@react-stately/select": ["@react-stately/select@3.9.2", "", { "dependencies": { "@react-stately/form": "^3.2.4", "@react-stately/list": "^3.13.4", "@react-stately/overlays": "^3.6.23", "@react-stately/utils": "^3.11.0", "@react-types/select": "^3.12.2", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-oWn0bijuusp8YI7FRM/wgtPVqiIrgU/ZUfLKe/qJUmT8D+JFaMAJnyrAzKpx98TrgamgtXynF78ccpopPhgrKQ=="],
+
+    "@react-stately/selection": ["@react-stately/selection@3.20.9", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-RhxRR5Wovg9EVi3pq7gBPK2BoKmP59tOXDMh2r1PbnGevg/7TNdR67DCEblcmXwHuBNS46ELfKdd0XGHqmS8nQ=="],
+
+    "@react-stately/slider": ["@react-stately/slider@3.7.5", "", { "dependencies": { "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@react-types/slider": "^3.8.4", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-OrQMNR5xamLYH52TXtvTgyw3EMwv+JI+1istQgEj1CHBjC9eZZqn5iNCN20tzm+uDPTH0EIGULFjjPIumqYUQg=="],
+
+    "@react-stately/table": ["@react-stately/table@3.15.4", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/flags": "^3.1.2", "@react-stately/grid": "^3.11.9", "@react-stately/selection": "^3.20.9", "@react-stately/utils": "^3.11.0", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@react-types/table": "^3.13.6", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-fGaNyw3wv7JgRCNzgyDzpaaTFuSy5f4Qekch4UheMXDJX7dOeaMhUXeOfvnXCVg+BGM4ey/D82RvDOGvPy1Nww=="],
+
+    "@react-stately/tabs": ["@react-stately/tabs@3.8.9", "", { "dependencies": { "@react-stately/list": "^3.13.4", "@react-types/shared": "^3.33.1", "@react-types/tabs": "^3.3.22", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-AQ4Xrn6YzIolaVShCV9cnwOjBKPAOGP/PTp7wpSEtQbQ0HZzUDG2RG/M4baMeUB2jZ33b7ifXyPcK78o0uOftg=="],
+
+    "@react-stately/toast": ["@react-stately/toast@3.1.3", "", { "dependencies": { "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-mT9QJKmD523lqFpOp0VWZ6QHZENFK7HrodnNJDVc7g616s5GNmemdlkITV43fSY3tHeThCVvPu+Uzh7RvQ9mpQ=="],
+
+    "@react-stately/toggle": ["@react-stately/toggle@3.9.5", "", { "dependencies": { "@react-stately/utils": "^3.11.0", "@react-types/checkbox": "^3.10.4", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-PVzXc788q3jH98Kvw1LYDL+wpVC14dCEKjOku8cSaqhEof6AJGaLR9yq+EF1yYSL2dxI6z8ghc0OozY8WrcFcA=="],
+
+    "@react-stately/tooltip": ["@react-stately/tooltip@3.5.11", "", { "dependencies": { "@react-stately/overlays": "^3.6.23", "@react-types/tooltip": "^3.5.2", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-o8PnFXbvDCuVZ4Ht9ahfS6KHwIZjXopvoQ2vUPxv920irdgWEeC+4omgDOnJ/xFvcpmmJAmSsrQsTQrTguDUQA=="],
+
+    "@react-stately/tree": ["@react-stately/tree@3.9.6", "", { "dependencies": { "@react-stately/collections": "^3.12.10", "@react-stately/selection": "^3.20.9", "@react-stately/utils": "^3.11.0", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-JCuhGyX2A+PAMsx2pRSwArfqNFZJ9JSPkDaOQJS8MFPAsBe5HemvXsdmv9aBIMzlbCYcVq6EsrFnzbVVTBt/6w=="],
+
+    "@react-stately/utils": ["@react-stately/utils@3.11.0", "", { "dependencies": { "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw=="],
+
+    "@react-stately/virtualizer": ["@react-stately/virtualizer@4.4.6", "", { "dependencies": { "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-9SfXgLFB61/8SXNLfg5ARx9jAK4m03Aw6/Cg8mdZN24SYarL4TKNRpfw8K/HHVU/bi6WHSJypk6Z/z19o/ztrg=="],
+
+    "@react-types/autocomplete": ["@react-types/autocomplete@3.0.0-alpha.38", "", { "dependencies": { "@react-types/combobox": "^3.14.0", "@react-types/searchfield": "^3.6.8", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-0XrlVC8drzcrCNzybbkZdLcTofXEzBsHuaFevt5awW1J0xBJ+SMLIQMDeUYrvKjjwXUBlCtjJJpOvitGt4Z+KA=="],
+
+    "@react-types/breadcrumbs": ["@react-types/breadcrumbs@3.7.19", "", { "dependencies": { "@react-types/link": "^3.6.7", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-AnkyYYmzaM2QFi/N0P/kQLM8tHOyFi7p397B/jEMucXDfwMw5Ny1ObCXeIEqbh8KrIa2Xp8SxmQlCV+8FPs4LA=="],
+
+    "@react-types/button": ["@react-types/button@3.15.1", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-M1HtsKreJkigCnqceuIT22hDJBSStbPimnpmQmsl7SNyqCFY3+DHS7y/Sl3GvqCkzxF7j9UTL0dG38lGQ3K4xQ=="],
+
+    "@react-types/calendar": ["@react-types/calendar@3.8.3", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-fpH6WNXotzH0TlKHXXxtjeLZ7ko0sbyHmwDAwmDFyP7T0Iwn1YQZ+lhceLifvynlxuOgX6oBItyUKmkHQ0FouQ=="],
+
+    "@react-types/checkbox": ["@react-types/checkbox@3.10.4", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-tYCG0Pd1usEz5hjvBEYcqcA0youx930Rss1QBIse9TgMekA1c2WmPDNupYV8phpO8Zuej3DL1WfBeXcgavK8aw=="],
+
+    "@react-types/color": ["@react-types/color@3.1.4", "", { "dependencies": { "@react-types/shared": "^3.33.1", "@react-types/slider": "^3.8.4" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-s+Xj4pvNBlJPpQ1Gr7bO1j4/tuwMUfdS9xIVFuiW5RvDsSybKTUJ/gqPzTxms94VDCRhLFocVn2STNdD2Erf6A=="],
+
+    "@react-types/combobox": ["@react-types/combobox@3.14.0", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-zmSSS7BcCOD8rGT8eGbVy7UlL5qq1vm88fFn4WgFe+lfK33ne+E7yTzTxcPY2TCGSo5fY6xMj3OG79FfVNGbSg=="],
+
+    "@react-types/datepicker": ["@react-types/datepicker@3.13.5", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@react-types/calendar": "^3.8.3", "@react-types/overlays": "^3.9.4", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-j28Vz+xvbb4bj7+9Xbpc4WTvSitlBvt7YEaEGM/8ZQ5g4Jr85H2KwkmDwjzmMN2r6VMQMMYq9JEcemq5wWpfUQ=="],
+
+    "@react-types/dialog": ["@react-types/dialog@3.5.24", "", { "dependencies": { "@react-types/overlays": "^3.9.4", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-NFurEP/zV0dA/41422lV1t+0oh6f/13n+VmLHZG8R13m1J3ql/kAXZ49zBSqkqANBO1ojyugWebk99IiR4pYOw=="],
+
+    "@react-types/form": ["@react-types/form@3.7.18", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-0sBJW0+I9nJcF4SmKrYFEWAlehiebSTy7xqriqAXtqfTEdvzAYLGaAK2/7gx+wlNZeDTdW43CDRJ4XAhyhBqnw=="],
+
+    "@react-types/grid": ["@react-types/grid@3.3.8", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-zJvXH8gc1e1VH2H3LRnHH/W2HIkLkZMH3Cu5pLcj0vDuLBSWpcr3Ikh3jZ+VUOZF0G1Jt1lO8pKIaqFzDLNmLQ=="],
+
+    "@react-types/link": ["@react-types/link@3.6.7", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-1apXCFJgMC1uydc2KNENrps1qR642FqDpwlNWe254UTpRZn/hEZhA6ImVr8WhomfLJu672WyWA0rUOv4HT+/pQ=="],
+
+    "@react-types/listbox": ["@react-types/listbox@3.7.6", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-335NYElKEByXMalAmeRPyulKIDd2cjOCQhLwvv2BtxO5zaJfZnBbhZs+XPd9zwU6YomyOxODKSHrwbNDx+Jf3w=="],
+
+    "@react-types/menu": ["@react-types/menu@3.10.7", "", { "dependencies": { "@react-types/overlays": "^3.9.4", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-+p7ixZdvPDJZhisqdtWiiuJ9pteNfK5i19NB6wzAw5XkljbEzodNhwLv6rI96DY5XpbFso2kcjw7IWi+rAAGGQ=="],
+
+    "@react-types/meter": ["@react-types/meter@3.4.15", "", { "dependencies": { "@react-types/progress": "^3.5.18" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-9WjNphhLLM+TA4Ev1y2MkpugJ5JjTXseHh7ZWWx2veq5DrXMZYclkRpfUrUdLVKvaBIPQCgpQIj0TcQi+quR9A=="],
+
+    "@react-types/numberfield": ["@react-types/numberfield@3.8.18", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-nLzk7YAG9yAUtSv+9R8LgCHsu8hJq8/A+m1KsKxvc8WmNJjIujSFgWvT21MWBiUgPBzJKGzAqpMDDa087mltJQ=="],
+
+    "@react-types/overlays": ["@react-types/overlays@3.9.4", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-7Z9HaebMFyYBqtv3XVNHEmVkm7AiYviV7gv0c98elEN2Co+eQcKFGvwBM9Gy/lV57zlTqFX1EX/SAqkMEbCLOA=="],
+
+    "@react-types/progress": ["@react-types/progress@3.5.18", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-mKeQn+KrHr1y0/k7KtrbeDGDaERH6i4f6yBwj/ZtYDCTNKMO3tPHJY6nzF0w/KKZLplIO+BjUbHXc2RVm8ovwQ=="],
+
+    "@react-types/radio": ["@react-types/radio@3.9.4", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-TkMRY3sA1PcFZhhclu4IUzUTIir6MzNJj8h6WT8vO6Nug2kXJ72qigugVFBWJSE472mltduOErEAo0rtAYWbQA=="],
+
+    "@react-types/searchfield": ["@react-types/searchfield@3.6.8", "", { "dependencies": { "@react-types/shared": "^3.33.1", "@react-types/textfield": "^3.12.8" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-M2p7OVdMTMDmlBcHd4N2uCBwg3uJSNM4lmEyf09YD44N5wDAI0yogk52QBwsnhpe+i2s65UwCYgunB+QltRX8A=="],
+
+    "@react-types/select": ["@react-types/select@3.12.2", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-AseOjfr3qM1W1qIWcbAe6NFpwZluVeQX/dmu9BYxjcnVvtoBLPMbE5zX/BPbv+N5eFYjoMyj7Ug9dqnI+LrlGw=="],
+
+    "@react-types/shared": ["@react-types/shared@3.33.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag=="],
+
+    "@react-types/slider": ["@react-types/slider@3.8.4", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-C+xFVvfKREai9S/ekBDCVaGPOQYkNUAsQhjQnNsUAATaox4I6IYLmcIgLmljpMQWqAe+gZiWsIwacRYMez2Tew=="],
+
+    "@react-types/switch": ["@react-types/switch@3.5.17", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-2GTPJvBCYI8YZ3oerHtXg+qikabIXCMJ6C2wcIJ5Xn0k9XOovowghfJi10OPB2GGyOiLBU74CczP5nx8adG90Q=="],
+
+    "@react-types/table": ["@react-types/table@3.13.6", "", { "dependencies": { "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-eluL+iFfnVmFm7OSZrrFG9AUjw+tcv898zbv+NsZACa8oXG1v9AimhZfd+Mo8q/5+sX/9hguWNXFkSvmTjuVPQ=="],
+
+    "@react-types/tabs": ["@react-types/tabs@3.3.22", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-HGwLD9dA3k3AGfRKGFBhNgxU9/LyRmxN0kxVj1ghA4L9S/qTOzS6GhrGNkGzsGxyVLV4JN8MLxjWN2o9QHnLEg=="],
+
+    "@react-types/textfield": ["@react-types/textfield@3.12.8", "", { "dependencies": { "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-wt6FcuE5AyntxsnPika/h3nf/DPmeAVbI018L9o6h+B/IL4sMWWdx663wx2KOOeHH8ejKGZQNPLhUKs4s1mVQA=="],
+
+    "@react-types/tooltip": ["@react-types/tooltip@3.5.2", "", { "dependencies": { "@react-types/overlays": "^3.9.4", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-FvSuZ2WP08NEWefrpCdBYpEEZh/5TvqvGjq0wqGzWg2OPwpc14HjD8aE7I3MOuylXkD4MSlMjl7J4DlvlcCs3Q=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.19", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.1", "@tailwindcss/oxide-darwin-arm64": "4.2.1", "@tailwindcss/oxide-darwin-x64": "4.2.1", "@tailwindcss/oxide-freebsd-x64": "4.2.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1", "@tailwindcss/oxide-linux-arm64-musl": "4.2.1", "@tailwindcss/oxide-linux-x64-gnu": "4.2.1", "@tailwindcss/oxide-linux-x64-musl": "4.2.1", "@tailwindcss/oxide-wasm32-wasi": "4.2.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1", "@tailwindcss/oxide-win32-x64-msvc": "4.2.1" } }, "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.1", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ=="],
+
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.1", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "postcss": "^8.5.6", "tailwindcss": "4.2.1" } }, "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
+
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
+
+    "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "framer-motion": ["framer-motion@11.18.2", "", { "dependencies": { "motion-dom": "^11.18.1", "motion-utils": "^11.18.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "intl-messageformat": ["intl-messageformat@10.7.18", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/fast-memoize": "2.2.7", "@formatjs/icu-messageformat-parser": "2.11.4", "tslib": "^2.8.0" } }, "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "motion-dom": ["motion-dom@11.18.1", "", { "dependencies": { "motion-utils": "^11.18.1" } }, "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw=="],
+
+    "motion-utils": ["motion-utils@11.18.1", "", {}, "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
+    "react-aria": ["react-aria@3.47.0", "", { "dependencies": { "@internationalized/string": "^3.2.7", "@react-aria/breadcrumbs": "^3.5.32", "@react-aria/button": "^3.14.5", "@react-aria/calendar": "^3.9.5", "@react-aria/checkbox": "^3.16.5", "@react-aria/color": "^3.1.5", "@react-aria/combobox": "^3.15.0", "@react-aria/datepicker": "^3.16.1", "@react-aria/dialog": "^3.5.34", "@react-aria/disclosure": "^3.1.3", "@react-aria/dnd": "^3.11.6", "@react-aria/focus": "^3.21.5", "@react-aria/gridlist": "^3.14.4", "@react-aria/i18n": "^3.12.16", "@react-aria/interactions": "^3.27.1", "@react-aria/label": "^3.7.25", "@react-aria/landmark": "^3.0.10", "@react-aria/link": "^3.8.9", "@react-aria/listbox": "^3.15.3", "@react-aria/menu": "^3.21.0", "@react-aria/meter": "^3.4.30", "@react-aria/numberfield": "^3.12.5", "@react-aria/overlays": "^3.31.2", "@react-aria/progress": "^3.4.30", "@react-aria/radio": "^3.12.5", "@react-aria/searchfield": "^3.8.12", "@react-aria/select": "^3.17.3", "@react-aria/selection": "^3.27.2", "@react-aria/separator": "^3.4.16", "@react-aria/slider": "^3.8.5", "@react-aria/ssr": "^3.9.10", "@react-aria/switch": "^3.7.11", "@react-aria/table": "^3.17.11", "@react-aria/tabs": "^3.11.1", "@react-aria/tag": "^3.8.1", "@react-aria/textfield": "^3.18.5", "@react-aria/toast": "^3.0.11", "@react-aria/tooltip": "^3.9.2", "@react-aria/tree": "^3.1.7", "@react-aria/utils": "^3.33.1", "@react-aria/visually-hidden": "^3.8.31", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-nvahimIqdByl/PXk/xPkG30LPRzcin+/Uk0uFfwbbKRRFC9aa22a6BRULZLqVHwa9GaNyKe6CDUxO1Dde4v0kA=="],
+
+    "react-aria-components": ["react-aria-components@1.16.0", "", { "dependencies": { "@internationalized/date": "^3.12.0", "@internationalized/string": "^3.2.7", "@react-aria/autocomplete": "3.0.0-rc.6", "@react-aria/collections": "^3.0.3", "@react-aria/dnd": "^3.11.6", "@react-aria/focus": "^3.21.5", "@react-aria/interactions": "^3.27.1", "@react-aria/live-announcer": "^3.4.4", "@react-aria/overlays": "^3.31.2", "@react-aria/ssr": "^3.9.10", "@react-aria/textfield": "^3.18.5", "@react-aria/toolbar": "3.0.0-beta.24", "@react-aria/utils": "^3.33.1", "@react-aria/virtualizer": "^4.1.13", "@react-stately/autocomplete": "3.0.0-beta.4", "@react-stately/layout": "^4.6.0", "@react-stately/selection": "^3.20.9", "@react-stately/table": "^3.15.4", "@react-stately/utils": "^3.11.0", "@react-stately/virtualizer": "^4.4.6", "@react-types/form": "^3.7.18", "@react-types/grid": "^3.3.8", "@react-types/shared": "^3.33.1", "@react-types/table": "^3.13.6", "@swc/helpers": "^0.5.0", "client-only": "^0.0.1", "react-aria": "^3.47.0", "react-stately": "^3.45.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-MjHbTLpMFzzD2Tv5KbeXoZwPczuUWZcRavVvQQlNHRtXHH38D+sToMEYpNeir7Wh3K/XWtzeX3EujfJW6QNkrw=="],
+
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-router": ["react-router@7.13.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA=="],
+
+    "react-router-dom": ["react-router-dom@7.13.1", "", { "dependencies": { "react-router": "7.13.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw=="],
+
+    "react-stately": ["react-stately@3.45.0", "", { "dependencies": { "@react-stately/calendar": "^3.9.3", "@react-stately/checkbox": "^3.7.5", "@react-stately/collections": "^3.12.10", "@react-stately/color": "^3.9.5", "@react-stately/combobox": "^3.13.0", "@react-stately/data": "^3.15.2", "@react-stately/datepicker": "^3.16.1", "@react-stately/disclosure": "^3.0.11", "@react-stately/dnd": "^3.7.4", "@react-stately/form": "^3.2.4", "@react-stately/list": "^3.13.4", "@react-stately/menu": "^3.9.11", "@react-stately/numberfield": "^3.11.0", "@react-stately/overlays": "^3.6.23", "@react-stately/radio": "^3.11.5", "@react-stately/searchfield": "^3.5.19", "@react-stately/select": "^3.9.2", "@react-stately/selection": "^3.20.9", "@react-stately/slider": "^3.7.5", "@react-stately/table": "^3.15.4", "@react-stately/tabs": "^3.8.9", "@react-stately/toast": "^3.1.3", "@react-stately/toggle": "^3.9.5", "@react-stately/tooltip": "^3.5.11", "@react-stately/tree": "^3.9.6", "@react-types/shared": "^3.33.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-G3bYr0BIiookpt4H05VeZUuVS/FslQAj2TeT8vDfCiL314Y+LtPXIPe/a3eamCA0wljy7z1EDYKV50Qbz7pcJg=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
+
+    "tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
+
+    "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
+
+    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chumo - タスク管理</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "chumo-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "type-check": "tsc -b --noEmit",
+    "lint": "eslint .",
+    "format": "oxlint --fix .",
+    "format:check": "oxlint ."
+  },
+  "dependencies": {
+    "@clerk/clerk-react": "^5",
+    "@tanstack/react-query": "^5",
+    "clsx": "^2",
+    "framer-motion": "^11",
+    "lucide-react": "^0.468",
+    "react": "^19",
+    "react-aria-components": "^1",
+    "react-dom": "^19",
+    "react-router-dom": "^7",
+    "tailwind-merge": "^2"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
+    "postcss": "^8",
+    "tailwindcss": "^4",
+    "typescript": "^5.7",
+    "vite": "^6"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AppLayout } from './components/layout/AppLayout';
+import { DashboardPage } from './pages/dashboard/DashboardPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,9 +17,10 @@ export function App() {
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <Routes>
-          {/* TODO: ページコンポーネント実装後に追加 */}
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<div>Dashboard</div>} />
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+          </Route>
           <Route path="/login" element={<div>Login</div>} />
         </Routes>
       </BrowserRouter>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,26 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60, // 1分
+      retry: 1,
+    },
+  },
+});
+
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          {/* TODO: ページコンポーネント実装後に追加 */}
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/dashboard" element={<div>Dashboard</div>} />
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+
+export function AppLayout() {
+  return (
+    <div className="flex h-screen overflow-hidden bg-bg-primary">
+      <Sidebar />
+      <main className="flex flex-1 flex-col overflow-hidden">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface HeaderProps {
+  title: string;
+  children?: ReactNode;
+}
+
+export function Header({ title, children }: HeaderProps) {
+  return (
+    <header className="flex h-16 items-center justify-between border-b border-border-default px-8">
+      <h1 className="text-2xl font-bold text-text-primary">{title}</h1>
+      {children && <div className="flex items-center gap-3">{children}</div>}
+    </header>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,80 @@
+import {
+  LayoutDashboard,
+  ListTodo,
+  BarChart3,
+  MessageSquare,
+  Settings,
+  SquareCheckBig,
+  StickyNote,
+  Palette,
+} from 'lucide-react';
+import { SidebarNavItem } from './SidebarNavItem';
+import { useTheme } from '../../hooks/useTheme';
+
+const NAV_ITEMS = [
+  { path: '/dashboard', label: 'ダッシュボード', icon: <LayoutDashboard size={20} /> },
+  { path: '/tasks', label: 'タスク', icon: <ListTodo size={20} /> },
+  { path: '/report', label: 'レポート', icon: <BarChart3 size={20} /> },
+  { path: '/contact', label: 'お問い合わせ', icon: <MessageSquare size={20} /> },
+  { path: '/settings', label: '設定', icon: <Settings size={20} /> },
+];
+
+export function Sidebar() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <aside className="flex h-full w-60 shrink-0 flex-col bg-teal-950 border-r border-teal-800 px-4 py-6">
+      {/* ロゴ */}
+      <div className="flex h-10 items-center gap-2.5 px-2">
+        <SquareCheckBig size={24} className="text-teal-300" />
+        <span className="text-xl font-bold text-white">ちゅも</span>
+      </div>
+
+      {/* スペーサー */}
+      <div className="h-8" />
+
+      {/* MENU ラベル */}
+      <p className="px-3 text-xs font-medium tracking-widest text-teal-400 mb-3">MENU</p>
+
+      {/* メインナビゲーション */}
+      <nav className="flex-1 space-y-1 overflow-y-auto">
+        {NAV_ITEMS.map((item) => (
+          <SidebarNavItem key={item.path} to={item.path} icon={item.icon} label={item.label} />
+        ))}
+      </nav>
+
+      {/* 下部エリア */}
+      <div className="space-y-1">
+        {/* メモ */}
+        <button
+          type="button"
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-base text-teal-300 transition-colors hover:bg-teal-800/50 hover:text-teal-200 [&_svg]:text-teal-400"
+        >
+          <StickyNote size={20} />
+          <span>メモ</span>
+        </button>
+
+        {/* テーマトグル */}
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-1.5 text-sm font-medium text-teal-300 transition-colors hover:bg-teal-800/50 hover:text-teal-200 [&_svg]:text-teal-400 h-9"
+        >
+          <Palette size={20} />
+          <span>{theme === 'light' ? 'ライトモード' : 'ダークモード'}</span>
+        </button>
+
+        {/* ユーザープロフィール */}
+        <div className="flex items-center gap-3 border-t border-teal-700 px-2 pt-2">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-default">
+            <span className="text-sm font-bold text-white">T</span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-white">Tanaka Yui</p>
+            <p className="truncate text-xs text-teal-400">Project Manager</p>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/layout/SidebarNavItem.tsx
+++ b/frontend/src/components/layout/SidebarNavItem.tsx
@@ -1,0 +1,28 @@
+import { NavLink } from 'react-router-dom';
+import { cn } from '../../lib/utils';
+import type { ReactNode } from 'react';
+
+interface SidebarNavItemProps {
+  to: string;
+  icon: ReactNode;
+  label: string;
+}
+
+export function SidebarNavItem({ to, icon, label }: SidebarNavItemProps) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        cn(
+          'flex h-10 items-center gap-3 rounded-lg px-3 text-base transition-colors',
+          isActive
+            ? 'bg-teal-700 font-medium text-white [&_svg]:text-teal-200'
+            : 'text-teal-300 [&_svg]:text-teal-400 hover:bg-teal-800/50 hover:text-teal-200'
+        )
+      }
+    >
+      {icon}
+      <span>{label}</span>
+    </NavLink>
+  );
+}

--- a/frontend/src/components/shared/TaskDrawer/CommentTab.tsx
+++ b/frontend/src/components/shared/TaskDrawer/CommentTab.tsx
@@ -1,0 +1,7 @@
+export function CommentTab() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <p className="text-sm text-text-tertiary">コメント機能は後日実装</p>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { Play, ExternalLink, Folder, MessageCircle, Flame, PawPrint } from 'lucide-react';
+
+export function DrawerActionBar() {
+  return (
+    <div className="border-b border-border-default px-6 py-4 space-y-3">
+      {/* 詳細ページボタン */}
+      <button
+        type="button"
+        className="flex h-10 w-full items-center justify-center gap-2 rounded-md border border-primary-default text-sm font-medium text-primary-default transition-colors hover:bg-bg-brand-subtle"
+      >
+        詳細ページ
+      </button>
+
+      {/* タイマー開始ボタン */}
+      <button
+        type="button"
+        className="flex h-10 w-full items-center justify-center gap-2 rounded-md border border-primary-default text-sm font-medium text-primary-default transition-colors hover:bg-bg-brand-subtle"
+      >
+        <Play size={18} />
+        タイマー開始
+      </button>
+
+      {/* 外部リンクボタングリッド */}
+      <div className="space-y-2">
+        <div className="grid grid-cols-2 gap-2">
+          <LinkButton icon={<Folder size={16} />} label="DRIVE作成" />
+          <LinkButton icon={<MessageCircle size={16} />} label="CHAT作成" />
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <LinkButton icon={<Flame size={16} />} label="FIRE issue作成" />
+          <LinkButton icon={<PawPrint size={16} />} label="PET issue作成" />
+        </div>
+      </div>
+
+      {/* BACKLOGボタン */}
+      <button
+        type="button"
+        className="flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary-default text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+      >
+        <ExternalLink size={16} />
+        BACKLOGを開く
+      </button>
+    </div>
+  );
+}
+
+function LinkButton({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <button
+      type="button"
+      className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-border-default text-xs font-medium text-text-secondary transition-colors hover:bg-bg-secondary"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/shared/TaskDrawer/DrawerHeader.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerHeader.tsx
@@ -1,0 +1,36 @@
+import { X, Trash2 } from 'lucide-react';
+
+interface DrawerHeaderProps {
+  title: string;
+  onClose: () => void;
+}
+
+export function DrawerHeader({ title, onClose }: DrawerHeaderProps) {
+  return (
+    <div className="border-b border-border-default px-6 py-5 space-y-4">
+      {/* タイトル + 閉じる */}
+      <div className="flex items-start justify-between gap-3">
+        <h2 className="text-lg font-bold leading-normal text-text-primary">{title}</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-bg-secondary"
+          aria-label="閉じる"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      {/* 削除ボタン */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium text-error-text transition-colors hover:bg-error-bg"
+        >
+          <Trash2 size={14} />
+          削除
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/TaskDrawer/DrawerTabBar.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerTabBar.tsx
@@ -1,0 +1,27 @@
+import { Tabs, TabList, Tab, TabPanel } from '../../ui/Tabs';
+import type { ReactNode } from 'react';
+
+interface DrawerTabBarProps {
+  detailContent: ReactNode;
+  commentContent: ReactNode;
+}
+
+export function DrawerTabBar({ detailContent, commentContent }: DrawerTabBarProps) {
+  return (
+    <Tabs defaultSelectedKey="detail" className="flex-1 flex flex-col min-h-0">
+      <TabList className="px-6">
+        <Tab id="detail">タスク詳細</Tab>
+        <Tab id="comment">
+          コメント
+          <span className="h-2 w-2 rounded-full bg-blue-500" />
+        </Tab>
+      </TabList>
+      <TabPanel id="detail" className="flex-1 overflow-y-auto px-6 py-5">
+        {detailContent}
+      </TabPanel>
+      <TabPanel id="comment" className="flex-1 overflow-y-auto px-6 py-5">
+        {commentContent}
+      </TabPanel>
+    </Tabs>
+  );
+}

--- a/frontend/src/components/shared/TaskDrawer/TaskDetailTab.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDetailTab.tsx
@@ -5,7 +5,8 @@ import { Badge } from '../../ui/Badge';
 import { Avatar } from '../../ui/Avatar';
 import { FLOW_STATUS_LABELS } from '../../../lib/constants';
 import { formatDate } from '../../../lib/taskUtils';
-import { getUserById, getLabelById, MOCK_SESSIONS } from '../../../lib/mockData';
+import { resolveAssignees, getUserById, getLabelById, MOCK_SESSIONS } from '../../../lib/mockData';
+import { formatDuration } from '../../../lib/taskUtils';
 
 interface TaskDetailTabProps {
   task: Task;
@@ -13,9 +14,7 @@ interface TaskDetailTabProps {
 
 export function TaskDetailTab({ task }: TaskDetailTabProps) {
   const label = getLabelById(task.kubunLabelId);
-  const assignees = task.assigneeIds
-    .map((id) => getUserById(id))
-    .filter((u): u is NonNullable<typeof u> => u != null);
+  const assignees = resolveAssignees(task.assigneeIds);
 
   const sessions = MOCK_SESSIONS.filter((s) => s.taskId === task.id);
 
@@ -106,17 +105,7 @@ export function TaskDetailTab({ task }: TaskDetailTabProps) {
             {sessions.map((session) => {
               const user = getUserById(session.userId);
               const startDate = new Date(session.startedAt);
-              const hours = Math.floor(session.durationSec / 3600);
-              const minutes = Math.floor((session.durationSec % 3600) / 60);
-              const seconds = session.durationSec % 60;
-
-              const durationText = [
-                hours > 0 ? `${hours}時間` : '',
-                minutes > 0 ? `${minutes}分` : '',
-                seconds > 0 ? `${seconds}秒` : '',
-              ]
-                .filter(Boolean)
-                .join('');
+              const durationText = formatDuration(session.durationSec);
 
               return (
                 <div key={session.id} className="flex items-center justify-between py-2 text-sm">

--- a/frontend/src/components/shared/TaskDrawer/TaskDetailTab.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDetailTab.tsx
@@ -1,0 +1,172 @@
+import type { ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import type { Task } from '../../../types';
+import { Badge } from '../../ui/Badge';
+import { Avatar } from '../../ui/Avatar';
+import { FLOW_STATUS_LABELS } from '../../../lib/constants';
+import { formatDate } from '../../../lib/taskUtils';
+import { getUserById, getLabelById, MOCK_SESSIONS } from '../../../lib/mockData';
+
+interface TaskDetailTabProps {
+  task: Task;
+}
+
+export function TaskDetailTab({ task }: TaskDetailTabProps) {
+  const label = getLabelById(task.kubunLabelId);
+  const assignees = task.assigneeIds
+    .map((id) => getUserById(id))
+    .filter((u): u is NonNullable<typeof u> => u != null);
+
+  const sessions = MOCK_SESSIONS.filter((s) => s.taskId === task.id);
+
+  return (
+    <div className="space-y-0">
+      {/* 説明 */}
+      <section className="pb-4">
+        <SectionLabel>説明</SectionLabel>
+        <div className="mt-2 rounded-md bg-bg-secondary p-3">
+          <p className="text-sm leading-relaxed text-text-secondary whitespace-pre-wrap">
+            {task.description || <span className="text-text-tertiary">説明を入力...</span>}
+          </p>
+        </div>
+      </section>
+
+      <Divider />
+
+      {/* プロパティ */}
+      <section className="py-3">
+        <PropertyRow label="担当">
+          <PropertyValue>
+            <span className="text-sm text-text-primary">{FLOW_STATUS_LABELS[task.flowStatus]}</span>
+            <ChevronDown size={14} className="text-text-tertiary" />
+          </PropertyValue>
+        </PropertyRow>
+        <PropertyRow label="進捗">
+          <PropertyValue>
+            {task.progressStatus ? (
+              <Badge status={task.progressStatus} />
+            ) : (
+              <span className="text-sm text-text-tertiary">未設定</span>
+            )}
+            <ChevronDown size={14} className="text-text-tertiary" />
+          </PropertyValue>
+        </PropertyRow>
+        <PropertyRow label="区分">
+          <PropertyValue>
+            <span className="text-sm text-text-primary">{label?.name ?? '未設定'}</span>
+            <ChevronDown size={14} className="text-text-tertiary" />
+          </PropertyValue>
+        </PropertyRow>
+      </section>
+
+      <Divider />
+
+      {/* スケジュール */}
+      <section className="py-3">
+        <PropertyRow label="ITアップ日">
+          <PropertyValue>
+            <span className="text-sm text-text-primary">{formatDate(task.itUpDate)}</span>
+            <ChevronDown size={14} className="text-text-tertiary" />
+          </PropertyValue>
+        </PropertyRow>
+        <PropertyRow label="リリース日">
+          <PropertyValue>
+            <span className="text-sm text-text-primary">{formatDate(task.releaseDate)}</span>
+            <ChevronDown size={14} className="text-text-tertiary" />
+          </PropertyValue>
+        </PropertyRow>
+      </section>
+
+      {/* アサイン */}
+      <section className="py-3">
+        <SectionLabel>アサイン</SectionLabel>
+        <div className="mt-2.5 flex items-center gap-2">
+          {assignees.map((user) => (
+            <Avatar key={user.id} name={user.displayName} size="md" />
+          ))}
+          <button
+            type="button"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-border-default text-text-tertiary transition-colors hover:bg-bg-secondary"
+            aria-label="アサインを追加"
+          >
+            +
+          </button>
+        </div>
+      </section>
+
+      <Divider />
+
+      {/* セッション履歴 */}
+      <section className="py-3">
+        <span className="text-xs font-medium text-text-tertiary">セッション履歴</span>
+        {sessions.length === 0 ? (
+          <p className="mt-2 text-sm text-text-tertiary">セッション履歴はありません</p>
+        ) : (
+          <div className="mt-1">
+            {sessions.map((session) => {
+              const user = getUserById(session.userId);
+              const startDate = new Date(session.startedAt);
+              const hours = Math.floor(session.durationSec / 3600);
+              const minutes = Math.floor((session.durationSec % 3600) / 60);
+              const seconds = session.durationSec % 60;
+
+              const durationText = [
+                hours > 0 ? `${hours}時間` : '',
+                minutes > 0 ? `${minutes}分` : '',
+                seconds > 0 ? `${seconds}秒` : '',
+              ]
+                .filter(Boolean)
+                .join('');
+
+              return (
+                <div key={session.id} className="flex items-center justify-between py-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    <Avatar name={user?.displayName ?? '不明'} size="sm" />
+                    <span className="text-text-primary">{user?.displayName ?? '不明'}</span>
+                    <span className="text-text-tertiary">
+                      {startDate.toLocaleDateString('ja-JP', {
+                        month: 'numeric',
+                        day: 'numeric',
+                      })}{' '}
+                      {startDate.toLocaleTimeString('ja-JP', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                      〜
+                    </span>
+                  </div>
+                  <span className="text-text-secondary">{durationText}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return <span className="text-xs font-bold tracking-wide text-text-tertiary">{children}</span>;
+}
+
+function PropertyRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex h-10 items-center py-1">
+      <span className="w-24 shrink-0 text-sm text-text-secondary">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function PropertyValue({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-8 flex-1 items-center justify-between rounded-sm bg-bg-secondary px-2.5">
+      {children}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className="h-px bg-border-default" />;
+}

--- a/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { Task } from '../../../types';
+import { DrawerHeader } from './DrawerHeader';
+import { DrawerActionBar } from './DrawerActionBar';
+import { DrawerTabBar } from './DrawerTabBar';
+import { TaskDetailTab } from './TaskDetailTab';
+import { CommentTab } from './CommentTab';
+
+interface TaskDrawerProps {
+  task: Task | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function TaskDrawer({ task, isOpen, onClose }: TaskDrawerProps) {
+  // ESCキーで閉じる
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && task && (
+        <>
+          {/* オーバーレイ */}
+          <motion.div
+            className="fixed inset-0 z-40 bg-black/30"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+
+          {/* ドロワー */}
+          <motion.div
+            className="fixed right-0 top-0 z-50 flex h-full w-[480px] flex-col bg-bg-primary shadow-xl border-l border-border-default"
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+            role="dialog"
+            aria-modal="true"
+            aria-label="タスク詳細"
+          >
+            <DrawerHeader title={task.title} onClose={onClose} />
+            <DrawerActionBar />
+            <DrawerTabBar
+              detailContent={<TaskDetailTab task={task} />}
+              commentContent={<CommentTab />}
+            />
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
@@ -9,11 +9,12 @@ import { CommentTab } from './CommentTab';
 
 interface TaskDrawerProps {
   task: Task | null;
-  isOpen: boolean;
   onClose: () => void;
 }
 
-export function TaskDrawer({ task, isOpen, onClose }: TaskDrawerProps) {
+export function TaskDrawer({ task, onClose }: TaskDrawerProps) {
+  const isOpen = task != null;
+
   // ESCキーで閉じる
   useEffect(() => {
     if (!isOpen) return;
@@ -26,7 +27,7 @@ export function TaskDrawer({ task, isOpen, onClose }: TaskDrawerProps) {
 
   return (
     <AnimatePresence>
-      {isOpen && task && (
+      {task && (
         <>
           {/* オーバーレイ */}
           <motion.div

--- a/frontend/src/components/shared/ThemeToggle.tsx
+++ b/frontend/src/components/shared/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import { Sun, Moon } from 'lucide-react';
+import { IconButton } from '../ui/IconButton';
+import { useTheme } from '../../hooks/useTheme';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <IconButton
+      aria-label={theme === 'light' ? 'ダークモードに切替' : 'ライトモードに切替'}
+      onPress={toggleTheme}
+    >
+      {theme === 'light' ? <Moon size={18} /> : <Sun size={18} />}
+    </IconButton>
+  );
+}

--- a/frontend/src/components/ui/Avatar.tsx
+++ b/frontend/src/components/ui/Avatar.tsx
@@ -1,0 +1,76 @@
+import { cn } from '../../lib/utils';
+
+const AVATAR_COLORS = [
+  'bg-teal-500',
+  'bg-pink-500',
+  'bg-purple-500',
+  'bg-blue-500',
+  'bg-amber-500',
+  'bg-cyan-500',
+  'bg-green-500',
+  'bg-red-500',
+] as const;
+
+function getAvatarColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length] ?? AVATAR_COLORS[0];
+}
+
+function getInitials(name: string): string {
+  // 日本語名の場合は最初の1文字
+  if (/[\u3000-\u9fff]/.test(name)) {
+    return name.charAt(0);
+  }
+  // 英語名の場合はイニシャル
+  return name
+    .split(' ')
+    .filter((n) => n.length > 0)
+    .map((n) => n.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+const sizeStyles = {
+  sm: 'h-6 w-6 text-xs',
+  md: 'h-8 w-8 text-sm',
+  lg: 'h-10 w-10 text-md',
+} as const;
+
+interface AvatarProps {
+  name: string;
+  imageUrl?: string;
+  size?: keyof typeof sizeStyles;
+  className?: string;
+}
+
+export function Avatar({ name, imageUrl, size = 'md', className }: AvatarProps) {
+  const initials = getInitials(name);
+  const colorClass = getAvatarColor(name);
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center justify-center rounded-full font-medium text-white shrink-0',
+        sizeStyles[size],
+        !imageUrl && colorClass,
+        className
+      )}
+      title={name}
+    >
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={name}
+          className="h-full w-full rounded-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        initials
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/AvatarGroup.tsx
+++ b/frontend/src/components/ui/AvatarGroup.tsx
@@ -1,0 +1,39 @@
+import { Avatar } from './Avatar';
+import { cn } from '../../lib/utils';
+
+interface AvatarGroupUser {
+  id: string;
+  displayName: string;
+  imageUrl?: string;
+}
+
+interface AvatarGroupProps {
+  users: AvatarGroupUser[];
+  max?: number;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export function AvatarGroup({ users, max = 5, size = 'sm', className }: AvatarGroupProps) {
+  if (users.length === 0) return null;
+
+  const visible = users.slice(0, max);
+  const remaining = users.length - max;
+
+  return (
+    <div className={cn('flex items-center -space-x-2', className)}>
+      {visible.map((user) => (
+        <Avatar
+          key={user.id}
+          name={user.displayName}
+          imageUrl={user.imageUrl}
+          size={size}
+          className="ring-2 ring-bg-primary"
+        />
+      ))}
+      {remaining > 0 && (
+        <span className="ml-1 text-xs font-medium text-text-tertiary">+{remaining}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,24 @@
+import type { ProgressStatus } from '../../types';
+import { PROGRESS_STATUS_COLOR_MAP } from '../../lib/constants';
+import { cn } from '../../lib/utils';
+
+interface BadgeProps {
+  status: ProgressStatus;
+  className?: string;
+}
+
+export function Badge({ status, className }: BadgeProps) {
+  const colorClass = PROGRESS_STATUS_COLOR_MAP[status];
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-3 py-0.5 text-xs font-bold text-white',
+        colorClass,
+        className
+      )}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,39 @@
+import { Button as AriaButton, type ButtonProps as AriaButtonProps } from 'react-aria-components';
+import { cn } from '../../lib/utils';
+
+const variantStyles = {
+  primary: 'bg-primary-default text-text-inverse hover:bg-primary-hover active:bg-primary-active',
+  secondary:
+    'bg-bg-tertiary text-text-primary hover:bg-neutral-300 active:bg-neutral-400 dark:hover:bg-neutral-600 dark:active:bg-neutral-500',
+  outline:
+    'border border-border-default text-text-primary hover:bg-bg-secondary active:bg-bg-tertiary',
+  ghost: 'text-text-primary hover:bg-bg-secondary active:bg-bg-tertiary',
+  destructive: 'bg-red-600 text-white hover:bg-red-700 active:bg-red-800',
+} as const;
+
+const sizeStyles = {
+  sm: 'h-8 px-3 text-sm gap-1.5',
+  md: 'h-9 px-4 text-md gap-2',
+  lg: 'h-10 px-5 text-md gap-2',
+} as const;
+
+export interface ButtonProps extends AriaButtonProps {
+  variant?: keyof typeof variantStyles;
+  size?: keyof typeof sizeStyles;
+}
+
+export function Button({ variant = 'primary', size = 'md', className, ...props }: ButtonProps) {
+  return (
+    <AriaButton
+      className={cn(
+        'inline-flex items-center justify-center rounded-md font-medium transition-colors',
+        'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus',
+        'disabled:opacity-50 disabled:pointer-events-none',
+        variantStyles[variant],
+        sizeStyles[size],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -1,0 +1,30 @@
+import { Button as AriaButton, type ButtonProps as AriaButtonProps } from 'react-aria-components';
+import { cn } from '../../lib/utils';
+
+const sizeStyles = {
+  sm: 'h-7 w-7',
+  md: 'h-9 w-9',
+  lg: 'h-10 w-10',
+} as const;
+
+export interface IconButtonProps extends AriaButtonProps {
+  size?: keyof typeof sizeStyles;
+  'aria-label': string;
+}
+
+export function IconButton({ size = 'md', className, ...props }: IconButtonProps) {
+  return (
+    <AriaButton
+      className={cn(
+        'inline-flex items-center justify-center rounded-md text-text-secondary transition-colors',
+        'hover:bg-bg-secondary hover:text-text-primary',
+        'active:bg-bg-tertiary',
+        'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus',
+        'disabled:opacity-50 disabled:pointer-events-none',
+        sizeStyles[size],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode } from 'react';
+import { TextField, Input as AriaInput, type TextFieldProps } from 'react-aria-components';
+import { cn } from '../../lib/utils';
+
+interface InputProps extends Omit<TextFieldProps, 'children'> {
+  placeholder?: string;
+  icon?: ReactNode;
+  inputClassName?: string;
+}
+
+export function Input({ icon, className, placeholder, inputClassName, ...props }: InputProps) {
+  return (
+    <TextField className={cn('relative', className)} {...props}>
+      {icon && (
+        <span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-text-tertiary">
+          {icon}
+        </span>
+      )}
+      <AriaInput
+        placeholder={placeholder}
+        className={cn(
+          'h-9 w-full rounded-md border border-border-default bg-bg-secondary px-3 text-sm text-text-primary',
+          'placeholder:text-text-tertiary',
+          'focus:border-border-focus focus:outline-none focus:ring-1 focus:ring-border-focus',
+          'transition-colors',
+          icon && 'pl-9',
+          inputClassName
+        )}
+      />
+    </TextField>
+  );
+}

--- a/frontend/src/components/ui/Spinner.tsx
+++ b/frontend/src/components/ui/Spinner.tsx
@@ -1,0 +1,26 @@
+import { cn } from '../../lib/utils';
+
+interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const sizeStyles = {
+  sm: 'h-4 w-4 border-2',
+  md: 'h-6 w-6 border-2',
+  lg: 'h-8 w-8 border-[3px]',
+} as const;
+
+export function Spinner({ size = 'md', className }: SpinnerProps) {
+  return (
+    <div
+      role="status"
+      aria-label="読み込み中"
+      className={cn(
+        'animate-spin rounded-full border-primary-default border-t-transparent',
+        sizeStyles[size],
+        className
+      )}
+    />
+  );
+}

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode, ComponentProps } from 'react';
+import {
+  Tabs as AriaTabs,
+  TabList as AriaTabList,
+  Tab as AriaTab,
+  TabPanel as AriaTabPanel,
+  type TabsProps as AriaTabsProps,
+  type TabProps as AriaTabProps,
+  type TabPanelProps as AriaTabPanelProps,
+} from 'react-aria-components';
+import { cn } from '../../lib/utils';
+
+export function Tabs({ className, ...props }: AriaTabsProps) {
+  return <AriaTabs className={cn('flex flex-col', className)} {...props} />;
+}
+
+export function TabList({ className, ...props }: ComponentProps<typeof AriaTabList>) {
+  return (
+    <AriaTabList className={cn('flex border-b border-border-default', className)} {...props} />
+  );
+}
+
+interface TabProps extends Omit<AriaTabProps, 'children'> {
+  badge?: number;
+  children?: ReactNode;
+}
+
+export function Tab({ className, badge, children, ...props }: TabProps) {
+  return (
+    <AriaTab
+      className={cn(
+        'relative flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium cursor-pointer transition-colors',
+        'text-text-tertiary hover:text-text-primary',
+        'selected:text-text-primary selected:font-medium',
+        'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5',
+        'selected:after:bg-primary-default',
+        'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-border-focus',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {badge != null && badge > 0 && (
+        <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+          {badge}
+        </span>
+      )}
+    </AriaTab>
+  );
+}
+
+export function TabPanel({ className, ...props }: AriaTabPanelProps) {
+  return <AriaTabPanel className={cn('flex-1 overflow-auto', className)} {...props} />;
+}

--- a/frontend/src/components/ui/ToggleGroup.tsx
+++ b/frontend/src/components/ui/ToggleGroup.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode } from 'react';
+import { cn } from '../../lib/utils';
+
+interface ToggleGroupItem {
+  value: string;
+  label: string;
+  icon: ReactNode;
+}
+
+interface ToggleGroupProps {
+  items: ToggleGroupItem[];
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+export function ToggleGroup({ items, value, onChange, className }: ToggleGroupProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center rounded-md border border-border-default p-0.5',
+        className
+      )}
+      role="radiogroup"
+    >
+      {items.map((item) => {
+        const isSelected = item.value === value;
+        return (
+          <button
+            key={item.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={item.label}
+            onClick={() => onChange(item.value)}
+            className={cn(
+              'inline-flex items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm transition-colors',
+              'focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-border-focus',
+              isSelected
+                ? 'bg-bg-primary text-text-primary shadow-sm'
+                : 'text-text-secondary hover:text-text-primary'
+            )}
+          >
+            {item.icon}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDashboardStats.ts
+++ b/frontend/src/hooks/useDashboardStats.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { Task } from '../types';
-import { COMPLETED_PROGRESS_STATUSES, DUE_SOON_THRESHOLD_DAYS } from '../lib/constants';
+import { getTaskBgVariant } from '../lib/taskUtils';
 
 interface DashboardStats {
   active: number;
@@ -11,12 +11,6 @@ interface DashboardStats {
 
 export function useDashboardStats(tasks: Task[]): DashboardStats {
   return useMemo(() => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    const thresholdDate = new Date(today);
-    thresholdDate.setDate(thresholdDate.getDate() + DUE_SOON_THRESHOLD_DAYS);
-
     let active = 0;
     let dueSoon = 0;
     let overdue = 0;
@@ -30,21 +24,9 @@ export function useDashboardStats(tasks: Task[]): DashboardStats {
 
       active++;
 
-      // 完了段階の進捗はカウント対象外
-      if (task.progressStatus && COMPLETED_PROGRESS_STATUSES.includes(task.progressStatus)) {
-        continue;
-      }
-
-      if (!task.itUpDate) continue;
-
-      const itDate = new Date(task.itUpDate);
-      itDate.setHours(0, 0, 0, 0);
-
-      if (itDate < today) {
-        overdue++;
-      } else if (itDate <= thresholdDate) {
-        dueSoon++;
-      }
+      const variant = getTaskBgVariant(task);
+      if (variant === 'error') overdue++;
+      else if (variant === 'warning') dueSoon++;
     }
 
     return { active, dueSoon, overdue, done };

--- a/frontend/src/hooks/useDashboardStats.ts
+++ b/frontend/src/hooks/useDashboardStats.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import type { Task } from '../types';
+import { COMPLETED_PROGRESS_STATUSES, DUE_SOON_THRESHOLD_DAYS } from '../lib/constants';
+
+interface DashboardStats {
+  active: number;
+  dueSoon: number;
+  overdue: number;
+  done: number;
+}
+
+export function useDashboardStats(tasks: Task[]): DashboardStats {
+  return useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const thresholdDate = new Date(today);
+    thresholdDate.setDate(thresholdDate.getDate() + DUE_SOON_THRESHOLD_DAYS);
+
+    let active = 0;
+    let dueSoon = 0;
+    let overdue = 0;
+    let done = 0;
+
+    for (const task of tasks) {
+      if (task.flowStatus === '完了') {
+        done++;
+        continue;
+      }
+
+      active++;
+
+      // 完了段階の進捗はカウント対象外
+      if (task.progressStatus && COMPLETED_PROGRESS_STATUSES.includes(task.progressStatus)) {
+        continue;
+      }
+
+      if (!task.itUpDate) continue;
+
+      const itDate = new Date(task.itUpDate);
+      itDate.setHours(0, 0, 0, 0);
+
+      if (itDate < today) {
+        overdue++;
+      } else if (itDate <= thresholdDate) {
+        dueSoon++;
+      }
+    }
+
+    return { active, dueSoon, overdue, done };
+  }, [tasks]);
+}

--- a/frontend/src/hooks/useTaskDrawer.ts
+++ b/frontend/src/hooks/useTaskDrawer.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export function useTaskDrawer() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const taskIdFromUrl = searchParams.get('task');
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(taskIdFromUrl);
+
+  // URL変更時に同期
+  useEffect(() => {
+    setSelectedTaskId(taskIdFromUrl);
+  }, [taskIdFromUrl]);
+
+  const openDrawer = useCallback(
+    (taskId: string) => {
+      setSelectedTaskId(taskId);
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.set('task', taskId);
+        return next;
+      });
+    },
+    [setSearchParams]
+  );
+
+  const closeDrawer = useCallback(() => {
+    setSelectedTaskId(null);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('task');
+      return next;
+    });
+  }, [setSearchParams]);
+
+  return {
+    selectedTaskId,
+    isOpen: selectedTaskId != null,
+    openDrawer,
+    closeDrawer,
+  } as const;
+}

--- a/frontend/src/hooks/useTaskDrawer.ts
+++ b/frontend/src/hooks/useTaskDrawer.ts
@@ -1,19 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export function useTaskDrawer() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const taskIdFromUrl = searchParams.get('task');
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(taskIdFromUrl);
-
-  // URL変更時に同期
-  useEffect(() => {
-    setSelectedTaskId(taskIdFromUrl);
-  }, [taskIdFromUrl]);
+  const selectedTaskId = searchParams.get('task');
 
   const openDrawer = useCallback(
     (taskId: string) => {
-      setSelectedTaskId(taskId);
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
         next.set('task', taskId);
@@ -24,7 +17,6 @@ export function useTaskDrawer() {
   );
 
   const closeDrawer = useCallback(() => {
-    setSelectedTaskId(null);
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       next.delete('task');
@@ -34,7 +26,6 @@ export function useTaskDrawer() {
 
   return {
     selectedTaskId,
-    isOpen: selectedTaskId != null,
     openDrawer,
     closeDrawer,
   } as const;

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'chumo-theme';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'dark' || stored === 'light') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t);
+  }, []);
+
+  return { theme, toggleTheme, setTheme } as const;
+}

--- a/frontend/src/hooks/useViewMode.ts
+++ b/frontend/src/hooks/useViewMode.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react';
+
+export type ViewMode = 'table' | 'card';
+
+const STORAGE_KEY = 'chumo-view-mode';
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === 'undefined') return 'table';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'table' || stored === 'card') return stored;
+  return 'table';
+}
+
+export function useViewMode() {
+  const [viewMode, setViewModeState] = useState<ViewMode>(getInitialViewMode);
+
+  const setViewMode = useCallback((mode: ViewMode) => {
+    setViewModeState(mode);
+    localStorage.setItem(STORAGE_KEY, mode);
+  }, []);
+
+  return { viewMode, setViewMode } as const;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,250 @@
+@import 'tailwindcss';
+@custom-variant dark (&:where(.dark, .dark *));
+
+/*
+ * Design Tokens — Pencil (designs/design.pen) から抽出
+ * 9パレット94色 + 24セマンティック + spacing/text/leading/font-weight/radius
+ */
+
+/* ---------- Primitive Colors ---------- */
+@theme {
+  /* Brand - Teal (11) */
+  --color-teal-50: #eefbfb;
+  --color-teal-100: #c5f2f1;
+  --color-teal-200: #8de5e4;
+  --color-teal-300: #55d5d4;
+  --color-teal-400: #27c2c1;
+  --color-teal-500: #00a8a7;
+  --color-teal-600: #008b8a;
+  --color-teal-700: #007170;
+  --color-teal-800: #005857;
+  --color-teal-900: #003f3e;
+  --color-teal-950: #002625;
+
+  /* Neutral (12) */
+  --color-neutral-50: #f9fafb;
+  --color-neutral-100: #f3f4f6;
+  --color-neutral-200: #e5e7eb;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-400: #9ca3af;
+  --color-neutral-450: #8e96a4;
+  --color-neutral-500: #6b7280;
+  --color-neutral-600: #4b5563;
+  --color-neutral-700: #374151;
+  --color-neutral-800: #1f2937;
+  --color-neutral-900: #111827;
+  --color-neutral-950: #030712;
+
+  /* Red (10) */
+  --color-red-50: #fef2f2;
+  --color-red-100: #fee2e2;
+  --color-red-200: #fecaca;
+  --color-red-300: #fca5a5;
+  --color-red-400: #f87171;
+  --color-red-500: #ef4444;
+  --color-red-600: #dc2626;
+  --color-red-700: #b91c1c;
+  --color-red-800: #991b1b;
+  --color-red-900: #7f1d1d;
+
+  /* Green (10) */
+  --color-green-50: #f0fdf4;
+  --color-green-100: #dcfce7;
+  --color-green-200: #bbf7d0;
+  --color-green-300: #86efac;
+  --color-green-400: #4ade80;
+  --color-green-500: #22c55e;
+  --color-green-600: #16a34a;
+  --color-green-700: #15803d;
+  --color-green-800: #166534;
+  --color-green-900: #14532d;
+
+  /* Blue (10) */
+  --color-blue-50: #eff6ff;
+  --color-blue-100: #dbeafe;
+  --color-blue-200: #bfdbfe;
+  --color-blue-300: #93c5fd;
+  --color-blue-400: #60a5fa;
+  --color-blue-500: #3b82f6;
+  --color-blue-600: #2563eb;
+  --color-blue-700: #1d4ed8;
+  --color-blue-800: #1e40af;
+  --color-blue-900: #1e3a8a;
+
+  /* Amber (10) */
+  --color-amber-50: #fffbeb;
+  --color-amber-100: #fef3c7;
+  --color-amber-200: #fde68a;
+  --color-amber-300: #fcd34d;
+  --color-amber-400: #fbbf24;
+  --color-amber-500: #f59e0b;
+  --color-amber-600: #d97706;
+  --color-amber-700: #b45309;
+  --color-amber-800: #92400e;
+  --color-amber-900: #78350f;
+
+  /* Cyan (10) */
+  --color-cyan-50: #ecfeff;
+  --color-cyan-100: #cffafe;
+  --color-cyan-200: #a5f3fc;
+  --color-cyan-300: #67e8f9;
+  --color-cyan-400: #22d3ee;
+  --color-cyan-500: #06b6d4;
+  --color-cyan-600: #0891b2;
+  --color-cyan-700: #0e7490;
+  --color-cyan-800: #155e75;
+  --color-cyan-900: #164e63;
+
+  /* Pink (10) */
+  --color-pink-50: #fdf2f8;
+  --color-pink-100: #fce7f3;
+  --color-pink-200: #fbcfe8;
+  --color-pink-300: #f9a8d4;
+  --color-pink-400: #f472b6;
+  --color-pink-500: #ec4899;
+  --color-pink-600: #db2777;
+  --color-pink-700: #be185d;
+  --color-pink-800: #9d174d;
+  --color-pink-900: #831843;
+
+  /* Purple (10) */
+  --color-purple-50: #f5f3ff;
+  --color-purple-100: #ede9fe;
+  --color-purple-200: #ddd6fe;
+  --color-purple-300: #c4b5fd;
+  --color-purple-400: #a78bfa;
+  --color-purple-500: #8b5cf6;
+  --color-purple-600: #7c3aed;
+  --color-purple-700: #6d28d9;
+  --color-purple-800: #5b21b6;
+  --color-purple-900: #4c1d95;
+
+  /* White */
+  --color-white: #ffffff;
+}
+
+/* ---------- Spacing / Text / Leading / Font Weight / Radius ---------- */
+@theme {
+  /* Spacing (7) */
+  --spacing-xxs: 4px;
+  --spacing-xs: 8px;
+  --spacing-sm: 12px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 40px;
+  --spacing-xxl: 64px;
+
+  /* Font Size (7) — namespace: --text-* → text-{name} */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 2rem;
+
+  /* Line Height (4) — namespace: --leading-* → leading-{name} */
+  --leading-tight: 1.25;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.75;
+  --leading-loose: 2;
+
+  /* Font Weight (3) */
+  --font-weight-regular: normal;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+
+  /* Border Radius (6) */
+  --radius-none: 0px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 9999px;
+}
+
+/* ---------- Semantic Tokens (Light) ---------- */
+@theme {
+  /* Background */
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f9fafb;
+  --color-bg-tertiary: #f3f4f6;
+  --color-bg-brand-subtle: #eefbfb;
+
+  /* Text */
+  --color-text-primary: #111827;
+  --color-text-secondary: #6b7280;
+  --color-text-tertiary: #9ca3af;
+  --color-text-disabled: #d1d5db;
+  --color-text-inverse: #ffffff;
+  --color-text-link: #007170;
+
+  /* Border */
+  --color-border-default: #e5e7eb;
+  --color-border-focus: #00a8a7;
+  --color-border-strong: #9ca3af;
+
+  /* Primary */
+  --color-primary-default: #008b8a;
+  --color-primary-hover: #007170;
+  --color-primary-active: #005857;
+
+  /* Status */
+  --color-error-bg: #fef2f2;
+  --color-error-text: #b91c1c;
+  --color-warning-bg: #fffbeb;
+  --color-warning-text: #b45309;
+  --color-success-bg: #f0fdf4;
+  --color-success-text: #15803d;
+  --color-info-bg: #eff6ff;
+  --color-info-text: #1d4ed8;
+}
+
+/* ---------- Semantic Tokens (Dark) ---------- */
+.dark {
+  /* Background */
+  --color-bg-primary: #030712;
+  --color-bg-secondary: #111827;
+  --color-bg-tertiary: #1f2937;
+  --color-bg-brand-subtle: #002625;
+
+  /* Text */
+  --color-text-primary: #f9fafb;
+  --color-text-secondary: #6b7280;
+  --color-text-tertiary: #9ca3af;
+  --color-text-disabled: #4b5563;
+  --color-text-inverse: #ffffff;
+  --color-text-link: #27c2c1;
+
+  /* Border */
+  --color-border-default: #374151;
+  --color-border-focus: #27c2c1;
+  --color-border-strong: #6b7280;
+
+  /* Primary */
+  --color-primary-default: #008b8a;
+  --color-primary-hover: #00a8a7;
+  --color-primary-active: #007170;
+
+  /* Status */
+  --color-error-bg: #2d1b1b;
+  --color-error-text: #f87171;
+  --color-warning-bg: #2d2a1b;
+  --color-warning-text: #fbbf24;
+  --color-success-bg: #1b2d1e;
+  --color-success-text: #4ade80;
+  --color-info-bg: #1b1f2d;
+  --color-info-text: #60a5fa;
+}
+
+/* ---------- Base Styles ---------- */
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,61 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
+export class HttpError extends Error {
+  status: number;
+  statusText: string;
+  details?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    status: number,
+    statusText: string,
+    details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    this.statusText = statusText;
+    this.details = details;
+  }
+}
+
+/**
+ * Clerk トークン付きで Hono API にリクエストを送信する
+ * getToken は useAuth().getToken から渡す
+ */
+export async function apiClient<T>(
+  path: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    getToken: () => Promise<string | null>;
+  }
+): Promise<T> {
+  const token = await options.getToken();
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: options.method || 'GET',
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  const data = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+
+  if (!response.ok) {
+    const errorMessage =
+      (data as { error?: unknown }).error ||
+      (data as { message?: unknown }).message ||
+      `HTTP ${response.status}: ${response.statusText}`;
+    throw new HttpError(String(errorMessage), response.status, response.statusText, data);
+  }
+
+  return data as T;
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -66,14 +66,3 @@ export const COMPLETED_PROGRESS_STATUSES: ProgressStatus[] = [
   'ST連絡済み',
   'SENJU登録',
 ];
-
-/**
- * ナビゲーション項目
- */
-export const NAV_ITEMS = [
-  { path: '/dashboard', label: 'ダッシュボード', icon: 'LayoutDashboard' },
-  { path: '/tasks', label: 'タスク', icon: 'ListTodo' },
-  { path: '/report', label: 'レポート', icon: 'BarChart3' },
-  { path: '/contact', label: 'お問い合わせ', icon: 'MessageSquare' },
-  { path: '/settings', label: '設定', icon: 'Settings' },
-] as const;

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,79 @@
+import type { FlowStatus, ProgressStatus } from '../types';
+
+/**
+ * 期限間近の閾値（日数）
+ * 運用後の調整を容易にするため定数化
+ */
+export const DUE_SOON_THRESHOLD_DAYS = 7;
+
+/**
+ * カードビューのFlowStatusカラム表示順序
+ */
+export const FLOW_STATUS_ORDER: FlowStatus[] = [
+  '未着手',
+  '待ち',
+  'ディレクション',
+  'デザイン',
+  'コーディング',
+];
+
+/**
+ * FlowStatusラベル（表示用）
+ */
+export const FLOW_STATUS_LABELS: Record<FlowStatus, string> = {
+  未着手: '未着手',
+  ディレクション: 'ディレクション',
+  コーディング: 'コーディング',
+  デザイン: 'デザイン',
+  待ち: '待ち',
+  対応中: '対応中',
+  週次報告: '週次報告',
+  月次報告: '月次報告',
+  完了: '完了',
+};
+
+/**
+ * 進捗バッジカラーマップ
+ * ProgressStatus → Tailwind color class
+ */
+export const PROGRESS_STATUS_COLOR_MAP: Record<ProgressStatus, string> = {
+  // 準備・計画段階（Purple 500→900）
+  未着手: 'bg-purple-500',
+  仕様確認: 'bg-purple-600',
+  待ち: 'bg-purple-700',
+  調査: 'bg-purple-800',
+  見積: 'bg-purple-900',
+  // 実作業段階（Pink 500→900）
+  CO: 'bg-pink-500',
+  ロック解除待ち: 'bg-pink-600',
+  デザイン: 'bg-pink-700',
+  コーディング: 'bg-pink-800',
+  品管チェック: 'bg-pink-900',
+  // 完了・連絡段階（Cyan 500→700）
+  IT連絡済み: 'bg-cyan-500',
+  ST連絡済み: 'bg-cyan-600',
+  SENJU登録: 'bg-cyan-700',
+  // 特殊
+  親課題: 'bg-neutral-600',
+};
+
+/**
+ * 完了・連絡段階の進捗ステータス
+ * この段階のタスクは期限ベースの背景色を適用しない
+ */
+export const COMPLETED_PROGRESS_STATUSES: ProgressStatus[] = [
+  'IT連絡済み',
+  'ST連絡済み',
+  'SENJU登録',
+];
+
+/**
+ * ナビゲーション項目
+ */
+export const NAV_ITEMS = [
+  { path: '/dashboard', label: 'ダッシュボード', icon: 'LayoutDashboard' },
+  { path: '/tasks', label: 'タスク', icon: 'ListTodo' },
+  { path: '/report', label: 'レポート', icon: 'BarChart3' },
+  { path: '/contact', label: 'お問い合わせ', icon: 'MessageSquare' },
+  { path: '/settings', label: '設定', icon: 'Settings' },
+] as const;

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -1,0 +1,325 @@
+import type { Task, User, Label, TaskSession } from '../types';
+
+// ダミーユーザー
+export const MOCK_USERS: User[] = [
+  {
+    id: 'user-1',
+    email: 'tanaka@example.com',
+    displayName: '田中太郎',
+    role: 'admin',
+    isAllowed: true,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  },
+  {
+    id: 'user-2',
+    email: 'sato@example.com',
+    displayName: '佐藤花子',
+    role: 'member',
+    isAllowed: true,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  },
+  {
+    id: 'user-3',
+    email: 'suzuki@example.com',
+    displayName: '鈴木一郎',
+    role: 'member',
+    isAllowed: true,
+    createdAt: new Date('2024-02-01'),
+    updatedAt: new Date('2024-02-01'),
+  },
+  {
+    id: 'user-4',
+    email: 'takahashi@example.com',
+    displayName: '高橋美咲',
+    role: 'member',
+    isAllowed: true,
+    createdAt: new Date('2024-03-01'),
+    updatedAt: new Date('2024-03-01'),
+  },
+  {
+    id: 'user-5',
+    email: 'ito@example.com',
+    displayName: '伊藤健太',
+    role: 'member',
+    isAllowed: true,
+    createdAt: new Date('2024-03-01'),
+    updatedAt: new Date('2024-03-01'),
+  },
+  {
+    id: 'user-6',
+    email: 'watanabe@example.com',
+    displayName: '渡辺雄大',
+    role: 'member',
+    isAllowed: true,
+    createdAt: new Date('2024-04-01'),
+    updatedAt: new Date('2024-04-01'),
+  },
+];
+
+// ダミー区分ラベル
+export const MOCK_LABELS: Label[] = [
+  {
+    id: 'label-kobetsu',
+    name: '個別',
+    color: '#6b7280',
+    projectId: null,
+    ownerId: 'user-1',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  },
+  {
+    id: 'label-unyo',
+    name: '運用',
+    color: '#6b7280',
+    projectId: null,
+    ownerId: 'user-1',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  },
+];
+
+// 現在ログイン中のユーザー（モック）
+export const MOCK_CURRENT_USER = MOCK_USERS[0]!;
+
+const today = new Date();
+const daysFromNow = (days: number) => {
+  const d = new Date(today);
+  d.setDate(d.getDate() + days);
+  return d;
+};
+
+// ダミータスク — 各FlowStatus × 各背景色パターン網羅
+export const MOCK_TASKS: Task[] = [
+  // ===== 期限超過（error）=====
+  {
+    id: 'task-1',
+    projectType: 'REG2017',
+    title: 'REG2017-2266【飯田】火災_SEO記事コンテンツ（リライト）',
+    flowStatus: 'ディレクション',
+    progressStatus: '待ち',
+    assigneeIds: ['user-1', 'user-2', 'user-3'],
+    itUpDate: daysFromNow(-3),
+    releaseDate: daysFromNow(-1),
+    kubunLabelId: 'label-unyo',
+    order: 1,
+    createdBy: 'user-1',
+    createdAt: new Date('2025-12-01'),
+    updatedAt: new Date('2026-01-15'),
+  },
+  {
+    id: 'task-2',
+    projectType: 'REG2017',
+    title: 'REG2017-2301【佐藤】火災_LP改修（A/Bテスト対応）',
+    flowStatus: 'コーディング',
+    progressStatus: 'コーディング',
+    assigneeIds: ['user-2'],
+    itUpDate: daysFromNow(-1),
+    releaseDate: daysFromNow(5),
+    kubunLabelId: 'label-kobetsu',
+    order: 2,
+    createdBy: 'user-2',
+    createdAt: new Date('2025-12-10'),
+    updatedAt: new Date('2026-01-20'),
+  },
+  // ===== 期限間近（warning）=====
+  {
+    id: 'task-3',
+    projectType: 'BRGREG',
+    title: 'BRGREG-450【田中】地震_見積書フォーム改修',
+    flowStatus: 'ディレクション',
+    progressStatus: '仕様確認',
+    assigneeIds: ['user-1', 'user-4'],
+    itUpDate: daysFromNow(3),
+    releaseDate: daysFromNow(7),
+    kubunLabelId: 'label-kobetsu',
+    order: 3,
+    createdBy: 'user-1',
+    createdAt: new Date('2025-12-15'),
+    updatedAt: new Date('2026-01-25'),
+  },
+  {
+    id: 'task-4',
+    projectType: 'MONO',
+    title: 'MONO-431 火災保険追いつきメール対応',
+    flowStatus: 'コーディング',
+    progressStatus: 'CO',
+    assigneeIds: ['user-1', 'user-3'],
+    itUpDate: daysFromNow(5),
+    releaseDate: daysFromNow(10),
+    kubunLabelId: 'label-unyo',
+    order: 4,
+    createdBy: 'user-3',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-02-01'),
+  },
+  // ===== 通常 =====
+  {
+    id: 'task-5',
+    projectType: 'REG2017',
+    title: 'REG2017-2290【鈴木】火災_マイページリニューアル',
+    flowStatus: '未着手',
+    progressStatus: '未着手',
+    assigneeIds: ['user-1'],
+    itUpDate: daysFromNow(20),
+    releaseDate: daysFromNow(25),
+    kubunLabelId: 'label-kobetsu',
+    order: 5,
+    createdBy: 'user-3',
+    createdAt: new Date('2026-01-10'),
+    updatedAt: new Date('2026-02-01'),
+  },
+  {
+    id: 'task-6',
+    projectType: 'BRGREG',
+    title: 'BRGREG-462【高橋】地震_デザインシステム更新',
+    flowStatus: 'デザイン',
+    progressStatus: 'デザイン',
+    assigneeIds: ['user-1', 'user-4', 'user-5'],
+    itUpDate: daysFromNow(14),
+    releaseDate: daysFromNow(21),
+    kubunLabelId: 'label-kobetsu',
+    order: 6,
+    createdBy: 'user-4',
+    createdAt: new Date('2026-01-20'),
+    updatedAt: new Date('2026-02-05'),
+  },
+  {
+    id: 'task-7',
+    projectType: 'MONO',
+    title: 'MONO-445 管理画面ダッシュボード改善',
+    flowStatus: '待ち',
+    progressStatus: '調査',
+    assigneeIds: ['user-1', 'user-2'],
+    itUpDate: null,
+    releaseDate: null,
+    kubunLabelId: 'label-unyo',
+    order: 7,
+    createdBy: 'user-1',
+    createdAt: new Date('2026-01-25'),
+    updatedAt: new Date('2026-02-10'),
+  },
+  // ===== 完了段階の進捗（背景色適用外）=====
+  {
+    id: 'task-8',
+    projectType: 'REG2017',
+    title: 'REG2017-2250【伊藤】火災_お問い合わせフォーム修正',
+    flowStatus: 'コーディング',
+    progressStatus: 'IT連絡済み',
+    assigneeIds: ['user-1', 'user-5'],
+    itUpDate: daysFromNow(-5), // 超過しているが進捗が完了段階なのでnormal
+    releaseDate: daysFromNow(2),
+    kubunLabelId: 'label-kobetsu',
+    order: 8,
+    createdBy: 'user-5',
+    createdAt: new Date('2025-11-15'),
+    updatedAt: new Date('2026-02-01'),
+  },
+  // ===== 完了タスク =====
+  {
+    id: 'task-9',
+    projectType: 'REG2017',
+    title: 'REG2017-2200【渡辺】火災_年末年始バナー対応',
+    flowStatus: '完了',
+    progressStatus: 'SENJU登録',
+    assigneeIds: ['user-1', 'user-6'],
+    itUpDate: daysFromNow(-10),
+    releaseDate: daysFromNow(-7),
+    kubunLabelId: 'label-unyo',
+    order: 9,
+    createdBy: 'user-6',
+    createdAt: new Date('2025-11-01'),
+    updatedAt: new Date('2026-01-05'),
+    completedAt: new Date('2026-01-05'),
+  },
+  // ===== 追加タスク（ディレクション・待ちバリエーション）=====
+  {
+    id: 'task-10',
+    projectType: 'DMREG2',
+    title: 'DMREG2-180【田中】ダイレクトメール配信基盤構築',
+    flowStatus: 'ディレクション',
+    progressStatus: '見積',
+    assigneeIds: ['user-1'],
+    itUpDate: daysFromNow(30),
+    releaseDate: null,
+    kubunLabelId: 'label-kobetsu',
+    order: 10,
+    createdBy: 'user-1',
+    createdAt: new Date('2026-02-01'),
+    updatedAt: new Date('2026-02-15'),
+  },
+  {
+    id: 'task-11',
+    projectType: 'PRREG',
+    title: 'PRREG-092【佐藤】PR_キャンペーンページ制作',
+    flowStatus: '待ち',
+    progressStatus: '待ち',
+    assigneeIds: ['user-1', 'user-2', 'user-4', 'user-5', 'user-6', 'user-3'],
+    itUpDate: daysFromNow(10),
+    releaseDate: daysFromNow(15),
+    kubunLabelId: 'label-unyo',
+    order: 11,
+    createdBy: 'user-2',
+    createdAt: new Date('2026-02-05'),
+    updatedAt: new Date('2026-02-20'),
+  },
+  {
+    id: 'task-12',
+    projectType: 'DES_FIRE',
+    title: 'DES_FIRE-033【鈴木】デザインシステムコンポーネント追加',
+    flowStatus: 'デザイン',
+    progressStatus: 'デザイン',
+    assigneeIds: ['user-1', 'user-3'],
+    itUpDate: daysFromNow(6),
+    releaseDate: daysFromNow(12),
+    kubunLabelId: 'label-kobetsu',
+    order: 12,
+    createdBy: 'user-3',
+    createdAt: new Date('2026-02-10'),
+    updatedAt: new Date('2026-02-25'),
+  },
+];
+
+// ダミーセッション
+export const MOCK_SESSIONS: TaskSession[] = [
+  {
+    id: 'session-1',
+    taskId: 'task-1',
+    userId: 'user-1',
+    startedAt: new Date('2026-02-13T14:00:00'),
+    endedAt: new Date('2026-02-13T14:39:53'),
+    durationSec: 2393,
+  },
+  {
+    id: 'session-2',
+    taskId: 'task-1',
+    userId: 'user-2',
+    startedAt: new Date('2026-02-12T10:00:00'),
+    endedAt: new Date('2026-02-12T11:25:00'),
+    durationSec: 5100,
+  },
+  {
+    id: 'session-3',
+    taskId: 'task-2',
+    userId: 'user-2',
+    startedAt: new Date('2026-02-11T09:30:00'),
+    endedAt: new Date('2026-02-11T11:40:00'),
+    durationSec: 7800,
+  },
+];
+
+/** ユーザーIDからユーザーを検索するヘルパー */
+export function getUserById(userId: string): User | undefined {
+  return MOCK_USERS.find((u) => u.id === userId);
+}
+
+/** ラベルIDからラベルを検索するヘルパー */
+export function getLabelById(labelId: string): Label | undefined {
+  return MOCK_LABELS.find((l) => l.id === labelId);
+}
+
+/** 現在のユーザーのタスク（マイタスク）を取得 */
+export function getMyTasks(): Task[] {
+  return MOCK_TASKS.filter((t) => t.assigneeIds.includes(MOCK_CURRENT_USER.id));
+}

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -319,6 +319,13 @@ export function getLabelById(labelId: string): Label | undefined {
   return MOCK_LABELS.find((l) => l.id === labelId);
 }
 
+/** アサイニーIDの配列からUserの配列を解決する */
+export function resolveAssignees(assigneeIds: string[]): User[] {
+  return assigneeIds
+    .map((id) => getUserById(id))
+    .filter((u): u is NonNullable<typeof u> => u != null);
+}
+
 /** 現在のユーザーのタスク（マイタスク）を取得 */
 export function getMyTasks(): Task[] {
   return MOCK_TASKS.filter((t) => t.assigneeIds.includes(MOCK_CURRENT_USER.id));

--- a/frontend/src/lib/taskUtils.ts
+++ b/frontend/src/lib/taskUtils.ts
@@ -1,0 +1,87 @@
+import type { Task } from '../types';
+import { COMPLETED_PROGRESS_STATUSES, DUE_SOON_THRESHOLD_DAYS } from './constants';
+
+export type TaskBgVariant = 'error' | 'warning' | 'normal';
+
+/**
+ * タスクの背景色バリアントを判定する
+ *
+ * 優先度順:
+ * 1. IT日 < 今日（期限超過） → error
+ * 2. IT日まで7日以内（期限間近） → warning
+ * 3. 上記以外 → normal
+ *
+ * 除外条件:
+ * - フローステータスが「完了」
+ * - 進捗が完了・連絡段階（IT連絡済み/ST連絡済み/SENJU登録）
+ * - IT日が未設定（null）
+ */
+export function getTaskBgVariant(task: Task): TaskBgVariant {
+  // 完了タスクは背景色なし
+  if (task.flowStatus === '完了') return 'normal';
+
+  // 完了・連絡段階の進捗は背景色なし
+  if (task.progressStatus && COMPLETED_PROGRESS_STATUSES.includes(task.progressStatus)) {
+    return 'normal';
+  }
+
+  // IT日未設定は通常
+  if (!task.itUpDate) return 'normal';
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const itDate = new Date(task.itUpDate);
+  itDate.setHours(0, 0, 0, 0);
+
+  // 期限超過
+  if (itDate < today) return 'error';
+
+  // 期限間近（7日以内、当日含む）
+  const thresholdDate = new Date(today);
+  thresholdDate.setDate(thresholdDate.getDate() + DUE_SOON_THRESHOLD_DAYS);
+  if (itDate <= thresholdDate) return 'warning';
+
+  return 'normal';
+}
+
+/**
+ * 背景色バリアントに対応するTailwindクラスを返す
+ */
+export function getTaskBgClass(variant: TaskBgVariant): string {
+  switch (variant) {
+    case 'error':
+      return 'bg-error-bg';
+    case 'warning':
+      return 'bg-warning-bg';
+    default:
+      return '';
+  }
+}
+
+/**
+ * 日付を yyyy-MM-dd 形式にフォーマットする
+ */
+export function formatDate(date: Date | null | undefined): string {
+  if (!date) return '-';
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 秒数を "Xh Ym Zs" 形式にフォーマットする
+ */
+export function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+
+  const parts: string[] = [];
+  if (h > 0) parts.push(`${h}時間`);
+  if (m > 0) parts.push(`${m}分`);
+  if (s > 0 || parts.length === 0) parts.push(`${s}秒`);
+  return parts.join('');
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,10 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Tailwindクラスをマージするユーティリティ
+ * clsx で条件付きクラスを結合し、tailwind-merge で重複を解決する
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,14 +6,14 @@ import './index.css';
 
 const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
-if (!CLERK_PUBLISHABLE_KEY) {
-  throw new Error('VITE_CLERK_PUBLISHABLE_KEY is not set');
-}
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    {CLERK_PUBLISHABLE_KEY ? (
+      <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+        <App />
+      </ClerkProvider>
+    ) : (
       <App />
-    </ClerkProvider>
+    )}
   </StrictMode>
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { ClerkProvider } from '@clerk/clerk-react';
+import { App } from './App';
+import './index.css';
+
+const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+if (!CLERK_PUBLISHABLE_KEY) {
+  throw new Error('VITE_CLERK_PUBLISHABLE_KEY is not set');
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+      <App />
+    </ClerkProvider>
+  </StrictMode>
+);

--- a/frontend/src/pages/dashboard/CardSectionHeader.tsx
+++ b/frontend/src/pages/dashboard/CardSectionHeader.tsx
@@ -1,0 +1,15 @@
+interface CardSectionHeaderProps {
+  label: string;
+  count: number;
+}
+
+export function CardSectionHeader({ label, count }: CardSectionHeaderProps) {
+  return (
+    <div className="flex items-center gap-2 pb-2">
+      <h3 className="text-sm font-bold text-text-primary">{label}</h3>
+      <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-bg-tertiary px-1.5 text-xs font-medium text-text-secondary">
+        {count}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import { Search, Bell } from 'lucide-react';
+import { Header } from '../../components/layout/Header';
+import { Input } from '../../components/ui/Input';
+import { IconButton } from '../../components/ui/IconButton';
+import { TaskDrawer } from '../../components/shared/TaskDrawer/TaskDrawer';
+import { StatsRow } from './StatsRow';
+import { TaskToolbar } from './TaskToolbar';
+import { TaskTableView } from './TaskTableView';
+import { TaskCardView } from './TaskCardView';
+import { useViewMode } from '../../hooks/useViewMode';
+import { useTaskDrawer } from '../../hooks/useTaskDrawer';
+import { useDashboardStats } from '../../hooks/useDashboardStats';
+import { getMyTasks } from '../../lib/mockData';
+import type { Task } from '../../types';
+
+export function DashboardPage() {
+  const myTasks = useMemo(() => getMyTasks(), []);
+  const activeTasks = useMemo(() => myTasks.filter((t) => t.flowStatus !== '完了'), [myTasks]);
+  const stats = useDashboardStats(myTasks);
+  const { viewMode, setViewMode } = useViewMode();
+  const { selectedTaskId, isOpen, openDrawer, closeDrawer } = useTaskDrawer();
+
+  const selectedTask = useMemo<Task | null>(
+    () => myTasks.find((t) => t.id === selectedTaskId) ?? null,
+    [myTasks, selectedTaskId]
+  );
+
+  const handleTaskClick = (task: Task) => {
+    openDrawer(task.id);
+  };
+
+  return (
+    <>
+      <Header title="ダッシュボード">
+        <Input placeholder="タスクを検索..." icon={<Search size={16} />} className="w-[220px]" />
+        <div className="relative">
+          <IconButton aria-label="通知" className="h-9 w-9 rounded-md border border-border-default">
+            <Bell size={18} />
+          </IconButton>
+          <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-blue-500" />
+        </div>
+      </Header>
+
+      <div className="flex-1 overflow-y-auto p-8 space-y-6">
+        <StatsRow
+          active={stats.active}
+          dueSoon={stats.dueSoon}
+          overdue={stats.overdue}
+          done={stats.done}
+        />
+
+        <TaskToolbar
+          taskCount={activeTasks.length}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+        />
+
+        {viewMode === 'table' ? (
+          <TaskTableView tasks={activeTasks} onTaskClick={handleTaskClick} />
+        ) : (
+          <TaskCardView tasks={activeTasks} onTaskClick={handleTaskClick} />
+        )}
+      </div>
+
+      <TaskDrawer task={selectedTask} isOpen={isOpen} onClose={closeDrawer} />
+    </>
+  );
+}

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -19,7 +19,7 @@ export function DashboardPage() {
   const activeTasks = useMemo(() => myTasks.filter((t) => t.flowStatus !== '完了'), [myTasks]);
   const stats = useDashboardStats(myTasks);
   const { viewMode, setViewMode } = useViewMode();
-  const { selectedTaskId, isOpen, openDrawer, closeDrawer } = useTaskDrawer();
+  const { selectedTaskId, openDrawer, closeDrawer } = useTaskDrawer();
 
   const selectedTask = useMemo<Task | null>(
     () => myTasks.find((t) => t.id === selectedTaskId) ?? null,
@@ -63,7 +63,7 @@ export function DashboardPage() {
         )}
       </div>
 
-      <TaskDrawer task={selectedTask} isOpen={isOpen} onClose={closeDrawer} />
+      <TaskDrawer task={selectedTask} onClose={closeDrawer} />
     </>
   );
 }

--- a/frontend/src/pages/dashboard/StatsCard.tsx
+++ b/frontend/src/pages/dashboard/StatsCard.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/utils';
+
+interface StatsCardProps {
+  label: string;
+  value: number;
+  icon: ReactNode;
+  variant?: 'default' | 'warning' | 'error' | 'success';
+}
+
+const iconBgStyles = {
+  default: 'text-info-text bg-info-bg',
+  warning: 'text-warning-text bg-warning-bg',
+  error: 'text-error-text bg-error-bg',
+  success: 'text-success-text bg-success-bg',
+} as const;
+
+export function StatsCard({ label, value, icon, variant = 'default' }: StatsCardProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border-default bg-bg-primary p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-text-secondary">{label}</span>
+        <div
+          className={cn(
+            'flex h-8 w-8 items-center justify-center rounded-md',
+            iconBgStyles[variant]
+          )}
+        >
+          {icon}
+        </div>
+      </div>
+      <p className="text-2xl font-bold leading-tight text-text-primary">{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/StatsRow.tsx
+++ b/frontend/src/pages/dashboard/StatsRow.tsx
@@ -1,0 +1,30 @@
+import { Activity, Clock, AlertTriangle, CheckCircle } from 'lucide-react';
+import { StatsCard } from './StatsCard';
+
+interface StatsRowProps {
+  active: number;
+  dueSoon: number;
+  overdue: number;
+  done: number;
+}
+
+export function StatsRow({ active, dueSoon, overdue, done }: StatsRowProps) {
+  return (
+    <div className="grid grid-cols-4 gap-4">
+      <StatsCard label="対応中" value={active} icon={<Activity size={20} />} variant="default" />
+      <StatsCard
+        label="期限1週間以内"
+        value={dueSoon}
+        icon={<Clock size={20} />}
+        variant="warning"
+      />
+      <StatsCard
+        label="期限超過"
+        value={overdue}
+        icon={<AlertTriangle size={20} />}
+        variant="error"
+      />
+      <StatsCard label="完了" value={done} icon={<CheckCircle size={20} />} variant="success" />
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TaskCard.tsx
+++ b/frontend/src/pages/dashboard/TaskCard.tsx
@@ -1,0 +1,73 @@
+import { Timer } from 'lucide-react';
+import type { Task } from '../../types';
+import { Badge } from '../../components/ui/Badge';
+import { AvatarGroup } from '../../components/ui/AvatarGroup';
+import { cn } from '../../lib/utils';
+import { getTaskBgVariant, getTaskBgClass, formatDate } from '../../lib/taskUtils';
+import { getUserById, getLabelById } from '../../lib/mockData';
+
+interface TaskCardProps {
+  task: Task;
+  onClick: (task: Task) => void;
+}
+
+export function TaskCard({ task, onClick }: TaskCardProps) {
+  const bgVariant = getTaskBgVariant(task);
+  const bgClass = getTaskBgClass(bgVariant);
+  const label = getLabelById(task.kubunLabelId);
+
+  const assignees = task.assigneeIds
+    .map((id) => getUserById(id))
+    .filter((u): u is NonNullable<typeof u> => u != null);
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-border-default p-3 cursor-pointer transition-colors hover:border-border-strong',
+        bgClass || 'bg-bg-primary'
+      )}
+      onClick={() => onClick(task)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(task);
+        }
+      }}
+    >
+      {/* タイトル（2行clamp） */}
+      <p className="text-sm font-medium text-text-primary line-clamp-2 mb-2">{task.title}</p>
+
+      {/* アサイン */}
+      {assignees.length > 0 && (
+        <div className="mb-2">
+          <AvatarGroup users={assignees} max={5} size="sm" />
+        </div>
+      )}
+
+      {/* IT/PR 2行 */}
+      <div className="mb-2 space-y-0">
+        <p className="text-xs text-text-secondary">
+          <span className="inline-block w-6 text-text-tertiary">IT</span>
+          {formatDate(task.itUpDate)}
+        </p>
+        <p className="text-xs text-text-tertiary">
+          <span className="inline-block w-6">PR</span>
+          {formatDate(task.releaseDate)}
+        </p>
+      </div>
+
+      {/* 進捗 + 区分 + タイマー */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {task.progressStatus && <Badge status={task.progressStatus} />}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-text-secondary">{label?.name ?? ''}</span>
+          <Timer size={14} className="text-text-disabled" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TaskCard.tsx
+++ b/frontend/src/pages/dashboard/TaskCard.tsx
@@ -4,7 +4,7 @@ import { Badge } from '../../components/ui/Badge';
 import { AvatarGroup } from '../../components/ui/AvatarGroup';
 import { cn } from '../../lib/utils';
 import { getTaskBgVariant, getTaskBgClass, formatDate } from '../../lib/taskUtils';
-import { getUserById, getLabelById } from '../../lib/mockData';
+import { resolveAssignees, getLabelById } from '../../lib/mockData';
 
 interface TaskCardProps {
   task: Task;
@@ -16,9 +16,7 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
   const bgClass = getTaskBgClass(bgVariant);
   const label = getLabelById(task.kubunLabelId);
 
-  const assignees = task.assigneeIds
-    .map((id) => getUserById(id))
-    .filter((u): u is NonNullable<typeof u> => u != null);
+  const assignees = resolveAssignees(task.assigneeIds);
 
   return (
     <div

--- a/frontend/src/pages/dashboard/TaskCardView.tsx
+++ b/frontend/src/pages/dashboard/TaskCardView.tsx
@@ -24,13 +24,6 @@ export function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) {
       if (existing) {
         existing.push(task);
       }
-      // 完了カラムは完了タスクがある場合のみ追加
-    }
-
-    // 完了タスクがある場合にカラムを追加
-    const completedTasks = tasks.filter((t) => t.flowStatus === '完了');
-    if (completedTasks.length > 0) {
-      grouped.set('完了', completedTasks);
     }
 
     return grouped;

--- a/frontend/src/pages/dashboard/TaskCardView.tsx
+++ b/frontend/src/pages/dashboard/TaskCardView.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import type { Task, FlowStatus } from '../../types';
+import { FLOW_STATUS_ORDER, FLOW_STATUS_LABELS } from '../../lib/constants';
+import { CardSectionHeader } from './CardSectionHeader';
+import { TaskCard } from './TaskCard';
+
+interface TaskCardViewProps {
+  tasks: Task[];
+  onTaskClick: (task: Task) => void;
+}
+
+export function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) {
+  const columns = useMemo(() => {
+    const grouped = new Map<FlowStatus, Task[]>();
+
+    // 初期化（全カラム表示）
+    for (const status of FLOW_STATUS_ORDER) {
+      grouped.set(status, []);
+    }
+
+    // タスクを振り分け
+    for (const task of tasks) {
+      const existing = grouped.get(task.flowStatus);
+      if (existing) {
+        existing.push(task);
+      }
+      // 完了カラムは完了タスクがある場合のみ追加
+    }
+
+    // 完了タスクがある場合にカラムを追加
+    const completedTasks = tasks.filter((t) => t.flowStatus === '完了');
+    if (completedTasks.length > 0) {
+      grouped.set('完了', completedTasks);
+    }
+
+    return grouped;
+  }, [tasks]);
+
+  return (
+    <div className="flex gap-4 overflow-x-auto pb-2">
+      {Array.from(columns.entries()).map(([status, statusTasks]) => (
+        <div key={status} className="flex-1 min-w-[200px]">
+          <CardSectionHeader label={FLOW_STATUS_LABELS[status]} count={statusTasks.length} />
+          <div className="space-y-2">
+            {statusTasks.map((task) => (
+              <TaskCard key={task.id} task={task} onClick={onTaskClick} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TaskTableHeader.tsx
+++ b/frontend/src/pages/dashboard/TaskTableHeader.tsx
@@ -1,0 +1,22 @@
+import { Clock } from 'lucide-react';
+
+export function TaskTableHeader() {
+  return (
+    <div className="flex items-center gap-2 border-b border-border-default bg-teal-50 px-4 py-2.5 text-sm font-medium text-teal-600 dark:bg-teal-950 dark:text-teal-400">
+      <div className="w-7 shrink-0" />
+      <div className="flex-1 min-w-0 text-center">タイトル</div>
+      <div className="w-[100px] shrink-0 text-center">アサイン</div>
+      <div className="w-[96px] shrink-0 text-center leading-tight">
+        ITアップ/
+        <br />
+        リリース
+      </div>
+      <div className="w-[110px] shrink-0 text-center">担当</div>
+      <div className="w-[100px] shrink-0 text-center">進捗</div>
+      <div className="w-[40px] shrink-0 text-center">区分</div>
+      <div className="w-[48px] shrink-0 flex items-center justify-center">
+        <Clock size={20} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TaskTableRow.tsx
+++ b/frontend/src/pages/dashboard/TaskTableRow.tsx
@@ -1,0 +1,84 @@
+import { Pin, PlayCircle } from 'lucide-react';
+import type { Task } from '../../types';
+import { Badge } from '../../components/ui/Badge';
+import { AvatarGroup } from '../../components/ui/AvatarGroup';
+import { cn } from '../../lib/utils';
+import { getTaskBgVariant, getTaskBgClass, formatDate } from '../../lib/taskUtils';
+import { FLOW_STATUS_LABELS } from '../../lib/constants';
+import { getUserById, getLabelById } from '../../lib/mockData';
+
+interface TaskTableRowProps {
+  task: Task;
+  onClick: (task: Task) => void;
+}
+
+export function TaskTableRow({ task, onClick }: TaskTableRowProps) {
+  const bgVariant = getTaskBgVariant(task);
+  const bgClass = getTaskBgClass(bgVariant);
+  const label = getLabelById(task.kubunLabelId);
+
+  const assignees = task.assigneeIds
+    .map((id) => getUserById(id))
+    .filter((u): u is NonNullable<typeof u> => u != null);
+
+  return (
+    <div
+      className={cn(
+        'flex h-[52px] items-center gap-2 border-b border-border-default px-4 cursor-pointer transition-colors hover:bg-bg-secondary',
+        bgClass,
+        bgVariant === 'error' && 'border-l-[3px] border-l-error-text',
+        bgVariant === 'warning' && 'border-l-[3px] border-l-warning-text'
+      )}
+      onClick={() => onClick(task)}
+      role="row"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(task);
+        }
+      }}
+    >
+      {/* ピン */}
+      <div className="w-7 shrink-0 flex items-center justify-center">
+        <Pin size={16} className="text-neutral-300" />
+      </div>
+
+      {/* タイトル */}
+      <div className="flex-1 min-w-0 overflow-hidden">
+        <p className="truncate text-sm font-bold text-text-primary">{task.title}</p>
+      </div>
+
+      {/* アサイン */}
+      <div className="w-[100px] shrink-0">
+        <AvatarGroup users={assignees} max={5} size="sm" />
+      </div>
+
+      {/* ITアップ/リリース */}
+      <div className="w-[96px] shrink-0 flex flex-col gap-0.5">
+        <p className="text-sm text-text-secondary">{formatDate(task.itUpDate)}</p>
+        <p className="text-sm text-text-tertiary">{formatDate(task.releaseDate)}</p>
+      </div>
+
+      {/* 担当（FlowStatus） */}
+      <div className="w-[110px] shrink-0">
+        <span className="text-sm text-text-secondary">{FLOW_STATUS_LABELS[task.flowStatus]}</span>
+      </div>
+
+      {/* 進捗 */}
+      <div className="w-[100px] shrink-0">
+        {task.progressStatus && <Badge status={task.progressStatus} />}
+      </div>
+
+      {/* 区分 */}
+      <div className="w-[40px] shrink-0">
+        <span className="text-sm text-text-secondary">{label?.name ?? ''}</span>
+      </div>
+
+      {/* タイマー */}
+      <div className="w-[48px] shrink-0 flex items-center justify-center">
+        <PlayCircle size={20} className="text-neutral-400" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TaskTableRow.tsx
+++ b/frontend/src/pages/dashboard/TaskTableRow.tsx
@@ -5,7 +5,7 @@ import { AvatarGroup } from '../../components/ui/AvatarGroup';
 import { cn } from '../../lib/utils';
 import { getTaskBgVariant, getTaskBgClass, formatDate } from '../../lib/taskUtils';
 import { FLOW_STATUS_LABELS } from '../../lib/constants';
-import { getUserById, getLabelById } from '../../lib/mockData';
+import { resolveAssignees, getLabelById } from '../../lib/mockData';
 
 interface TaskTableRowProps {
   task: Task;
@@ -17,9 +17,7 @@ export function TaskTableRow({ task, onClick }: TaskTableRowProps) {
   const bgClass = getTaskBgClass(bgVariant);
   const label = getLabelById(task.kubunLabelId);
 
-  const assignees = task.assigneeIds
-    .map((id) => getUserById(id))
-    .filter((u): u is NonNullable<typeof u> => u != null);
+  const assignees = resolveAssignees(task.assigneeIds);
 
   return (
     <div

--- a/frontend/src/pages/dashboard/TaskTableView.tsx
+++ b/frontend/src/pages/dashboard/TaskTableView.tsx
@@ -1,0 +1,24 @@
+import type { Task } from '../../types';
+import { TaskTableHeader } from './TaskTableHeader';
+import { TaskTableRow } from './TaskTableRow';
+
+interface TaskTableViewProps {
+  tasks: Task[];
+  onTaskClick: (task: Task) => void;
+}
+
+export function TaskTableView({ tasks, onTaskClick }: TaskTableViewProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border-default" role="table">
+      <TaskTableHeader />
+      <div role="rowgroup">
+        {tasks.map((task) => (
+          <TaskTableRow key={task.id} task={task} onClick={onTaskClick} />
+        ))}
+        {tasks.length === 0 && (
+          <div className="px-4 py-8 text-center text-sm text-text-tertiary">タスクがありません</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TaskToolbar.tsx
+++ b/frontend/src/pages/dashboard/TaskToolbar.tsx
@@ -1,0 +1,45 @@
+import { LayoutList, LayoutGrid, Filter } from 'lucide-react';
+import { ToggleGroup } from '../../components/ui/ToggleGroup';
+import { Button } from '../../components/ui/Button';
+import type { ViewMode } from '../../hooks/useViewMode';
+
+interface TaskToolbarProps {
+  taskCount: number;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+}
+
+export function TaskToolbar({ taskCount, viewMode, onViewModeChange }: TaskToolbarProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-bold text-text-primary">マイタスク</h2>
+        <span className="inline-flex items-center justify-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-bold text-primary-default">
+          {taskCount}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <ToggleGroup
+          items={[
+            {
+              value: 'table',
+              label: 'テーブルビュー',
+              icon: <LayoutList size={16} />,
+            },
+            {
+              value: 'card',
+              label: 'カードビュー',
+              icon: <LayoutGrid size={16} />,
+            },
+          ]}
+          value={viewMode}
+          onChange={(v) => onViewModeChange(v as ViewMode)}
+        />
+        <Button variant="outline" size="sm" className="text-text-secondary text-xs">
+          <Filter size={16} />
+          フィルター
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,187 @@
+/**
+ * プロジェクトタイプの固定値
+ */
+export const PROJECT_TYPES = [
+  'REG2017',
+  'BRGREG',
+  'MONO',
+  'MONO_ADMIN',
+  'DES_FIRE',
+  'DesignSystem',
+  'DMREG2',
+  'monosus',
+  'PRREG',
+] as const;
+
+export type ProjectType = (typeof PROJECT_TYPES)[number];
+
+export type UserRole = 'admin' | 'member';
+
+export type FlowStatus =
+  | '未着手'
+  | 'ディレクション'
+  | 'コーディング'
+  | 'デザイン'
+  | '待ち'
+  | '対応中'
+  | '週次報告'
+  | '月次報告'
+  | '完了';
+
+export type ProgressStatus =
+  | '未着手'
+  | '仕様確認'
+  | '待ち'
+  | '調査'
+  | '見積'
+  | 'CO'
+  | 'ロック解除待ち'
+  | 'デザイン'
+  | 'コーディング'
+  | '品管チェック'
+  | 'IT連絡済み'
+  | 'ST連絡済み'
+  | 'SENJU登録'
+  | '親課題';
+
+export type Priority = 'low' | 'medium' | 'high' | 'urgent';
+
+export interface User {
+  id: string;
+  email: string;
+  displayName: string;
+  role: UserRole;
+  isAllowed: boolean;
+  githubUsername?: string;
+  googleOAuthUpdatedAt?: Date;
+  chatId?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  ownerId: string;
+  memberIds: string[];
+  backlogProjectKey?: string;
+  driveParentId?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Label {
+  id: string;
+  name: string;
+  color: string;
+  projectId: string | null;
+  ownerId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface TaskExternal {
+  source: 'backlog';
+  issueId: string;
+  issueKey: string;
+  url: string;
+  lastSyncedAt: Date;
+  syncStatus: 'ok' | 'failed';
+}
+
+export interface Task {
+  id: string;
+  projectType: ProjectType;
+  external?: TaskExternal;
+  title: string;
+  description?: string;
+  flowStatus: FlowStatus;
+  progressStatus?: ProgressStatus | null;
+  assigneeIds: string[];
+  itUpDate: Date | null;
+  releaseDate: Date | null;
+  kubunLabelId: string;
+  googleDriveUrl?: string | null;
+  fireIssueUrl?: string | null;
+  googleChatThreadUrl?: string | null;
+  backlogUrl?: string | null;
+  dueDate?: Date | null;
+  priority?: Priority | null;
+  order: number;
+  over3Reason?: string;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+  completedAt?: Date | null;
+}
+
+export interface TaskSession {
+  id: string;
+  taskId: string;
+  userId: string;
+  startedAt: Date;
+  endedAt: Date | null;
+  durationSec: number;
+  note?: string;
+}
+
+export interface ActiveSession {
+  projectType: ProjectType;
+  taskId: string;
+  sessionId: string;
+}
+
+export interface TaskActivity {
+  id: string;
+  taskId: string;
+  type: 'sync' | 'timerStart' | 'timerStop' | 'update' | 'driveCreate' | 'fireCreate';
+  actorId: string;
+  payload?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export type ContactType = 'error' | 'feature' | 'other';
+export type DeviceType = 'PC' | 'SP';
+export type PCOSType = 'Mac' | 'Windows' | 'Linux' | 'other';
+export type SPOSType = 'iOS' | 'Android' | 'other';
+export type BrowserType = 'Chrome' | 'Firefox' | 'Safari' | 'Arc' | 'Comet' | 'Dia' | 'other';
+export type SmartphoneType = 'iPhone' | 'Android' | 'other';
+
+export interface ErrorReportDetails {
+  issue: string;
+  reproductionSteps: string;
+  environment: {
+    device: DeviceType;
+    os: PCOSType | SPOSType | SmartphoneType;
+    browser: BrowserType;
+    osVersion?: string;
+    browserVersion: string;
+  };
+  screenshotUrl?: string;
+}
+
+export interface Contact {
+  id: string;
+  type: ContactType;
+  title: string;
+  content: string;
+  userId: string;
+  userName: string;
+  userEmail: string;
+  errorReportDetails?: ErrorReportDetails;
+  githubIssueUrl?: string;
+  status: 'pending' | 'resolved';
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface TaskComment {
+  id: string;
+  taskId: string;
+  authorId: string;
+  content: string;
+  mentionedUserIds?: string[];
+  readBy: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    /* Path alias */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "vite-env.d.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8787',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "neon-postgres": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "391693eee67001639ab65474df185da3ea5cf9ee4b99badecfd64561113edbb4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Vite + React 19 + Tailwind CSS v4 + React Aria Components でフロントエンド基盤を構築
- ダッシュボードページをモックデータで完全実装（テーブルビュー/カードビュー切替、統計カード、タスク詳細ドロワー）
- デザインシステム（カラートークン、タイポグラフィ、スペーシング）をCSS変数 + `@theme` で定義、ダークモード対応

## 主な変更

### フロントエンド基盤 (`frontend/`)
- **ビルド**: Vite 6 + React 19 + TypeScript strict mode
- **スタイリング**: Tailwind CSS v4 (`@theme` トークン + `@custom-variant dark`)
- **UIコンポーネント**: Button, Badge, Avatar, AvatarGroup, Input, Tabs, ToggleGroup, Spinner, IconButton
- **レイアウト**: Sidebar (w-60固定) + Header (h-16) + AppLayout (flex)
- **ルーティング**: React Router v7 + Clerk認証（開発時はキーなしでバイパス）

### ダッシュボードページ
- **統計カード**: 対応中 / 期限1週間以内 / 期限超過 / 完了 の4カード
- **テーブルビュー**: 8列（ピン/タイトル/アサイン/IT・リリース/担当/進捗/区分/タイマー）+ 背景色ルール（error/warning）
- **カードビュー**: FlowStatusカラム分けグリッド
- **ビュー切替**: localStorage永続化
- **タスク詳細ドロワー**: スライドイン/アウト + タブ切替（詳細/コメント）+ URL同期 (`?task=xxx`)

### デザイン関連
- Pencilデザインファイル (`designs/design.pen`) — 変数91個、Light/Dark全画面
- design-reviewスキル（Pencil+Playwright比較ワークフロー）

### ESLint設定
- `frontend/src/**` 用の `no-undef: off` + TypeScript parser設定を追加

## Test plan
- [ ] `cd frontend && npm run dev` でダッシュボードが表示される
- [ ] テーブル/カードビュー切替が動作する
- [ ] タスクをクリックするとドロワーがスライドインする
- [ ] ESC/オーバーレイクリックでドロワーが閉じる
- [ ] URLに `?task=xxx` が反映・復元される
- [ ] ダークモード切替が動作する
- [ ] `npm run build` がエラーなく完了する

🤖 Generated with [Claude Code](https://claude.ai/code)