### PR TITLE
✨ feat: タスク一覧をAPI接続に移行

### DIFF
--- a/backend/src/routes/tasks.test.ts
+++ b/backend/src/routes/tasks.test.ts
@@ -84,9 +84,11 @@ describe('Tasks API', () => {
       expect(body.tasks.every((t: { projectType: string }) => t.projectType === 'MONO')).toBe(true);
     });
 
-    it('projectType未指定だと400', async () => {
+    it('projectType未指定でも全タスクを返す', async () => {
       const res = await app.request('/api/tasks');
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.tasks).toBeDefined();
     });
   });
 

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -96,25 +96,37 @@ const updateOrderSchema = z.object({
 
 /**
  * GET /
- * プロジェクトタイプ別タスク一覧（ページネーション）
+ * タスク一覧（ページネーション）
+ * projectType 指定時はフィルタ、未指定時は全タスク
+ * excludeCompleted=true で完了タスクを除外
  */
 app.get('/', async (c) => {
   const db = c.get('db');
   const projectType = c.req.query('projectType');
+  const excludeCompleted = c.req.query('excludeCompleted') === 'true';
   const limitValue = parseInt(c.req.query('limit') ?? '50', 10);
   const offset = parseInt(c.req.query('offset') ?? '0', 10);
 
-  if (!projectType) {
-    return c.json({ error: 'projectType is required' }, 400);
+  const conditions = [];
+
+  if (projectType) {
+    conditions.push(
+      eq(tasks.projectType, projectType as (typeof tasks.projectType.enumValues)[number])
+    );
   }
 
-  const result = await db
+  if (excludeCompleted) {
+    conditions.push(ne(tasks.flowStatus, '完了'));
+  }
+
+  const query = db
     .select()
     .from(tasks)
-    .where(eq(tasks.projectType, projectType as (typeof tasks.projectType.enumValues)[number]))
     .orderBy(desc(tasks.createdAt))
     .limit(limitValue)
     .offset(offset);
+
+  const result = conditions.length > 0 ? await query.where(and(...conditions)) : await query;
 
   return c.json({ tasks: result, hasMore: result.length === limitValue });
 });

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+import type { Task } from '../types';
+
+interface TasksResponse {
+  tasks: Task[];
+  hasMore: boolean;
+}
+
+interface AssignedTasksResponse {
+  tasks: Task[];
+}
+
+interface UseTasksOptions {
+  projectType?: string;
+  excludeCompleted?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * タスク一覧を取得
+ * GET /api/tasks?projectType=xxx&excludeCompleted=true&limit=50&offset=0
+ */
+export function useTasks(options: UseTasksOptions = {}) {
+  const { getToken, isSignedIn } = useAuth();
+  const { projectType, excludeCompleted = true, limit = 50, offset = 0 } = options;
+
+  const params = new URLSearchParams();
+  if (projectType) params.set('projectType', projectType);
+  if (excludeCompleted) params.set('excludeCompleted', 'true');
+  params.set('limit', String(limit));
+  params.set('offset', String(offset));
+
+  const queryString = params.toString();
+
+  return useQuery({
+    queryKey: [...queryKeys.tasks(projectType), { excludeCompleted, limit, offset }],
+    queryFn: () => apiClient<TasksResponse>(`/api/tasks?${queryString}`, { getToken }),
+    enabled: isSignedIn,
+  });
+}
+
+/**
+ * 自分にアサインされた未完了タスクを取得（ダッシュボード用）
+ * GET /api/tasks/assigned
+ */
+export function useAssignedTasks() {
+  const { getToken, isSignedIn, userId } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.assignedTasks(userId ?? undefined),
+    queryFn: () =>
+      apiClient<AssignedTasksResponse>('/api/tasks/assigned', { getToken }).then(
+        (res) => res.tasks
+      ),
+    enabled: isSignedIn,
+  });
+}

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -5,15 +5,16 @@ import { StatsRow } from './components/StatsRow';
 import { TaskToolbar } from './components/TaskToolbar';
 import { TaskTableView } from '../tasks/components/TaskTableView';
 import { TaskCardView } from '../tasks/components/TaskCardView';
+import { Spinner } from '../../components/ui/Spinner';
 import { useViewMode } from '../../hooks/useViewMode';
 import { useTaskDrawer } from '../../hooks/useTaskDrawer';
 import { useDashboardStats } from '../../hooks/useDashboardStats';
-import { getMyTasks } from '../../lib/mockData';
+import { useAssignedTasks } from '../../hooks/useTasks';
 import { FLOW_STATUS_COMPLETED } from '../../lib/constants';
 import type { Task } from '../../types';
 
 export function DashboardPage() {
-  const myTasks = useMemo(() => getMyTasks(), []);
+  const { data: myTasks = [], isLoading, error } = useAssignedTasks();
   const activeTasks = useMemo(
     () => myTasks.filter((t) => t.flowStatus !== FLOW_STATUS_COMPLETED),
     [myTasks]
@@ -43,16 +44,28 @@ export function DashboardPage() {
           done={stats.done}
         />
 
-        <TaskToolbar
-          taskCount={activeTasks.length}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
-        />
-
-        {viewMode === 'table' ? (
-          <TaskTableView tasks={activeTasks} onTaskClick={handleTaskClick} />
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-error-border bg-error-bg p-4 text-sm text-error-text">
+            タスクの取得に失敗しました: {error.message}
+          </div>
         ) : (
-          <TaskCardView tasks={activeTasks} onTaskClick={handleTaskClick} />
+          <>
+            <TaskToolbar
+              taskCount={activeTasks.length}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+            />
+
+            {viewMode === 'table' ? (
+              <TaskTableView tasks={activeTasks} onTaskClick={handleTaskClick} />
+            ) : (
+              <TaskCardView tasks={activeTasks} onTaskClick={handleTaskClick} />
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/pages/tasks/MemberTaskListPage.tsx
+++ b/frontend/src/pages/tasks/MemberTaskListPage.tsx
@@ -5,29 +5,37 @@ import { MemberTaskToolbar } from './components/MemberTaskToolbar';
 import { TaskFilterPanel } from './components/TaskFilterPanel';
 import { MemberSection } from './components/MemberSection';
 import { MemberCardSection } from './components/MemberCardSection';
+import { Spinner } from '../../components/ui/Spinner';
 import { useViewMode } from '../../hooks/useViewMode';
 import { useTaskDrawer } from '../../hooks/useTaskDrawer';
-import { getAllTasks, MOCK_USERS } from '../../lib/mockData';
-import { FLOW_STATUS_COMPLETED } from '../../lib/constants';
+import { useTasks } from '../../hooks/useTasks';
+import { useUsers } from '../../hooks/useUsers';
 import type { Task, User } from '../../types';
 
-const allTasks = getAllTasks();
-const activeTasks = allTasks.filter((t) => t.flowStatus !== FLOW_STATUS_COMPLETED);
-
 export function MemberTaskListPage() {
+  const {
+    data,
+    isLoading: tasksLoading,
+    error: tasksError,
+  } = useTasks({ excludeCompleted: true, limit: 500 });
+  const { data: users = [], isLoading: usersLoading } = useUsers();
+
+  const tasks = useMemo(() => data?.tasks ?? [], [data?.tasks]);
+  const isLoading = tasksLoading || usersLoading;
+
   const { viewMode, setViewMode } = useViewMode('members');
   const { selectedTaskId, openDrawer, closeDrawer } = useTaskDrawer();
 
   const selectedTask = useMemo<Task | null>(
-    () => allTasks.find((t) => t.id === selectedTaskId) ?? null,
-    [allTasks, selectedTaskId]
+    () => tasks.find((t) => t.id === selectedTaskId) ?? null,
+    [tasks, selectedTaskId]
   );
 
   // メンバーごとにタスクをグループ化
   const memberGroups = useMemo(() => {
     const grouped = new Map<string, Task[]>();
 
-    for (const task of activeTasks) {
+    for (const task of tasks) {
       for (const assigneeId of task.assigneeIds) {
         const existing = grouped.get(assigneeId);
         if (existing) {
@@ -39,15 +47,15 @@ export function MemberTaskListPage() {
     }
 
     const result: { member: User; tasks: Task[] }[] = [];
-    for (const user of MOCK_USERS) {
-      const tasks = grouped.get(user.id);
-      if (tasks && tasks.length > 0) {
-        result.push({ member: user, tasks });
+    for (const user of users) {
+      const userTasks = grouped.get(user.id);
+      if (userTasks && userTasks.length > 0) {
+        result.push({ member: user, tasks: userTasks });
       }
     }
 
     return result;
-  }, []);
+  }, [tasks, users]);
 
   const handleTaskClick = (task: Task) => {
     openDrawer(task.id);
@@ -71,26 +79,35 @@ export function MemberTaskListPage() {
           </span>
         </div>
 
-        {/* メンバーセクション */}
-        <div className="space-y-5">
-          {memberGroups.map(({ member, tasks }) =>
-            viewMode === 'table' ? (
-              <MemberSection
-                key={member.id}
-                member={member}
-                tasks={tasks}
-                onTaskClick={handleTaskClick}
-              />
-            ) : (
-              <MemberCardSection
-                key={member.id}
-                member={member}
-                tasks={tasks}
-                onTaskClick={handleTaskClick}
-              />
-            )
-          )}
-        </div>
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : tasksError ? (
+          <div className="rounded-lg border border-error-border bg-error-bg p-4 text-sm text-error-text">
+            タスクの取得に失敗しました: {tasksError.message}
+          </div>
+        ) : (
+          <div className="space-y-5">
+            {memberGroups.map(({ member, tasks: memberTasks }) =>
+              viewMode === 'table' ? (
+                <MemberSection
+                  key={member.id}
+                  member={member}
+                  tasks={memberTasks}
+                  onTaskClick={handleTaskClick}
+                />
+              ) : (
+                <MemberCardSection
+                  key={member.id}
+                  member={member}
+                  tasks={memberTasks}
+                  onTaskClick={handleTaskClick}
+                />
+              )
+            )}
+          </div>
+        )}
       </div>
 
       <TaskDrawer task={selectedTask} onClose={closeDrawer} />

--- a/frontend/src/pages/tasks/TaskListPage.tsx
+++ b/frontend/src/pages/tasks/TaskListPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Header } from '../../components/layout/Header';
 import { TaskDrawer } from '../../components/shared/TaskDrawer/TaskDrawer';
 import { TaskTableView } from './components/TaskTableView';
@@ -6,27 +6,36 @@ import { TaskCardView } from './components/TaskCardView';
 import { TaskListToolbar } from './components/TaskListToolbar';
 import { TaskFilterPanel } from './components/TaskFilterPanel';
 import { Pagination } from '../../components/ui/Pagination';
+import { Spinner } from '../../components/ui/Spinner';
 import { useViewMode } from '../../hooks/useViewMode';
 import { useTaskDrawer } from '../../hooks/useTaskDrawer';
-import { getAllTasks } from '../../lib/mockData';
-import { FLOW_STATUS_COMPLETED } from '../../lib/constants';
+import { useTasks } from '../../hooks/useTasks';
 import type { Task } from '../../types';
 
-const allTasks = getAllTasks();
-const activeTasks = allTasks.filter((t) => t.flowStatus !== FLOW_STATUS_COMPLETED);
-
-// 静的実装: ページネーション用の定数
-const TOTAL_ITEMS = 245;
 const PER_PAGE = 30;
-const CURRENT_PAGE = 1;
 
 export function TaskListPage() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const offset = (currentPage - 1) * PER_PAGE;
+
+  const { data, isLoading, error } = useTasks({
+    excludeCompleted: true,
+    limit: PER_PAGE,
+    offset,
+  });
+
+  const tasks = useMemo(() => data?.tasks ?? [], [data?.tasks]);
+  const hasMore = data?.hasMore ?? false;
+
+  // hasMore ベースで総件数を推定（正確な totalCount は API に追加が必要）
+  const estimatedTotal = hasMore ? offset + PER_PAGE + 1 : offset + tasks.length;
+
   const { viewMode, setViewMode } = useViewMode('tasks');
   const { selectedTaskId, openDrawer, closeDrawer } = useTaskDrawer();
 
   const selectedTask = useMemo<Task | null>(
-    () => allTasks.find((t) => t.id === selectedTaskId) ?? null,
-    [allTasks, selectedTaskId]
+    () => tasks.find((t) => t.id === selectedTaskId) ?? null,
+    [tasks, selectedTaskId]
   );
 
   const handleTaskClick = (task: Task) => {
@@ -39,7 +48,7 @@ export function TaskListPage() {
 
       <div className="flex-1 overflow-y-auto p-8 space-y-6">
         <TaskListToolbar
-          taskCount={activeTasks.length}
+          taskCount={tasks.length}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
         />
@@ -56,14 +65,32 @@ export function TaskListPage() {
           </span>
         </div>
 
-        {viewMode === 'table' ? (
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-error-border bg-error-bg p-4 text-sm text-error-text">
+            タスクの取得に失敗しました: {error.message}
+          </div>
+        ) : viewMode === 'table' ? (
           <div className="space-y-4">
-            <Pagination totalItems={TOTAL_ITEMS} currentPage={CURRENT_PAGE} perPage={PER_PAGE} />
-            <TaskTableView tasks={activeTasks} onTaskClick={handleTaskClick} enableInfoBg />
-            <Pagination totalItems={TOTAL_ITEMS} currentPage={CURRENT_PAGE} perPage={PER_PAGE} />
+            <Pagination
+              totalItems={estimatedTotal}
+              currentPage={currentPage}
+              perPage={PER_PAGE}
+              onPageChange={setCurrentPage}
+            />
+            <TaskTableView tasks={tasks} onTaskClick={handleTaskClick} enableInfoBg />
+            <Pagination
+              totalItems={estimatedTotal}
+              currentPage={currentPage}
+              perPage={PER_PAGE}
+              onPageChange={setCurrentPage}
+            />
           </div>
         ) : (
-          <TaskCardView tasks={activeTasks} onTaskClick={handleTaskClick} enableInfoBg />
+          <TaskCardView tasks={tasks} onTaskClick={handleTaskClick} enableInfoBg />
         )}
       </div>
 

--- a/frontend/src/pages/tasks/components/TaskFilterPanel.tsx
+++ b/frontend/src/pages/tasks/components/TaskFilterPanel.tsx
@@ -2,7 +2,8 @@ import { ListFilter, X } from 'lucide-react';
 import { Input } from '../../../components/ui/Input';
 import { Select } from '../../../components/ui/Select';
 import { PROJECT_TYPES } from '../../../types';
-import { MOCK_USERS, MOCK_LABELS } from '../../../lib/mockData';
+import { useUsers } from '../../../hooks/useUsers';
+import { useLabels } from '../../../hooks/useLabels';
 
 const FLOW_STATUS_OPTIONS = [
   { value: '完了以外', label: '完了以外' },
@@ -16,16 +17,6 @@ const FLOW_STATUS_OPTIONS = [
 ];
 
 const PROJECT_OPTIONS = PROJECT_TYPES.map((p) => ({ value: p, label: p }));
-
-const ASSIGN_OPTIONS = MOCK_USERS.map((u) => ({
-  value: u.id,
-  label: u.displayName,
-}));
-
-const KUBUN_OPTIONS = MOCK_LABELS.map((l) => ({
-  value: l.id,
-  label: l.name,
-}));
 
 const TIMER_OPTIONS = [
   { value: 'active', label: '計測中' },
@@ -48,6 +39,19 @@ function generateMonthOptions(): { value: string; label: string }[] {
 const MONTH_OPTIONS = generateMonthOptions();
 
 export function TaskFilterPanel() {
+  const { data: users = [] } = useUsers();
+  const { data: labels = [] } = useLabels();
+
+  const assignOptions = users.map((u) => ({
+    value: u.id,
+    label: u.displayName,
+  }));
+
+  const kubunOptions = labels.map((l) => ({
+    value: l.id,
+    label: l.name,
+  }));
+
   return (
     <div className="rounded-lg border border-border-default bg-bg-tertiary px-6 py-4 space-y-3">
       {/* ヘッダー */}
@@ -84,12 +88,12 @@ export function TaskFilterPanel() {
           active
           className="flex-1"
         />
-        <Select label="アサイン" options={ASSIGN_OPTIONS} placeholder="すべて" className="flex-1" />
+        <Select label="アサイン" options={assignOptions} placeholder="すべて" className="flex-1" />
       </div>
 
       {/* フィルター Row 2 */}
       <div className="flex items-end gap-3">
-        <Select label="区分" options={KUBUN_OPTIONS} placeholder="すべて" className="flex-1" />
+        <Select label="区分" options={kubunOptions} placeholder="すべて" className="flex-1" />
         <Select label="タイマー" options={TIMER_OPTIONS} placeholder="すべて" className="flex-1" />
         <Select
           label="ITアップ月"


### PR DESCRIPTION
## Summary
- **バックエンド**: `GET /api/tasks` の `projectType` をオプション化 + `excludeCompleted` パラメータ追加
- **フロントエンド**: Dashboard / TaskList / MemberTaskList の3ページをモックデータからバックエンドAPIに接続
- **TaskFilterPanel**: `MOCK_USERS` / `MOCK_LABELS` → `useUsers()` / `useLabels()` に置換
- 全ページにローディング（Spinner）とエラー表示を追加

## 変更ファイル

### バックエンド
| ファイル | 内容 |
|---------|------|
| `backend/src/routes/tasks.ts` | projectType オプション化 + excludeCompleted |
| `backend/src/routes/tasks.test.ts` | テスト更新 |

### フロントエンド
| ファイル | 内容 |
|---------|------|
| `frontend/src/hooks/useTasks.ts` | useTasks + useAssignedTasks フック（新規） |
| `frontend/src/pages/dashboard/DashboardPage.tsx` | getMyTasks → useAssignedTasks |
| `frontend/src/pages/tasks/TaskListPage.tsx` | getAllTasks → useTasks + ページネーション |
| `frontend/src/pages/tasks/MemberTaskListPage.tsx` | モック → useTasks + useUsers |
| `frontend/src/pages/tasks/components/TaskFilterPanel.tsx` | モック → useUsers/useLabels |

## Test plan
- [ ] ダッシュボードで自分のアサインタスクが API から取得・表示される
- [ ] タスク一覧でページネーションが動作する
- [ ] メンバー別一覧でユーザーごとのタスクグループが正しく表示される
- [ ] フィルターパネルにユーザー名・ラベル名が API データから表示される
- [ ] API 未接続時にローディングスピナー → エラーメッセージが表示される
- [ ] `cd frontend && bun run type-check` が通る

🤖 Generated with [Claude Code](https://claude.ai/code)