### PR TITLE
♻️ refactor(frontend): mockData 依存を完全除去

### DIFF
--- a/frontend/src/pages/tasks/components/TaskCard.tsx
+++ b/frontend/src/pages/tasks/components/TaskCard.tsx
@@ -5,7 +5,8 @@ import { Badge } from '../../../components/ui/Badge';
 import { AvatarGroup } from '../../../components/ui/AvatarGroup';
 import { cn } from '../../../lib/utils';
 import { getTaskBgVariant, getTaskBgClass, formatDate } from '../../../lib/taskUtils';
-import { resolveAssignees, getLabelById } from '../../../lib/mockData';
+import { useUsers } from '../../../hooks/useUsers';
+import { useLabels } from '../../../hooks/useLabels';
 
 interface TaskCardProps {
   task: Task;
@@ -16,9 +17,13 @@ interface TaskCardProps {
 export function TaskCard({ task, onClick, enableInfoBg }: TaskCardProps) {
   const bgVariant = getTaskBgVariant(task, { enableInfoVariant: enableInfoBg });
   const bgClass = getTaskBgClass(bgVariant);
+  const { getUserById } = useUsers();
+  const { getLabelById } = useLabels();
   const label = getLabelById(task.kubunLabelId);
 
-  const assignees = resolveAssignees(task.assigneeIds);
+  const assignees = task.assigneeIds
+    .map((id) => getUserById(id))
+    .filter((u): u is NonNullable<typeof u> => u != null);
 
   return (
     <div

--- a/frontend/src/pages/tasks/components/TaskTableRow.tsx
+++ b/frontend/src/pages/tasks/components/TaskTableRow.tsx
@@ -6,7 +6,8 @@ import { AvatarGroup } from '../../../components/ui/AvatarGroup';
 import { cn } from '../../../lib/utils';
 import { getTaskBgVariant, getTaskBgClass, formatDate } from '../../../lib/taskUtils';
 import { FLOW_STATUS_LABELS } from '../../../lib/constants';
-import { resolveAssignees, getLabelById } from '../../../lib/mockData';
+import { useUsers } from '../../../hooks/useUsers';
+import { useLabels } from '../../../hooks/useLabels';
 
 interface TaskTableRowProps {
   task: Task;
@@ -17,9 +18,13 @@ interface TaskTableRowProps {
 export function TaskTableRow({ task, onClick, enableInfoBg }: TaskTableRowProps) {
   const bgVariant = getTaskBgVariant(task, { enableInfoVariant: enableInfoBg });
   const bgClass = getTaskBgClass(bgVariant);
+  const { getUserById } = useUsers();
+  const { getLabelById } = useLabels();
   const label = getLabelById(task.kubunLabelId);
 
-  const assignees = resolveAssignees(task.assigneeIds);
+  const assignees = task.assigneeIds
+    .map((id) => getUserById(id))
+    .filter((u): u is NonNullable<typeof u> => u != null);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- `TaskTableRow` / `TaskCard` の `resolveAssignees` / `getLabelById` を mockData から `useUsers` / `useLabels` フックに置換
- **mockData.ts の import が全ページコンポーネントからゼロに** 🎉
- TanStack Query キャッシュ共有により、リスト内の各行/カードで重複フェッチなし

## 背景
Phase 0〜8 で主要ページ（Dashboard / Tasks / Reports / Contacts / Settings）はすべて API 接続済み。
残っていた TaskTableRow と TaskCard の mockData 依存を除去し、モック → API 移行を完了させる。

## mockData.ts の残存 import 状況
| 対象 | 状態 |
|------|------|
| ページコンポーネント全体 | ✅ **ゼロ** |
| TaskDetailPage のサブコンポーネント | ⚠️ インラインモック（mockData.ts 非参照、別 Issue で対応） |
| ReportDrawer | ⚠️ インラインモック（同上） |
| mockData.ts 自体 | 残存（どこからも import されていない。削除は別 Issue） |

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `frontend/src/pages/tasks/components/TaskTableRow.tsx` | mockData → useUsers/useLabels |
| `frontend/src/pages/tasks/components/TaskCard.tsx` | mockData → useUsers/useLabels |

## Test plan
- [ ] タスク一覧テーブルでユーザー名・ラベル名が API データから表示される
- [ ] タスクカードビューでユーザー名・ラベル名が API データから表示される
- [ ] `cd frontend && bun run type-check` が通る

🤖 Generated with [Claude Code](https://claude.ai/code)