### PR TITLE
✨ feat(frontend): コメント機能を実装

### DIFF
--- a/frontend/src/components/shared/TaskDrawer/CommentTab.tsx
+++ b/frontend/src/components/shared/TaskDrawer/CommentTab.tsx
@@ -1,7 +1,152 @@
-export function CommentTab() {
+import { useState } from 'react';
+import { Send, Trash2 } from 'lucide-react';
+import { Avatar } from '../../ui/Avatar';
+import { Spinner } from '../../ui/Spinner';
+import {
+  useTaskComments,
+  useCreateComment,
+  useDeleteComment,
+} from '../../../hooks/useTaskComments';
+import { useUsers } from '../../../hooks/useUsers';
+import { useAuth } from '../../../hooks/useAuth';
+import type { TaskComment } from '../../../types';
+
+interface CommentTabProps {
+  taskId: string | null;
+  projectType: string | null;
+}
+
+export function CommentTab({ taskId, projectType }: CommentTabProps) {
+  const { data: comments, isLoading } = useTaskComments(taskId, projectType);
+  const { getUserName } = useUsers();
+  const { userId } = useAuth();
+
+  if (!taskId || !projectType) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-sm text-text-tertiary">タスクを選択してください</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center justify-center py-12">
-      <p className="text-sm text-text-tertiary">コメント機能は後日実装</p>
+    <div className="flex h-full flex-col">
+      {/* コメント一覧 */}
+      <div className="flex-1 overflow-y-auto space-y-4">
+        {comments && comments.length > 0 ? (
+          comments.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              authorName={getUserName(comment.authorId)}
+              isOwn={comment.authorId === userId}
+              taskId={taskId}
+            />
+          ))
+        ) : (
+          <p className="py-8 text-center text-sm text-text-tertiary">コメントはまだありません</p>
+        )}
+      </div>
+
+      {/* 投稿フォーム */}
+      <CommentForm taskId={taskId} projectType={projectType} />
+    </div>
+  );
+}
+
+function CommentItem({
+  comment,
+  authorName,
+  isOwn,
+  taskId,
+}: {
+  comment: TaskComment;
+  authorName: string;
+  isOwn: boolean;
+  taskId: string;
+}) {
+  const deleteComment = useDeleteComment();
+  const createdAt = new Date(comment.createdAt);
+
+  return (
+    <div className="group flex gap-3">
+      <Avatar name={authorName} size="sm" className="mt-0.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-text-primary">{authorName}</span>
+          <span className="text-xs text-text-tertiary">
+            {createdAt.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}{' '}
+            {createdAt.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
+          </span>
+          {isOwn && (
+            <button
+              type="button"
+              onClick={() => deleteComment.mutate({ commentId: comment.id, taskId })}
+              className="ml-auto hidden rounded p-1 text-text-tertiary hover:bg-error-bg hover:text-error-text group-hover:block"
+              aria-label="コメントを削除"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+        </div>
+        <p className="mt-1 text-sm leading-relaxed text-text-secondary whitespace-pre-wrap">
+          {comment.content}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CommentForm({ taskId, projectType }: { taskId: string; projectType: string }) {
+  const [content, setContent] = useState('');
+  const createComment = useCreateComment();
+
+  const handleSubmit = () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+
+    createComment.mutate(
+      { taskId, projectType, content: trimmed },
+      { onSuccess: () => setContent('') }
+    );
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className="border-t border-border-default pt-3">
+      <div className="flex gap-2">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="コメントを入力... (Cmd+Enter で送信)"
+          rows={2}
+          className="flex-1 resize-none rounded-md border border-border-default bg-bg-secondary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-primary-default focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!content.trim() || createComment.isPending}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary-default text-white transition-colors hover:bg-primary-hover disabled:opacity-40"
+          aria-label="コメントを送信"
+        >
+          <Send size={16} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
@@ -119,7 +119,7 @@ export function TaskDrawer({
                   <DrawerTabBar
                     detailTabLabel={detailTabLabel}
                     detailContent={detailContent ?? <TaskDetailTab task={task} />}
-                    commentContent={<CommentTab />}
+                    commentContent={<CommentTab taskId={task.id} projectType={task.projectType} />}
                     detailPadding={detailPadding}
                   />
                 </>

--- a/frontend/src/hooks/useTaskComments.ts
+++ b/frontend/src/hooks/useTaskComments.ts
@@ -1,0 +1,153 @@
+import { useEffect, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+import type { TaskComment } from '../types';
+
+interface CommentsResponse {
+  comments: TaskComment[];
+}
+
+interface UnreadResponse {
+  taskIds: string[];
+}
+
+/**
+ * タスクのコメント一覧を取得
+ * GET /api/comments?taskId=xxx&projectType=xxx
+ */
+export function useTaskComments(taskId: string | null, projectType: string | null) {
+  const { getToken, isSignedIn, userId } = useAuth();
+  const queryClient = useQueryClient();
+  const hasMarkedAsRead = useRef(false);
+
+  const query = useQuery({
+    queryKey: queryKeys.comments(taskId ?? ''),
+    queryFn: () =>
+      apiClient<CommentsResponse>(`/api/comments?taskId=${taskId}&projectType=${projectType}`, {
+        getToken,
+      }).then((res) => res.comments),
+    enabled: isSignedIn && taskId != null && projectType != null,
+  });
+
+  // コメントタブを開いた時に既読マーク
+  useEffect(() => {
+    if (
+      query.data &&
+      query.data.length > 0 &&
+      taskId &&
+      projectType &&
+      userId &&
+      !hasMarkedAsRead.current
+    ) {
+      const hasUnread = query.data.some((c) => !c.readBy.includes(userId));
+      if (hasUnread) {
+        hasMarkedAsRead.current = true;
+        apiClient('/api/comments/mark-read', {
+          method: 'POST',
+          body: { taskId, projectType },
+          getToken,
+        }).then(() => {
+          queryClient.invalidateQueries({ queryKey: queryKeys.unreadComments() });
+        });
+      }
+    }
+  }, [query.data, taskId, projectType, userId, getToken, queryClient]);
+
+  return query;
+}
+
+/**
+ * 未読コメントがあるタスクID一覧
+ * GET /api/comments/unread
+ */
+export function useUnreadComments() {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.unreadComments(),
+    queryFn: () =>
+      apiClient<UnreadResponse>('/api/comments/unread', { getToken }).then(
+        (res) => new Set(res.taskIds)
+      ),
+    enabled: isSignedIn,
+    staleTime: 1000 * 30, // 30秒
+  });
+}
+
+/**
+ * コメント作成
+ */
+export function useCreateComment() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: {
+      taskId: string;
+      projectType: string;
+      content: string;
+      mentionedUserIds?: string[];
+    }) =>
+      apiClient<{ id: string }>('/api/comments', {
+        method: 'POST',
+        body: data,
+        getToken,
+      }),
+    onSuccess: (_result, { taskId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.comments(taskId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.unreadComments() });
+    },
+  });
+}
+
+/**
+ * コメント更新
+ */
+export function useUpdateComment() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+      mentionedUserIds,
+      taskId: _taskId,
+    }: {
+      commentId: string;
+      content: string;
+      mentionedUserIds?: string[];
+      taskId: string;
+    }) =>
+      apiClient<{ success: boolean }>(`/api/comments/${commentId}`, {
+        method: 'PUT',
+        body: { content, mentionedUserIds },
+        getToken,
+      }),
+    onSuccess: (_result, { taskId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.comments(taskId) });
+    },
+  });
+}
+
+/**
+ * コメント削除
+ */
+export function useDeleteComment() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId, taskId: _taskId }: { commentId: string; taskId: string }) =>
+      apiClient<{ success: boolean }>(`/api/comments/${commentId}`, {
+        method: 'DELETE',
+        getToken,
+      }),
+    onSuccess: (_result, { taskId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.comments(taskId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.unreadComments() });
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- `useTaskComments`: コメント一覧取得 + ドロワー表示時の自動既読マーク
- `useUnreadComments`: 未読コメントがあるタスクID一覧取得
- `useCreateComment` / `useUpdateComment` / `useDeleteComment`: CRUD mutation フック
- **CommentTab UI**: コメント一覧（アバター+名前+日時+本文）+ 投稿フォーム（Cmd+Enter対応）+ 自分のコメント削除（ホバーで表示）
- TaskDrawer から `taskId` / `projectType` を CommentTab に渡す

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `frontend/src/hooks/useTaskComments.ts` | コメント CRUD + 既読 + 未読フック群（新規） |
| `frontend/src/components/shared/TaskDrawer/CommentTab.tsx` | コメントUI実装（全面書き換え） |
| `frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx` | CommentTab に props 追加 |

## Test plan
- [ ] ドロワーのコメントタブでコメント一覧が表示される
- [ ] テキスト入力 + 送信ボタン or Cmd+Enter でコメント投稿できる
- [ ] 自分のコメントにホバーすると削除ボタンが表示される
- [ ] コメント削除が動作する
- [ ] コメントタブを開くと未読が既読になる
- [ ] `cd frontend && bun run type-check` が通る

🤖 Generated with [Claude Code](https://claude.ai/code)