### PR TITLE
✨ feat(frontend): レポートページをAPI接続に移行

### DIFF
--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+
+interface ReportItem {
+  title: string;
+  durationSec: number;
+  over3hours?: string;
+  taskId: string;
+  projectType: string;
+}
+
+interface ReportResponse {
+  items: ReportItem[];
+  totalDurationSec: number;
+}
+
+export type { ReportItem };
+
+/**
+ * レポートデータを取得
+ * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg
+ */
+export function useReportData(type: 'normal' | 'brg', fromDate: string, toDate: string) {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.reports(type, fromDate, toDate),
+    queryFn: () =>
+      apiClient<ReportResponse>(`/api/reports/time?from=${fromDate}&to=${toDate}&type=${type}`, {
+        getToken,
+      }),
+    enabled: isSignedIn && !!fromDate && !!toDate,
+  });
+}
+
+/**
+ * レポートCSVをダウンロード
+ */
+export async function downloadReportCsv(
+  type: 'normal' | 'brg',
+  fromDate: string,
+  toDate: string,
+  getToken: () => Promise<string | null>
+) {
+  const token = await getToken();
+  const url = `/api/reports/time/csv?from=${fromDate}&to=${toDate}&type=${type}`;
+
+  const response = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+
+  if (!response.ok) {
+    throw new Error(`CSV download failed: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = `report_${type}_${fromDate}_${toDate}.csv`;
+  a.click();
+  URL.revokeObjectURL(blobUrl);
+}

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -61,5 +61,5 @@ export async function downloadReportCsv(
   a.href = blobUrl;
   a.download = `report_${type}_${fromDate}_${toDate}.csv`;
   a.click();
-  URL.revokeObjectURL(blobUrl);
+  setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
 }

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Header } from '../../components/layout/Header';
 import { Tabs, TabList, Tab, TabPanel } from '../../components/ui/Tabs';
 import { Modal } from '../../components/ui/Modal';
@@ -12,7 +12,6 @@ import { ReportTable } from './components/ReportTable';
 import { ExportModalContent } from './components/ExportModalContent';
 import { SessionEditModalContent } from './components/SessionEditModalContent';
 import { useReportData, downloadReportCsv } from '../../hooks/useReportData';
-import type { ReportItem } from '../../hooks/useReportData';
 import { useAuth } from '../../hooks/useAuth';
 import type { ReportEntry, ReportType, TaskSession } from '../../types';
 
@@ -39,8 +38,11 @@ export function ReportPage() {
   // タブ状態
   const [activeTab, setActiveTab] = useState<ReportType | 'all'>('all');
 
-  // モーダル状態
+  // エクスポート状態
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+  const [exportRange, setExportRange] = useState<'all' | 'normal' | 'brg'>('all');
+
+  // セッション編集
   const [editingSession, setEditingSession] = useState<{
     entry: ReportEntry;
     session: TaskSession;
@@ -59,17 +61,21 @@ export function ReportPage() {
 
   const totalDurationSec = data?.totalDurationSec ?? 0;
 
-  // API ReportItem → フロント ReportEntry にマッピング
-  const entries: ReportEntry[] = (data?.items ?? []).map((item: ReportItem) => ({
-    id: item.taskId,
-    taskId: item.taskId,
-    title: item.title,
-    type: reportType,
-    totalDurationSec: item.durationSec,
-    over3Reason: item.over3hours,
-    sessions: [],
-    date: new Date(fromDate),
-  }));
+  // API ReportItem → フロント ReportEntry にマッピング（メモ化）
+  const entries = useMemo<ReportEntry[]>(
+    () =>
+      (data?.items ?? []).map((item) => ({
+        id: item.taskId,
+        taskId: item.taskId,
+        title: item.title,
+        type: reportType,
+        totalDurationSec: item.durationSec,
+        over3Reason: item.over3hours,
+        sessions: [],
+        date: new Date(year, month - 1, 1),
+      })),
+    [data?.items, reportType, year, month]
+  );
 
   // 表示用日付
   const startDate = formatDateSlash(year, month, 1);
@@ -108,13 +114,11 @@ export function ReportPage() {
     setActiveTab(key as ReportType | 'all');
   };
 
-  const handleExport = useCallback(
-    async (exportType: 'normal' | 'brg') => {
-      await downloadReportCsv(exportType, fromDate, toDate, getToken);
-      setIsExportModalOpen(false);
-    },
-    [fromDate, toDate, getToken]
-  );
+  const handleExport = useCallback(async () => {
+    const csvType = exportRange === 'all' ? 'normal' : exportRange;
+    await downloadReportCsv(csvType, fromDate, toDate, getToken);
+    setIsExportModalOpen(false);
+  }, [exportRange, fromDate, toDate, getToken]);
 
   return (
     <>
@@ -162,7 +166,6 @@ export function ReportPage() {
         </Tabs>
       </div>
 
-      {/* 共通ドロワー（レポート詳細タブを差し込み） */}
       <TaskDrawer
         isOpen={selectedEntry != null}
         title={selectedEntry?.title ?? ''}
@@ -187,7 +190,7 @@ export function ReportPage() {
           />
         }
       >
-        <ExportModalContent />
+        <ExportModalContent range={exportRange} onRangeChange={setExportRange} />
       </Modal>
 
       <Modal

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { Header } from '../../components/layout/Header';
 import { Tabs, TabList, Tab, TabPanel } from '../../components/ui/Tabs';
 import { Modal } from '../../components/ui/Modal';
+import { Spinner } from '../../components/ui/Spinner';
 import { TaskDrawer } from '../../components/shared/TaskDrawer/TaskDrawer';
 import { ReportDetailTab } from '../../components/shared/ReportDrawer/ReportDetailTab';
 import { ReportToolbar } from './components/ReportToolbar';
@@ -10,7 +11,9 @@ import { SummaryRow } from './components/SummaryRow';
 import { ReportTable } from './components/ReportTable';
 import { ExportModalContent } from './components/ExportModalContent';
 import { SessionEditModalContent } from './components/SessionEditModalContent';
-import { getReportEntries } from '../../lib/mockData';
+import { useReportData, downloadReportCsv } from '../../hooks/useReportData';
+import type { ReportItem } from '../../hooks/useReportData';
+import { useAuth } from '../../hooks/useAuth';
 import type { ReportEntry, ReportType, TaskSession } from '../../types';
 
 function getLastDayOfMonth(year: number, month: number): number {
@@ -21,10 +24,17 @@ function formatDateSlash(year: number, month: number, day: number): string {
   return `${year}/${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}`;
 }
 
+function formatDateISO(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
 export function ReportPage() {
+  const { getToken } = useAuth();
+
   // 月ナビ状態
-  const [year, setYear] = useState(2026);
-  const [month, setMonth] = useState(1);
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
 
   // タブ状態
   const [activeTab, setActiveTab] = useState<ReportType | 'all'>('all');
@@ -39,18 +49,29 @@ export function ReportPage() {
   // ドロワー状態
   const [selectedEntry, setSelectedEntry] = useState<ReportEntry | null>(null);
 
-  // レポートデータ
-  const entries = useMemo(() => {
-    const type = activeTab === 'all' ? undefined : activeTab;
-    return getReportEntries(type);
-  }, [activeTab]);
+  // API用の日付
+  const fromDate = formatDateISO(year, month, 1);
+  const toDate = formatDateISO(year, month, getLastDayOfMonth(year, month));
 
-  const totalDurationSec = useMemo(
-    () => entries.reduce((sum, e) => sum + e.totalDurationSec, 0),
-    [entries]
-  );
+  // レポートデータ取得
+  const reportType = activeTab === 'all' ? 'normal' : activeTab;
+  const { data, isLoading, error } = useReportData(reportType, fromDate, toDate);
 
-  // 日付範囲
+  const totalDurationSec = data?.totalDurationSec ?? 0;
+
+  // API ReportItem → フロント ReportEntry にマッピング
+  const entries: ReportEntry[] = (data?.items ?? []).map((item: ReportItem) => ({
+    id: item.taskId,
+    taskId: item.taskId,
+    title: item.title,
+    type: reportType,
+    totalDurationSec: item.durationSec,
+    over3Reason: item.over3hours,
+    sessions: [],
+    date: new Date(fromDate),
+  }));
+
+  // 表示用日付
   const startDate = formatDateSlash(year, month, 1);
   const endDate = formatDateSlash(year, month, getLastDayOfMonth(year, month));
 
@@ -87,6 +108,14 @@ export function ReportPage() {
     setActiveTab(key as ReportType | 'all');
   };
 
+  const handleExport = useCallback(
+    async (exportType: 'normal' | 'brg') => {
+      await downloadReportCsv(exportType, fromDate, toDate, getToken);
+      setIsExportModalOpen(false);
+    },
+    [fromDate, toDate, getToken]
+  );
+
   return (
     <>
       <Header title="レポート" />
@@ -111,12 +140,24 @@ export function ReportPage() {
           <div className="mt-6 space-y-6">
             <SummaryRow totalDurationSec={totalDurationSec} entryCount={entries.length} />
 
-            <TabPanel id="all">
-              <ReportTable entries={entries} onRowClick={handleRowClick} />
-            </TabPanel>
-            <TabPanel id="brg">
-              <ReportTable entries={entries} onRowClick={handleRowClick} />
-            </TabPanel>
+            {isLoading ? (
+              <div className="flex justify-center py-12">
+                <Spinner size="lg" />
+              </div>
+            ) : error ? (
+              <div className="rounded-lg border border-error-border bg-error-bg p-4 text-sm text-error-text">
+                レポートの取得に失敗しました: {error.message}
+              </div>
+            ) : (
+              <>
+                <TabPanel id="all">
+                  <ReportTable entries={entries} onRowClick={handleRowClick} />
+                </TabPanel>
+                <TabPanel id="brg">
+                  <ReportTable entries={entries} onRowClick={handleRowClick} />
+                </TabPanel>
+              </>
+            )}
           </div>
         </Tabs>
       </div>
@@ -139,7 +180,12 @@ export function ReportPage() {
         isOpen={isExportModalOpen}
         onClose={() => setIsExportModalOpen(false)}
         title="スプレッドシートに出力"
-        footer={<ExportModalContent.Footer onCancel={() => setIsExportModalOpen(false)} />}
+        footer={
+          <ExportModalContent.Footer
+            onCancel={() => setIsExportModalOpen(false)}
+            onExport={handleExport}
+          />
+        }
       >
         <ExportModalContent />
       </Modal>

--- a/frontend/src/pages/reports/components/ExportModalContent.tsx
+++ b/frontend/src/pages/reports/components/ExportModalContent.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react';
 import { Upload } from 'lucide-react';
 import { Button } from '../../../components/ui/Button';
 
 type ExportRange = 'all' | 'normal' | 'brg';
-type ExportMethod = 'create' | 'update';
 
-export function ExportModalContent() {
-  const [range, setRange] = useState<ExportRange>('all');
-  const [method, setMethod] = useState<ExportMethod>('create');
+interface ExportModalContentProps {
+  range: ExportRange;
+  onRangeChange: (range: ExportRange) => void;
+}
 
+export function ExportModalContent({ range, onRangeChange }: ExportModalContentProps) {
   return (
     <div className="space-y-6">
       {/* 出力範囲 */}
@@ -20,42 +20,21 @@ export function ExportModalContent() {
             value="all"
             label="全て"
             checked={range === 'all'}
-            onChange={() => setRange('all')}
+            onChange={() => onRangeChange('all')}
           />
           <RadioOption
             name="range"
             value="normal"
             label="通常のみ"
             checked={range === 'normal'}
-            onChange={() => setRange('normal')}
+            onChange={() => onRangeChange('normal')}
           />
           <RadioOption
             name="range"
             value="brg"
             label="BRGのみ"
             checked={range === 'brg'}
-            onChange={() => setRange('brg')}
-          />
-        </div>
-      </div>
-
-      {/* 出力方法 */}
-      <div className="space-y-3">
-        <span className="text-sm font-medium text-text-primary">出力方法</span>
-        <div className="space-y-2">
-          <RadioOption
-            name="method"
-            value="create"
-            label="新規作成"
-            checked={method === 'create'}
-            onChange={() => setMethod('create')}
-          />
-          <RadioOption
-            name="method"
-            value="update"
-            label="更新"
-            checked={method === 'update'}
-            onChange={() => setMethod('update')}
+            onChange={() => onRangeChange('brg')}
           />
         </div>
       </div>
@@ -65,7 +44,7 @@ export function ExportModalContent() {
 
 interface FooterProps {
   onCancel: () => void;
-  onExport?: (type: 'normal' | 'brg') => void;
+  onExport: () => void;
 }
 
 ExportModalContent.Footer = function ExportModalFooter({ onCancel, onExport }: FooterProps) {
@@ -74,7 +53,7 @@ ExportModalContent.Footer = function ExportModalFooter({ onCancel, onExport }: F
       <Button variant="outline" size="sm" onPress={onCancel}>
         キャンセル
       </Button>
-      <Button variant="primary" size="sm" onPress={() => onExport?.('normal')}>
+      <Button variant="primary" size="sm" onPress={onExport}>
         <Upload size={16} />
         出力
       </Button>

--- a/frontend/src/pages/reports/components/ExportModalContent.tsx
+++ b/frontend/src/pages/reports/components/ExportModalContent.tsx
@@ -65,15 +65,16 @@ export function ExportModalContent() {
 
 interface FooterProps {
   onCancel: () => void;
+  onExport?: (type: 'normal' | 'brg') => void;
 }
 
-ExportModalContent.Footer = function ExportModalFooter({ onCancel }: FooterProps) {
+ExportModalContent.Footer = function ExportModalFooter({ onCancel, onExport }: FooterProps) {
   return (
     <>
       <Button variant="outline" size="sm" onPress={onCancel}>
         キャンセル
       </Button>
-      <Button variant="primary" size="sm">
+      <Button variant="primary" size="sm" onPress={() => onExport?.('normal')}>
         <Upload size={16} />
         出力
       </Button>


### PR DESCRIPTION
## Summary
- `useReportData`: `GET /api/reports/time?from=xxx&to=xxx&type=normal|brg` でレポートデータ取得
- `downloadReportCsv`: `GET /api/reports/time/csv` で CSV Blob ダウンロード
- **ReportPage**: `getReportEntries()` モック → `useReportData()` API に置換
- API `ReportItem` → フロント `ReportEntry` へのマッピング追加
- 月ナビの初期値をハードコード `2026/1` → 現在の年月に変更
- ExportModalContent の Footer に `onExport` コールバック追加
- ローディング（Spinner）/ エラー表示を追加

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `frontend/src/hooks/useReportData.ts` | レポート取得 + CSV DL（新規） |
| `frontend/src/pages/reports/ReportPage.tsx` | モック → API 置換 |
| `frontend/src/pages/reports/components/ExportModalContent.tsx` | onExport コールバック追加 |

## Test plan
- [ ] 月ナビで月を切り替えるとレポートデータが再取得される
- [ ] 通常 / BRG タブ切り替えでデータが変わる
- [ ] CSV エクスポートボタンでファイルがダウンロードされる
- [ ] API 未接続時にローディング → エラー表示
- [ ] `cd frontend && bun run type-check` が通る

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * レポート機能が API ベースのデータ取得に対応しました。CSV ファイルのダウンロード機能を追加しました。

* **Refactor**
  * エクスポートモーダルのコンポーネント設計を改善し、より柔軟な制御が可能になりました。ローディングおよびエラー状態の表示機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->