### PR TITLE
✨ feat(frontend): ユーザー・ラベル取得フック追加

### DIFF
--- a/frontend/src/hooks/useCurrentUser.ts
+++ b/frontend/src/hooks/useCurrentUser.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+import type { User } from '../types';
+
+interface CurrentUserResponse {
+  user: User;
+}
+
+/**
+ * 現在ログイン中のユーザー情報を取得
+ * GET /api/users/me
+ */
+export function useCurrentUser() {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.currentUser(),
+    queryFn: () =>
+      apiClient<CurrentUserResponse>('/api/users/me', { getToken }).then((res) => res.user),
+    enabled: isSignedIn,
+    staleTime: 1000 * 60 * 5, // 5分
+  });
+}

--- a/frontend/src/hooks/useLabels.ts
+++ b/frontend/src/hooks/useLabels.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+import type { Label } from '../types';
+
+interface LabelsResponse {
+  labels: Label[];
+}
+
+/**
+ * 区分ラベル一覧を取得
+ * GET /api/labels
+ */
+export function useLabels() {
+  const { getToken, isSignedIn } = useAuth();
+
+  const query = useQuery({
+    queryKey: queryKeys.labels(),
+    queryFn: () => apiClient<LabelsResponse>('/api/labels', { getToken }).then((res) => res.labels),
+    enabled: isSignedIn,
+    staleTime: 1000 * 60 * 10, // 10分（ラベルは変更頻度が低い）
+  });
+
+  const labelMap = useMemo(() => {
+    const map = new Map<string, Label>();
+    if (query.data) {
+      for (const label of query.data) {
+        map.set(label.id, label);
+      }
+    }
+    return map;
+  }, [query.data]);
+
+  const getLabelById = (labelId: string): Label | undefined => labelMap.get(labelId);
+
+  const getLabelName = (labelId: string): string => labelMap.get(labelId)?.name ?? labelId;
+
+  return { ...query, labelMap, getLabelById, getLabelName };
+}

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+import type { User } from '../types';
+
+interface UsersResponse {
+  users: User[];
+}
+
+/**
+ * ユーザー一覧を取得
+ * GET /api/users
+ */
+export function useUsers() {
+  const { getToken, isSignedIn } = useAuth();
+
+  const query = useQuery({
+    queryKey: queryKeys.users(),
+    queryFn: () => apiClient<UsersResponse>('/api/users', { getToken }).then((res) => res.users),
+    enabled: isSignedIn,
+    staleTime: 1000 * 60 * 5, // 5分
+  });
+
+  const userMap = useMemo(() => {
+    const map = new Map<string, User>();
+    if (query.data) {
+      for (const user of query.data) {
+        map.set(user.id, user);
+      }
+    }
+    return map;
+  }, [query.data]);
+
+  const getUserById = (userId: string): User | undefined => userMap.get(userId);
+
+  const getUserName = (userId: string): string => userMap.get(userId)?.displayName ?? userId;
+
+  return { ...query, userMap, getUserById, getUserName };
+}


### PR DESCRIPTION
## Summary
- `useCurrentUser`: `GET /api/users/me` で現在ユーザー情報を TanStack Query で取得
- `useUsers`: `GET /api/users` でユーザー一覧取得 + `getUserById` / `getUserName` ヘルパー付き
- `useLabels`: `GET /api/labels` でラベル一覧取得 + `getLabelById` / `getLabelName` ヘルパー付き
- 全フック共通: `useAuth().getToken` で Clerk Bearer 認証、`enabled: isSignedIn` で未認証時はフェッチ無効化

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `frontend/src/hooks/useCurrentUser.ts` | 現在ユーザー取得（staleTime: 5分） |
| `frontend/src/hooks/useUsers.ts` | ユーザー一覧 + Map ベースの検索ヘルパー |
| `frontend/src/hooks/useLabels.ts` | ラベル一覧 + Map ベースの検索ヘルパー |

## Test plan
- [ ] ログイン後に `useCurrentUser` が `/api/users/me` を呼んでユーザー情報を返す
- [ ] `useUsers` がユーザー一覧を返し、`getUserName(id)` で名前解決できる
- [ ] `useLabels` がラベル一覧を返し、`getLabelName(id)` で名前解決できる
- [ ] 未認証時にはAPIコールが発生しない（`enabled: isSignedIn`）
- [ ] `cd frontend && bun run type-check` が通る

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 認証済みユーザーの情報を取得できるようになりました
  * ラベル一覧の取得とラベル検索機能を追加しました
  * ユーザー一覧の取得とユーザー検索機能を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->