### PR TITLE
✨ feat(frontend): お問い合わせページをAPI接続に移行

### DIFF
--- a/frontend/src/hooks/useContacts.ts
+++ b/frontend/src/hooks/useContacts.ts
@@ -59,7 +59,8 @@ export function useCreateContact() {
         getToken,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.contacts() });
+      // 新規作成は常に pending なので pending キャッシュのみ無効化
+      queryClient.invalidateQueries({ queryKey: queryKeys.contacts('pending') });
     },
   });
 }

--- a/frontend/src/hooks/useContacts.ts
+++ b/frontend/src/hooks/useContacts.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+import type { Contact } from '../types';
+
+interface ContactsResponse {
+  contacts: Contact[];
+}
+
+/**
+ * お問い合わせ一覧を取得
+ * GET /api/contact?status=pending|resolved
+ */
+export function useContacts(status: 'pending' | 'resolved') {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.contacts(status),
+    queryFn: () =>
+      apiClient<ContactsResponse>(`/api/contact?status=${status}`, { getToken }).then(
+        (res) => res.contacts
+      ),
+    enabled: isSignedIn,
+  });
+}
+
+/**
+ * お問い合わせ作成
+ * POST /api/contact
+ */
+export function useCreateContact() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: {
+      type: string;
+      title: string;
+      content?: string;
+      userName: string;
+      userEmail: string;
+      errorReportDetails?: {
+        issue: string;
+        reproductionSteps: string;
+        environment: {
+          device: string;
+          os: string;
+          browser: string;
+          osVersion?: string;
+          browserVersion: string;
+        };
+        screenshotUrl?: string;
+      };
+    }) =>
+      apiClient<{ id: string }>('/api/contact', {
+        method: 'POST',
+        body: data,
+        getToken,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.contacts() });
+    },
+  });
+}
+
+/**
+ * お問い合わせステータス更新
+ * PUT /api/contact/:id
+ */
+export function useUpdateContactStatus() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ contactId, status }: { contactId: string; status: 'pending' | 'resolved' }) =>
+      apiClient<{ success: boolean }>(`/api/contact/${contactId}`, {
+        method: 'PUT',
+        body: { status },
+        getToken,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.contacts() });
+    },
+  });
+}

--- a/frontend/src/pages/contacts/ContactPage.tsx
+++ b/frontend/src/pages/contacts/ContactPage.tsx
@@ -1,24 +1,47 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { CircleCheckBig, Plus } from 'lucide-react';
 import { Header } from '../../components/layout/Header';
 import { Button } from '../../components/ui/Button';
+import { Spinner } from '../../components/ui/Spinner';
 import { ContactCard } from './components/ContactCard';
 import { ContactFormDrawer } from './components/ContactFormDrawer';
 import type { ContactFormData } from './components/ContactFormDrawer';
-import { getContactsByStatus } from '../../lib/mockData';
+import { useContacts, useCreateContact } from '../../hooks/useContacts';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
 
 export function ContactPage() {
   const [showResolved, setShowResolved] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
-  const contacts = useMemo(
-    () => getContactsByStatus(showResolved ? 'resolved' : 'pending'),
-    [showResolved]
-  );
+  const status = showResolved ? 'resolved' : 'pending';
+  const { data: contacts = [], isLoading, error } = useContacts(status);
+  const createContact = useCreateContact();
+  const { data: currentUser } = useCurrentUser();
 
   const handleSubmit = (data: ContactFormData) => {
-    // TODO: API連携時に実装
-    void data;
+    createContact.mutate(
+      {
+        type: data.type,
+        title: data.title,
+        content: data.content || undefined,
+        userName: currentUser?.displayName ?? '',
+        userEmail: currentUser?.email ?? '',
+        errorReportDetails: data.errorDetails
+          ? {
+              issue: data.errorDetails.issue,
+              reproductionSteps: data.errorDetails.reproductionSteps,
+              environment: {
+                device: data.errorDetails.device,
+                os: data.errorDetails.os,
+                browser: data.errorDetails.browser,
+                osVersion: data.errorDetails.osVersion,
+                browserVersion: data.errorDetails.browserVersion,
+              },
+            }
+          : undefined,
+      },
+      { onSuccess: () => setIsDrawerOpen(false) }
+    );
   };
 
   return (
@@ -35,7 +58,15 @@ export function ContactPage() {
       </Header>
 
       <div className="flex-1 overflow-y-auto p-8">
-        {contacts.length === 0 ? (
+        {isLoading ? (
+          <div className="flex justify-center py-16">
+            <Spinner size="lg" />
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-error-border bg-error-bg p-4 text-sm text-error-text">
+            お問い合わせの取得に失敗しました: {error.message}
+          </div>
+        ) : contacts.length === 0 ? (
           <div className="flex items-center justify-center py-16">
             <p className="text-sm text-text-tertiary">
               {showResolved ? '解決済みのお問い合わせはありません' : 'お問い合わせはありません'}


### PR DESCRIPTION
## Summary
- `useContacts`: `GET /api/contact?status=pending|resolved` でお問い合わせ一覧取得
- `useCreateContact`: `POST /api/contact` でお問い合わせ作成（バックエンドが GitHub Issue を自動作成）
- `useUpdateContactStatus`: `PUT /api/contact/:id` でステータス更新
- **ContactPage**: `getContactsByStatus()` モック → `useContacts()` API に置換
- フォーム送信時に `useCurrentUser` でユーザー名・メールを自動付与
- ローディング / エラー表示を追加

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `frontend/src/hooks/useContacts.ts` | お問い合わせ CRUD フック群（新規） |
| `frontend/src/pages/contacts/ContactPage.tsx` | モック → API 置換 |

## Test plan
- [ ] 対応中 / 解決済み切り替えで一覧が更新される
- [ ] 新規作成フォームから送信すると API が呼ばれ一覧に反映される
- [ ] API 未接続時にローディング → エラー表示
- [ ] `cd frontend && bun run type-check` が通る

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コンタクト一覧をサーバーからリアルタイム取得するようにしました。
  * コンタクト作成フォームを実装し、実際に機能するようになりました。
  * コンタクトのステータス更新機能を追加しました。
  * データ読込中とエラー状態の表示を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->