### PR TITLE
✨ feat: 設定ページ機能実装 (#122〜#125)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.dev.vars
 
 # vercel
 .vercel

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -131,6 +131,7 @@ export const tasks = pgTable(
     fireIssueUrl: text('fire_issue_url'),
     googleChatThreadUrl: text('google_chat_thread_url'),
     backlogUrl: text('backlog_url'),
+    petIssueUrl: text('pet_issue_url'),
     dueDate: timestamp('due_date', { withTimezone: true }),
     priority: priorityEnum('priority'),
     order: real('order').notNull().default(0),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,6 +52,16 @@ app.use(
   })
 );
 
+// エラーハンドリング
+app.onError((err, c) => {
+  console.error('API Error:', err.message, err.stack);
+  const isDev = c.env.ENVIRONMENT === 'development';
+  return c.json(
+    { error: isDev ? err.message : 'Internal Server Error', ...(isDev && { stack: err.stack }) },
+    500
+  );
+});
+
 // Health check (認証不要)
 app.get('/health', (c) => c.json({ status: 'ok' }));
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -13,10 +13,26 @@ const SKIP_EXACT_PATHS = ['/api/drive/callback'];
 const SKIP_ALLOWED_CHECK_PATHS = ['/api/users/me'];
 
 /**
+ * isAllowed チェック共通処理
+ * usersテーブルに行が存在し、isAllowed=true であることを確認
+ */
+async function checkUserAllowed(db: Database, userId: string): Promise<'allowed' | 'forbidden'> {
+  const [user] = await db
+    .select({ isAllowed: users.isAllowed })
+    .from(users)
+    .where(eq(users.id, userId));
+
+  if (!user || !user.isAllowed) {
+    return 'forbidden';
+  }
+  return 'allowed';
+}
+
+/**
  * Clerk JWT検証ミドルウェア
  * Authorization: Bearer <token> からユーザーIDを抽出して c.set('userId', ...) にセット
  * サーバー間通信用に X-Internal-Key + X-Internal-User-Id ヘッダーも受け付ける
- * isAllowed=false のユーザーは拒否する
+ * isAllowed=false または行が存在しないユーザーは拒否する
  */
 export const authMiddleware = createMiddleware<
   Env & { Variables: { userId: string; db: Database } }
@@ -25,6 +41,8 @@ export const authMiddleware = createMiddleware<
   if (SKIP_PREFIX_PATHS.some((p) => path.startsWith(p)) || SKIP_EXACT_PATHS.includes(path)) {
     return next();
   }
+
+  const skipAllowedCheck = SKIP_ALLOWED_CHECK_PATHS.includes(path);
 
   // サーバー間通信（内部APIキー認証）
   const internalKey = c.req.header('X-Internal-Key');
@@ -35,6 +53,12 @@ export const authMiddleware = createMiddleware<
     c.env.INTERNAL_API_KEY &&
     internalKey === c.env.INTERNAL_API_KEY
   ) {
+    if (!skipAllowedCheck) {
+      const db = c.get('db');
+      if ((await checkUserAllowed(db, internalUserId)) === 'forbidden') {
+        return c.json({ error: 'Forbidden' }, 403);
+      }
+    }
     c.set('userId', internalUserId);
     return await next();
   }
@@ -48,29 +72,25 @@ export const authMiddleware = createMiddleware<
 
   const token = authHeader.slice(7);
 
+  // verifyToken のみ catch（DB参照/下流ハンドラの例外はグローバルエラーハンドラに委譲）
+  let userId: string;
   try {
     const payload = await verifyToken(token, {
       secretKey: c.env.CLERK_SECRET_KEY,
     });
-
-    const userId = payload.sub;
-
-    // isAllowed チェック（/me はID移行フローがあるためスキップ）
-    if (!SKIP_ALLOWED_CHECK_PATHS.includes(path)) {
-      const db = c.get('db');
-      const [user] = await db
-        .select({ isAllowed: users.isAllowed })
-        .from(users)
-        .where(eq(users.id, userId));
-
-      if (user && !user.isAllowed) {
-        return c.json({ error: 'Forbidden' }, 403);
-      }
-    }
-
-    c.set('userId', userId);
-    await next();
+    userId = payload.sub;
   } catch {
     return c.json({ error: 'Invalid token' }, 401);
   }
+
+  // isAllowed チェック（/me はID移行フローがあるためスキップ）
+  if (!skipAllowedCheck) {
+    const db = c.get('db');
+    if ((await checkUserAllowed(db, userId)) === 'forbidden') {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+  }
+
+  c.set('userId', userId);
+  await next();
 });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,8 +2,10 @@ import { createMiddleware } from 'hono/factory';
 import { verifyToken } from '@clerk/backend';
 import type { Env } from '../index';
 
-// ミドルウェアをスキップするパス
-const SKIP_PATHS = ['/api/files/', '/api/drive/callback'];
+// prefix一致でスキップするパス
+const SKIP_PREFIX_PATHS = ['/api/files/'];
+// 完全一致でスキップするパス（クエリパラメータは無視）
+const SKIP_EXACT_PATHS = ['/api/drive/callback'];
 
 /**
  * Clerk JWT検証ミドルウェア
@@ -12,7 +14,8 @@ const SKIP_PATHS = ['/api/files/', '/api/drive/callback'];
  */
 export const authMiddleware = createMiddleware<Env & { Variables: { userId: string } }>(
   async (c, next) => {
-    if (SKIP_PATHS.some((p) => c.req.path.startsWith(p))) {
+    const path = c.req.path;
+    if (SKIP_PREFIX_PATHS.some((p) => path.startsWith(p)) || SKIP_EXACT_PATHS.includes(path)) {
       return next();
     }
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,55 +1,76 @@
 import { createMiddleware } from 'hono/factory';
 import { verifyToken } from '@clerk/backend';
+import { eq } from 'drizzle-orm';
+import { users } from '../db/schema';
 import type { Env } from '../index';
+import type { Database } from '../db';
 
 // prefix一致でスキップするパス
 const SKIP_PREFIX_PATHS = ['/api/files/'];
 // 完全一致でスキップするパス（クエリパラメータは無視）
 const SKIP_EXACT_PATHS = ['/api/drive/callback'];
+// isAllowed チェックをスキップするパス（ID移行フローで未登録ユーザーがアクセスする）
+const SKIP_ALLOWED_CHECK_PATHS = ['/api/users/me'];
 
 /**
  * Clerk JWT検証ミドルウェア
  * Authorization: Bearer <token> からユーザーIDを抽出して c.set('userId', ...) にセット
  * サーバー間通信用に X-Internal-Key + X-Internal-User-Id ヘッダーも受け付ける
+ * isAllowed=false のユーザーは拒否する
  */
-export const authMiddleware = createMiddleware<Env & { Variables: { userId: string } }>(
-  async (c, next) => {
-    const path = c.req.path;
-    if (SKIP_PREFIX_PATHS.some((p) => path.startsWith(p)) || SKIP_EXACT_PATHS.includes(path)) {
-      return next();
-    }
-
-    // サーバー間通信（内部APIキー認証）
-    const internalKey = c.req.header('X-Internal-Key');
-    const internalUserId = c.req.header('X-Internal-User-Id');
-    if (
-      internalKey &&
-      internalUserId &&
-      c.env.INTERNAL_API_KEY &&
-      internalKey === c.env.INTERNAL_API_KEY
-    ) {
-      c.set('userId', internalUserId);
-      return await next();
-    }
-
-    // Clerk JWT認証
-    const authHeader = c.req.header('Authorization');
-
-    if (!authHeader?.startsWith('Bearer ')) {
-      return c.json({ error: 'Unauthorized' }, 401);
-    }
-
-    const token = authHeader.slice(7);
-
-    try {
-      const payload = await verifyToken(token, {
-        secretKey: c.env.CLERK_SECRET_KEY,
-      });
-
-      c.set('userId', payload.sub);
-      await next();
-    } catch {
-      return c.json({ error: 'Invalid token' }, 401);
-    }
+export const authMiddleware = createMiddleware<
+  Env & { Variables: { userId: string; db: Database } }
+>(async (c, next) => {
+  const path = c.req.path;
+  if (SKIP_PREFIX_PATHS.some((p) => path.startsWith(p)) || SKIP_EXACT_PATHS.includes(path)) {
+    return next();
   }
-);
+
+  // サーバー間通信（内部APIキー認証）
+  const internalKey = c.req.header('X-Internal-Key');
+  const internalUserId = c.req.header('X-Internal-User-Id');
+  if (
+    internalKey &&
+    internalUserId &&
+    c.env.INTERNAL_API_KEY &&
+    internalKey === c.env.INTERNAL_API_KEY
+  ) {
+    c.set('userId', internalUserId);
+    return await next();
+  }
+
+  // Clerk JWT認証
+  const authHeader = c.req.header('Authorization');
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const token = authHeader.slice(7);
+
+  try {
+    const payload = await verifyToken(token, {
+      secretKey: c.env.CLERK_SECRET_KEY,
+    });
+
+    const userId = payload.sub;
+
+    // isAllowed チェック（/me はID移行フローがあるためスキップ）
+    if (!SKIP_ALLOWED_CHECK_PATHS.includes(path)) {
+      const db = c.get('db');
+      const [user] = await db
+        .select({ isAllowed: users.isAllowed })
+        .from(users)
+        .where(eq(users.id, userId));
+
+      if (user && !user.isAllowed) {
+        return c.json({ error: 'Forbidden' }, 403);
+      }
+    }
+
+    c.set('userId', userId);
+    await next();
+  } catch {
+    return c.json({ error: 'Invalid token' }, 401);
+  }
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { verifyToken } from '@clerk/backend';
 import type { Env } from '../index';
 
 // ミドルウェアをスキップするパス
-const SKIP_PATHS = ['/api/files/'];
+const SKIP_PATHS = ['/api/files/', '/api/drive/callback'];
 
 /**
  * Clerk JWT検証ミドルウェア

--- a/backend/src/routes/drive.ts
+++ b/backend/src/routes/drive.ts
@@ -12,6 +12,193 @@ type DriveEnv = Env & {
 
 const app = new Hono<DriveEnv>();
 
+// --- OAuth HMAC署名ヘルパー（Web Crypto API） ---
+
+const STATE_MAX_AGE_MS = 10 * 60 * 1000; // 10分
+
+async function hmacSign(secret: string, data: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return btoa(String.fromCharCode(...new Uint8Array(sig)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+async function verifyHmac(secret: string, data: string, signatureB64: string): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+  const sigBytes = Uint8Array.from(atob(signatureB64.replace(/-/g, '+').replace(/_/g, '/')), (c) =>
+    c.charCodeAt(0)
+  );
+  return crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(data));
+}
+
+function buildOAuthState(userId: string, ts: number, sig: string): string {
+  return btoa(JSON.stringify({ userId, ts, sig }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function parseOAuthState(state: string): { userId: string; ts: number; sig: string } | null {
+  try {
+    const padded = state.replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(padded);
+    const parsed = JSON.parse(json);
+    if (
+      typeof parsed.userId === 'string' &&
+      typeof parsed.ts === 'number' &&
+      typeof parsed.sig === 'string'
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// --- OAuth エンドポイント ---
+
+const OAUTH_SCOPES = [
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/spreadsheets',
+].join(' ');
+
+/**
+ * GET /auth-url
+ * Google OAuth認証URLを生成して返却
+ */
+app.get('/auth-url', async (c) => {
+  const userId = c.get('userId');
+  const clientId = c.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = c.env.GOOGLE_OAUTH_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    return c.json({ error: 'OAuth configuration is incomplete' }, 500);
+  }
+
+  // redirect_uri をリクエストURLから動的構築
+  const url = new URL(c.req.url);
+  const redirectUri = `${url.protocol}//${url.host}/api/drive/callback`;
+
+  // HMAC署名付き state パラメータ生成
+  const ts = Date.now();
+  const sig = await hmacSign(clientSecret, `${userId}:${ts}`);
+  const state = buildOAuthState(userId, ts, sig);
+
+  const params = new globalThis.URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: OAUTH_SCOPES,
+    access_type: 'offline',
+    prompt: 'consent',
+    state,
+  });
+
+  return c.json({ url: `https://accounts.google.com/o/oauth2/v2/auth?${params}` });
+});
+
+/**
+ * GET /callback
+ * Google OAuthコールバック処理（認証不要 — SKIP_PATHSで除外）
+ * code → refresh_token交換 → DB保存 → フロントにリダイレクト
+ */
+app.get('/callback', async (c) => {
+  const db = c.get('db');
+  const code = c.req.query('code');
+  const stateParam = c.req.query('state');
+  const error = c.req.query('error');
+  const appOrigin = c.env.APP_ORIGIN;
+  const clientId = c.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = c.env.GOOGLE_OAUTH_CLIENT_SECRET;
+
+  const errorRedirect = (msg: string) =>
+    c.redirect(
+      `${appOrigin}/settings?tab=integrations&drive=error&message=${encodeURIComponent(msg)}`
+    );
+
+  if (error) {
+    return errorRedirect(
+      error === 'access_denied' ? 'Google認証が拒否されました' : `OAuth error: ${error}`
+    );
+  }
+
+  if (!code || !stateParam || !clientId || !clientSecret) {
+    return errorRedirect('不正なリクエストです');
+  }
+
+  // state パラメータ検証
+  const state = parseOAuthState(stateParam);
+  if (!state) {
+    return errorRedirect('不正なstateパラメータです');
+  }
+
+  // タイムスタンプ検証
+  if (Date.now() - state.ts > STATE_MAX_AGE_MS) {
+    return errorRedirect('認証リクエストが期限切れです。再度お試しください');
+  }
+
+  // HMAC署名検証
+  const valid = await verifyHmac(clientSecret, `${state.userId}:${state.ts}`, state.sig);
+  if (!valid) {
+    return errorRedirect('署名検証に失敗しました');
+  }
+
+  // redirect_uri をリクエストURLから動的構築
+  const url = new URL(c.req.url);
+  const redirectUri = `${url.protocol}//${url.host}/api/drive/callback`;
+
+  // code → token 交換
+  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new globalThis.URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    return errorRedirect('トークン交換に失敗しました');
+  }
+
+  const tokenData = (await tokenRes.json()) as { refresh_token?: string; access_token?: string };
+  if (!tokenData.refresh_token) {
+    return errorRedirect('リフレッシュトークンが取得できませんでした');
+  }
+
+  // DB に refresh_token 保存
+  await db
+    .update(users)
+    .set({
+      googleRefreshToken: tokenData.refresh_token,
+      googleOAuthUpdatedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, state.userId));
+
+  return c.redirect(`${appOrigin}/settings?tab=integrations&drive=connected`);
+});
+
+// --- Drive / Sheets ヘルパー ---
+
 const createFolderSchema = z.object({
   taskId: z.string(),
 });

--- a/backend/src/routes/drive.ts
+++ b/backend/src/routes/drive.ts
@@ -32,17 +32,22 @@ async function hmacSign(secret: string, data: string): Promise<string> {
 }
 
 async function verifyHmac(secret: string, data: string, signatureB64: string): Promise<boolean> {
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['verify']
-  );
-  const sigBytes = Uint8Array.from(atob(signatureB64.replace(/-/g, '+').replace(/_/g, '/')), (c) =>
-    c.charCodeAt(0)
-  );
-  return crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(data));
+  try {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+    const sigBytes = Uint8Array.from(
+      atob(signatureB64.replace(/-/g, '+').replace(/_/g, '/')),
+      (c) => c.charCodeAt(0)
+    );
+    return await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(data));
+  } catch {
+    return false;
+  }
 }
 
 function buildOAuthState(userId: string, ts: number, sig: string): string {

--- a/backend/src/routes/github.ts
+++ b/backend/src/routes/github.ts
@@ -14,58 +14,65 @@ const createIssueSchema = z.object({
   taskId: z.string(),
 });
 
+// --- 共通ヘルパー ---
+
+type UrlColumn = 'fireIssueUrl' | 'petIssueUrl';
+
+interface CreateIssueOpts {
+  repo: string;
+  urlColumn: UrlColumn;
+}
+
+const CREATING_MARKER = 'creating...';
+
 /**
- * POST /issues
- * タスクからGitHub Issueを作成
+ * GitHub Issue 作成の共通ロジック
+ * 楽観ロック + Issue作成 + URL保存
  */
-app.post('/issues', zValidator('json', createIssueSchema), async (c) => {
-  const db = c.get('db');
-  const { taskId } = c.req.valid('json');
+async function createGithubIssueForTask(
+  db: Database,
+  taskId: string,
+  githubToken: string,
+  opts: CreateIssueOpts
+) {
+  const { repo, urlColumn } = opts;
 
   // タスク取得
   const [task] = await db.select().from(tasks).where(eq(tasks.id, taskId));
-
   if (!task) {
-    return c.json({ error: 'Task not found' }, 404);
+    return { error: 'Task not found', status: 404 as const };
   }
 
   // 既に Issue が作成済みならスキップ
-  const CREATING_MARKER = 'creating...';
-  if (task.fireIssueUrl && task.fireIssueUrl !== CREATING_MARKER) {
-    return c.json({ success: true, url: task.fireIssueUrl, alreadyExists: true });
-  }
-
-  // GitHubトークンの確認（claim前に実施）
-  const githubToken = c.env.GITHUB_TOKEN;
-  if (!githubToken) {
-    return c.json({ error: 'GitHub token not configured' }, 500);
+  const existingUrl = task[urlColumn];
+  if (existingUrl && existingUrl !== CREATING_MARKER) {
+    return { success: true, url: existingUrl, alreadyExists: true };
   }
 
   // 楽観ロック: 作成中マーカーを原子的にセット（TOCTOU防止）
   const [claimed] = await db
     .update(tasks)
-    .set({ fireIssueUrl: CREATING_MARKER, updatedAt: new Date() })
-    .where(and(eq(tasks.id, taskId), isNull(tasks.fireIssueUrl)))
+    .set({ [urlColumn]: CREATING_MARKER, updatedAt: new Date() })
+    .where(and(eq(tasks.id, taskId), isNull(tasks[urlColumn])))
     .returning({ id: tasks.id });
 
   if (!claimed) {
-    // 別リクエストが先にclaimした
     const [current] = await db
-      .select({ fireIssueUrl: tasks.fireIssueUrl })
+      .select({ url: tasks[urlColumn] })
       .from(tasks)
       .where(eq(tasks.id, taskId));
-    if (!current?.fireIssueUrl || current.fireIssueUrl === CREATING_MARKER) {
-      return c.json({ error: 'Issue creation in progress' }, 409);
+    if (!current?.url || current.url === CREATING_MARKER) {
+      return { error: 'Issue creation in progress', status: 409 as const };
     }
-    return c.json({ success: true, url: current.fireIssueUrl, alreadyExists: true });
+    return { success: true, url: current.url, alreadyExists: true };
   }
 
   // マーカーをクリアするヘルパー
   const clearMarker = async () => {
     await db
       .update(tasks)
-      .set({ fireIssueUrl: null, updatedAt: new Date() })
-      .where(and(eq(tasks.id, taskId), eq(tasks.fireIssueUrl, CREATING_MARKER)));
+      .set({ [urlColumn]: null, updatedAt: new Date() })
+      .where(and(eq(tasks.id, taskId), eq(tasks[urlColumn], CREATING_MARKER)));
   };
 
   try {
@@ -102,7 +109,7 @@ app.post('/issues', zValidator('json', createIssueSchema), async (c) => {
       .join('\n\n');
 
     // GitHub API 呼び出し
-    const res = await fetch('https://api.github.com/repos/monosus/ss-fire-design-system/issues', {
+    const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
       method: 'POST',
       headers: {
         Authorization: `token ${githubToken}`,
@@ -120,7 +127,7 @@ app.post('/issues', zValidator('json', createIssueSchema), async (c) => {
     if (!res.ok) {
       await clearMarker();
       const errorText = await res.text();
-      return c.json({ error: `GitHub API error: ${errorText}` }, 500);
+      return { error: `GitHub API error: ${errorText}`, status: 500 as const };
     }
 
     const issueData = (await res.json()) as { html_url: string };
@@ -129,14 +136,62 @@ app.post('/issues', zValidator('json', createIssueSchema), async (c) => {
     // タスクにURLを保存
     await db
       .update(tasks)
-      .set({ fireIssueUrl: issueUrl, updatedAt: new Date() })
+      .set({ [urlColumn]: issueUrl, updatedAt: new Date() })
       .where(eq(tasks.id, taskId));
 
-    return c.json({ success: true, url: issueUrl });
+    return { success: true, url: issueUrl };
   } catch (error) {
     await clearMarker();
     throw error;
   }
+}
+
+/**
+ * POST /issues
+ * Fire Design System の GitHub Issue を作成
+ */
+app.post('/issues', zValidator('json', createIssueSchema), async (c) => {
+  const db = c.get('db');
+  const { taskId } = c.req.valid('json');
+  const githubToken = c.env.GITHUB_TOKEN;
+
+  if (!githubToken) {
+    return c.json({ error: 'GitHub token not configured' }, 500);
+  }
+
+  const result = await createGithubIssueForTask(db, taskId, githubToken, {
+    repo: 'monosus/ss-fire-design-system',
+    urlColumn: 'fireIssueUrl',
+  });
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status);
+  }
+  return c.json(result);
+});
+
+/**
+ * POST /pet-issues
+ * PET (sonysonpo-design-system-and-website) の GitHub Issue を作成
+ */
+app.post('/pet-issues', zValidator('json', createIssueSchema), async (c) => {
+  const db = c.get('db');
+  const { taskId } = c.req.valid('json');
+  const githubToken = c.env.GITHUB_TOKEN;
+
+  if (!githubToken) {
+    return c.json({ error: 'GitHub token not configured' }, 500);
+  }
+
+  const result = await createGithubIssueForTask(db, taskId, githubToken, {
+    repo: 'monosus/sonysonpo-design-system-and-website',
+    urlColumn: 'petIssueUrl',
+  });
+
+  if ('error' in result) {
+    return c.json({ error: result.error }, result.status);
+  }
+  return c.json(result);
 });
 
 export default app;

--- a/backend/src/routes/github.ts
+++ b/backend/src/routes/github.ts
@@ -133,15 +133,33 @@ async function createGithubIssueForTask(
     const issueData = (await res.json()) as { html_url: string };
     const issueUrl = issueData.html_url;
 
-    // タスクにURLを保存
-    await db
-      .update(tasks)
-      .set({ [urlColumn]: issueUrl, updatedAt: new Date() })
-      .where(eq(tasks.id, taskId));
+    // GitHub Issue 作成済み — DB保存失敗時はマーカーにURLを残して重複防止
+    try {
+      await db
+        .update(tasks)
+        .set({ [urlColumn]: issueUrl, updatedAt: new Date() })
+        .where(eq(tasks.id, taskId));
+    } catch (dbError) {
+      // URL をマーカーとして残す（次回リクエストで alreadyExists として返る）
+      await db
+        .update(tasks)
+        .set({ [urlColumn]: issueUrl, updatedAt: new Date() })
+        .where(eq(tasks.id, taskId))
+        .catch(() => {}); // 二重失敗は無視
+      throw dbError;
+    }
 
     return { success: true, url: issueUrl };
   } catch (error) {
-    await clearMarker();
+    // GitHub API 呼び出し前のエラーのみマーカークリア
+    // （Issue作成後のDB保存失敗はURLがマーカーとして残る）
+    const [current] = await db
+      .select({ url: tasks[urlColumn] })
+      .from(tasks)
+      .where(eq(tasks.id, taskId));
+    if (current?.url === CREATING_MARKER) {
+      await clearMarker();
+    }
     throw error;
   }
 }

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -193,6 +193,77 @@ app.put('/:id', zValidator('json', updateUserSchema), async (c) => {
   return c.json({ user: updated });
 });
 
+const inviteSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(userRoleEnum.enumValues),
+});
+
+/**
+ * POST /invite
+ * メンバー招待（Clerk Invitation API + DBプレースホルダー作成）
+ * admin権限が必要
+ */
+app.post('/invite', zValidator('json', inviteSchema), async (c) => {
+  const db = c.get('db');
+  const currentUserId = c.get('userId');
+  const { email, role } = c.req.valid('json');
+
+  // admin権限チェック
+  const [currentUser] = await db
+    .select({ role: users.role })
+    .from(users)
+    .where(eq(users.id, currentUserId));
+
+  if (!currentUser || currentUser.role !== 'admin') {
+    return c.json({ error: '管理者権限が必要です' }, 403);
+  }
+
+  // 既存メール重複チェック
+  const [existing] = await db
+    .select({ id: users.id, isAllowed: users.isAllowed })
+    .from(users)
+    .where(eq(users.email, email));
+
+  if (existing) {
+    // 無効化されたユーザーなら再有効化
+    if (!existing.isAllowed) {
+      await db
+        .update(users)
+        .set({ isAllowed: true, role, updatedAt: new Date() })
+        .where(eq(users.id, existing.id));
+      return c.json({ success: true, restored: true });
+    }
+    return c.json({ error: 'このメールアドレスは既に登録されています' }, 409);
+  }
+
+  // Clerk 招待送信
+  const clerkClient = createClerkClient({ secretKey: c.env.CLERK_SECRET_KEY });
+  const appOrigin = c.env.APP_ORIGIN;
+
+  try {
+    await clerkClient.invitations.createInvitation({
+      emailAddress: email,
+      redirectUrl: `${appOrigin}/login`,
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+    return c.json({ error: message }, 500);
+  }
+
+  // DBにプレースホルダーユーザー作成
+  // 招待ユーザーが初回ログインすると /me のID移行ロジックでClerk IDに更新される
+  const invitedId = `invited_${crypto.randomUUID()}`;
+  await db.insert(users).values({
+    id: invitedId,
+    email,
+    displayName: email.split('@')[0],
+    role,
+    isAllowed: true,
+  });
+
+  return c.json({ success: true });
+});
+
 /**
  * POST /me/fcm-tokens
  * FCMトークンを追加

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -236,7 +236,17 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
     return c.json({ error: 'このメールアドレスは既に登録されています' }, 409);
   }
 
-  // Clerk 招待送信
+  // DBにプレースホルダーユーザーを先に作成（整合性確保）
+  const invitedId = `invited_${crypto.randomUUID()}`;
+  await db.insert(users).values({
+    id: invitedId,
+    email,
+    displayName: email.split('@')[0],
+    role,
+    isAllowed: true,
+  });
+
+  // Clerk 招待送信（DB insert 成功後）
   const clerkClient = createClerkClient({ secretKey: c.env.CLERK_SECRET_KEY });
   const appOrigin = c.env.APP_ORIGIN;
 
@@ -246,20 +256,14 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       redirectUrl: `${appOrigin}/login`,
     });
   } catch (e) {
+    // Clerk失敗時はDBレコードを削除して補償
+    await db
+      .delete(users)
+      .where(eq(users.id, invitedId))
+      .catch(() => {});
     const message = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
     return c.json({ error: message }, 500);
   }
-
-  // DBにプレースホルダーユーザー作成
-  // 招待ユーザーが初回ログインすると /me のID移行ロジックでClerk IDに更新される
-  const invitedId = `invited_${crypto.randomUUID()}`;
-  await db.insert(users).values({
-    id: invitedId,
-    email,
-    displayName: email.split('@')[0],
-    role,
-    isAllowed: true,
-  });
 
   return c.json({ success: true });
 });

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -6,7 +6,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 
 export default [
   {
-    ignores: ['node_modules/**', 'dist/**'],
+    ignores: ['node_modules/**', 'dist/**', 'public/**'],
   },
   js.configs.recommended,
   {

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,30 @@
+// Service Worker for Web Push Notifications
+
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() ?? {};
+  const title = data.title || '通知';
+  const options = {
+    body: data.body || '',
+    icon: '/favicon.ico',
+    badge: '/favicon.ico',
+    data: data.data || {},
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.clickAction || '/';
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      // 既存のウィンドウがあればフォーカス
+      for (const client of windowClients) {
+        if (client.url.includes(url) && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      // なければ新しいウィンドウを開く
+      return clients.openWindow(url);
+    })
+  );
+});

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,18 +1,23 @@
 // Service Worker for Web Push Notifications
 
 self.addEventListener('push', (event) => {
-  let data = {};
+  let payload = {};
   try {
-    data = event.data?.json() ?? {};
+    payload = event.data?.json() ?? {};
   } catch {
     // 不正なJSONペイロードは無視
   }
-  const title = data.title || '通知';
+
+  // FCM notification + data 形式と、フラットな data 形式の両方に対応
+  const notification = payload.notification || {};
+  const data = payload.data || payload;
+
+  const title = notification.title || data.title || '通知';
   const options = {
-    body: data.body || '',
+    body: notification.body || data.body || '',
     icon: '/favicon.ico',
     badge: '/favicon.ico',
-    data: data.data || {},
+    data: data,
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
@@ -22,13 +27,11 @@ self.addEventListener('notificationclick', (event) => {
   const url = event.notification.data?.clickAction || '/';
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
-      // 既存のウィンドウがあればフォーカス
       for (const client of windowClients) {
         if (client.url.includes(url) && 'focus' in client) {
           return client.focus();
         }
       }
-      // なければ新しいウィンドウを開く
       return clients.openWindow(url);
     })
   );

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,7 +1,12 @@
 // Service Worker for Web Push Notifications
 
 self.addEventListener('push', (event) => {
-  const data = event.data?.json() ?? {};
+  let data = {};
+  try {
+    data = event.data?.json() ?? {};
+  } catch {
+    // 不正なJSONペイロードは無視
+  }
   const title = data.title || '通知';
   const options = {
     body: data.body || '',

--- a/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
@@ -57,14 +57,14 @@ export function DrawerActionBar({ task }: DrawerActionBarProps) {
         }
         mutation.mutate(task.id, {
           onSuccess: (data: { url?: string; alreadyExists?: boolean }) => {
-            if (data.url && !data.alreadyExists) {
+            if (data.url) {
               window.open(data.url, '_blank');
             }
           },
-          onError: (error: Error) => {
+          onError: (error: Error & { details?: Record<string, unknown> }) => {
             if (
               opts?.onAuthError &&
-              (error.message?.includes('requiresAuth') || error.message?.includes('認証が必要'))
+              (error as { details?: { requiresAuth?: boolean } }).details?.requiresAuth
             ) {
               opts.onAuthError();
             }

--- a/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
@@ -1,35 +1,85 @@
-import type { ReactNode } from 'react';
-import { Play, Square, ExternalLink, Folder, MessageCircle, Flame, PawPrint } from 'lucide-react';
+import { type ReactNode, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Play,
+  Square,
+  ExternalLink,
+  Folder,
+  MessageCircle,
+  Flame,
+  PawPrint,
+  Loader2,
+} from 'lucide-react';
+import type { UseMutationResult } from '@tanstack/react-query';
 import { useActiveSession, useTimer, useElapsedTime } from '../../../hooks/useTimer';
+import { useIntegrations } from '../../../hooks/useIntegrations';
+import type { Task } from '../../../types';
 
 interface DrawerActionBarProps {
-  taskId?: string;
-  projectType?: string;
+  task: Task;
 }
 
-export function DrawerActionBar({ taskId, projectType }: DrawerActionBarProps) {
+export function DrawerActionBar({ task }: DrawerActionBarProps) {
+  const navigate = useNavigate();
   const { data: activeSession } = useActiveSession();
   const { start, stop } = useTimer();
+  const { createDriveFolder, createChatThread, createFireIssue, createPetIssue } =
+    useIntegrations();
 
-  const isThisTaskActive =
-    activeSession != null && activeSession.taskId === taskId && taskId != null;
+  const isThisTaskActive = activeSession != null && activeSession.taskId === task.id;
   const isOtherTaskActive = activeSession != null && !isThisTaskActive;
   const { formatted } = useElapsedTime(
     isThisTaskActive && activeSession ? activeSession.startedAt : null
   );
 
   const handleTimerToggle = () => {
-    if (!taskId || !projectType) return;
-
     if (isThisTaskActive && activeSession) {
       stop.mutate({
         sessionId: activeSession.id,
-        projectType: activeSession.projectType ?? projectType,
+        projectType: activeSession.projectType ?? task.projectType,
       });
     } else {
-      start.mutate({ taskId, projectType });
+      start.mutate({ taskId: task.id, projectType: task.projectType });
     }
   };
+
+  // 統合ボタン共通ハンドラ生成
+  const makeIntegrationHandler = useCallback(
+    (
+      existingUrl: string | null | undefined,
+      mutation: UseMutationResult<any, any, string, any>,
+      opts?: { onAuthError?: () => void }
+    ) =>
+      () => {
+        if (existingUrl) {
+          window.open(existingUrl, '_blank');
+          return;
+        }
+        mutation.mutate(task.id, {
+          onSuccess: (data: { url?: string; alreadyExists?: boolean }) => {
+            if (data.url && !data.alreadyExists) {
+              window.open(data.url, '_blank');
+            }
+          },
+          onError: (error: Error) => {
+            if (
+              opts?.onAuthError &&
+              (error.message?.includes('requiresAuth') || error.message?.includes('認証が必要'))
+            ) {
+              opts.onAuthError();
+            }
+          },
+        });
+      },
+    [task.id]
+  );
+
+  const handleDriveClick = makeIntegrationHandler(task.googleDriveUrl, createDriveFolder, {
+    onAuthError: () => navigate('/settings?tab=integrations'),
+  });
+  const handleChatClick = makeIntegrationHandler(task.googleChatThreadUrl, createChatThread);
+  const handleFireClick = makeIntegrationHandler(task.fireIssueUrl, createFireIssue);
+  const handlePetClick = makeIntegrationHandler(task.petIssueUrl, createPetIssue);
 
   return (
     <div className="border-b border-border-default px-6 py-4 space-y-3">
@@ -68,19 +118,41 @@ export function DrawerActionBar({ taskId, projectType }: DrawerActionBarProps) {
       {/* 外部リンクボタングリッド */}
       <div className="space-y-2">
         <div className="grid grid-cols-2 gap-2">
-          <LinkButton icon={<Folder size={16} />} label="DRIVE作成" />
-          <LinkButton icon={<MessageCircle size={16} />} label="CHAT作成" />
+          <LinkButton
+            icon={<Folder size={16} />}
+            label={task.googleDriveUrl ? 'DRIVE開く' : 'DRIVE作成'}
+            onClick={handleDriveClick}
+            loading={createDriveFolder.isPending}
+          />
+          <LinkButton
+            icon={<MessageCircle size={16} />}
+            label={task.googleChatThreadUrl ? 'CHAT開く' : 'CHAT作成'}
+            onClick={handleChatClick}
+            loading={createChatThread.isPending}
+          />
         </div>
         <div className="grid grid-cols-2 gap-2">
-          <LinkButton icon={<Flame size={16} />} label="FIRE issue作成" />
-          <LinkButton icon={<PawPrint size={16} />} label="PET issue作成" />
+          <LinkButton
+            icon={<Flame size={16} />}
+            label={task.fireIssueUrl ? 'FIRE開く' : 'FIRE issue作成'}
+            onClick={handleFireClick}
+            loading={createFireIssue.isPending}
+          />
+          <LinkButton
+            icon={<PawPrint size={16} />}
+            label={task.petIssueUrl ? 'PET開く' : 'PET issue作成'}
+            onClick={handlePetClick}
+            loading={createPetIssue.isPending}
+          />
         </div>
       </div>
 
       {/* BACKLOGボタン */}
       <button
         type="button"
-        className="flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary-default text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+        onClick={() => task.backlogUrl && window.open(task.backlogUrl, '_blank')}
+        disabled={!task.backlogUrl}
+        className="flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary-default text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:opacity-40"
       >
         <ExternalLink size={16} />
         BACKLOGを開く
@@ -89,13 +161,25 @@ export function DrawerActionBar({ taskId, projectType }: DrawerActionBarProps) {
   );
 }
 
-function LinkButton({ icon, label }: { icon: ReactNode; label: string }) {
+function LinkButton({
+  icon,
+  label,
+  onClick,
+  loading,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick?: () => void;
+  loading?: boolean;
+}) {
   return (
     <button
       type="button"
-      className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-border-default text-xs font-medium text-text-secondary transition-colors hover:bg-bg-secondary"
+      onClick={onClick}
+      disabled={loading}
+      className="flex h-10 items-center justify-center gap-1.5 rounded-md border border-border-default text-xs font-medium text-text-secondary transition-colors hover:bg-bg-secondary disabled:opacity-40"
     >
-      {icon}
+      {loading ? <Loader2 size={16} className="animate-spin" /> : icon}
       {label}
     </button>
   );

--- a/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
@@ -12,11 +12,18 @@ import {
 } from 'lucide-react';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { useActiveSession, useTimer, useElapsedTime } from '../../../hooks/useTimer';
-import { useIntegrations } from '../../../hooks/useIntegrations';
+import { useIntegrations, type IntegrationResult } from '../../../hooks/useIntegrations';
+import { HttpError } from '../../../lib/api';
 import type { Task } from '../../../types';
+
+type IntegrationMutation = UseMutationResult<IntegrationResult, Error, string, unknown>;
 
 interface DrawerActionBarProps {
   task: Task;
+}
+
+function openExternal(url: string) {
+  window.open(url, '_blank', 'noopener,noreferrer');
 }
 
 export function DrawerActionBar({ task }: DrawerActionBarProps) {
@@ -47,25 +54,27 @@ export function DrawerActionBar({ task }: DrawerActionBarProps) {
   const makeIntegrationHandler = useCallback(
     (
       existingUrl: string | null | undefined,
-      mutation: UseMutationResult<any, any, string, any>,
+      mutation: IntegrationMutation,
       opts?: { onAuthError?: () => void }
     ) =>
       () => {
         if (existingUrl) {
-          window.open(existingUrl, '_blank');
+          openExternal(existingUrl);
           return;
         }
+        // ポップアップブロッカー対策: クリック時に同期的に空ウィンドウを開く
+        const newWindow = window.open('', '_blank', 'noopener,noreferrer');
         mutation.mutate(task.id, {
-          onSuccess: (data: { url?: string; alreadyExists?: boolean }) => {
-            if (data.url) {
-              window.open(data.url, '_blank');
+          onSuccess: (data) => {
+            if (data.url && newWindow && !newWindow.closed) {
+              newWindow.location.href = data.url;
+            } else if (data.url) {
+              openExternal(data.url);
             }
           },
-          onError: (error: Error & { details?: Record<string, unknown> }) => {
-            if (
-              opts?.onAuthError &&
-              (error as { details?: { requiresAuth?: boolean } }).details?.requiresAuth
-            ) {
+          onError: (error) => {
+            newWindow?.close();
+            if (opts?.onAuthError && error instanceof HttpError && error.details?.requiresAuth) {
               opts.onAuthError();
             }
           },
@@ -150,7 +159,7 @@ export function DrawerActionBar({ task }: DrawerActionBarProps) {
       {/* BACKLOGボタン */}
       <button
         type="button"
-        onClick={() => task.backlogUrl && window.open(task.backlogUrl, '_blank')}
+        onClick={() => task.backlogUrl && openExternal(task.backlogUrl)}
         disabled={!task.backlogUrl}
         className="flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary-default text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:opacity-40"
       >

--- a/frontend/src/components/shared/TaskDrawer/TaskDetailTab.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDetailTab.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
 import type { Task } from '../../../types';
 import { Badge } from '../../ui/Badge';
 import { Avatar } from '../../ui/Avatar';
@@ -96,6 +96,27 @@ export function TaskDetailTab({ task }: TaskDetailTabProps) {
         </div>
       </section>
 
+      {/* 外部連携 */}
+      {hasIntegrationUrls(task) && (
+        <>
+          <Divider />
+          <section className="py-3">
+            <SectionLabel>外部連携</SectionLabel>
+            <div className="mt-2 space-y-1.5">
+              {task.googleDriveUrl && (
+                <IntegrationLink label="Google Drive" url={task.googleDriveUrl} />
+              )}
+              {task.googleChatThreadUrl && (
+                <IntegrationLink label="Google Chat" url={task.googleChatThreadUrl} />
+              )}
+              {task.fireIssueUrl && <IntegrationLink label="Fire Issue" url={task.fireIssueUrl} />}
+              {task.petIssueUrl && <IntegrationLink label="PET Issue" url={task.petIssueUrl} />}
+              {task.backlogUrl && <IntegrationLink label="Backlog" url={task.backlogUrl} />}
+            </div>
+          </section>
+        </>
+      )}
+
       <Divider />
 
       {/* セッション履歴（Phase 5 で API 接続予定） */}
@@ -125,6 +146,30 @@ function PropertyValue({ children }: { children: ReactNode }) {
     <div className="flex h-8 flex-1 items-center justify-between rounded-sm bg-bg-secondary px-2.5">
       {children}
     </div>
+  );
+}
+
+function IntegrationLink({ label, url }: { label: string; url: string }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm text-primary-default transition-colors hover:bg-bg-brand-subtle"
+    >
+      <ExternalLink size={14} />
+      {label}
+    </a>
+  );
+}
+
+function hasIntegrationUrls(task: Task): boolean {
+  return !!(
+    task.googleDriveUrl ||
+    task.googleChatThreadUrl ||
+    task.fireIssueUrl ||
+    task.petIssueUrl ||
+    task.backlogUrl
   );
 }
 

--- a/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
+++ b/frontend/src/components/shared/TaskDrawer/TaskDrawer.tsx
@@ -115,7 +115,7 @@ export function TaskDrawer({
                     onDelete={handleDeleteRequest}
                     isDeleting={deleteTask.isPending}
                   />
-                  <DrawerActionBar taskId={task.id} projectType={task.projectType} />
+                  <DrawerActionBar task={task} />
                   <DrawerTabBar
                     detailTabLabel={detailTabLabel}
                     detailContent={detailContent ?? <TaskDetailTab task={task} />}

--- a/frontend/src/hooks/useIntegrations.ts
+++ b/frontend/src/hooks/useIntegrations.ts
@@ -3,7 +3,7 @@ import { apiClient } from '../lib/api';
 import { queryKeys } from '../lib/queryKeys';
 import { useAuth } from './useAuth';
 
-interface IntegrationResult {
+export interface IntegrationResult {
   success: boolean;
   url: string;
   alreadyExists?: boolean;

--- a/frontend/src/hooks/useIntegrations.ts
+++ b/frontend/src/hooks/useIntegrations.ts
@@ -1,0 +1,66 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+
+interface IntegrationResult {
+  success: boolean;
+  url: string;
+  alreadyExists?: boolean;
+  requiresAuth?: boolean;
+  warning?: string;
+}
+
+/**
+ * タスクドロワーの外部連携ボタン用 mutation hooks
+ */
+export function useIntegrations() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  const invalidateTasks = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.tasks() });
+  };
+
+  const createDriveFolder = useMutation({
+    mutationFn: (taskId: string) =>
+      apiClient<IntegrationResult>('/api/drive/folders', {
+        method: 'POST',
+        body: { taskId },
+        getToken,
+      }),
+    onSuccess: invalidateTasks,
+  });
+
+  const createChatThread = useMutation({
+    mutationFn: (taskId: string) =>
+      apiClient<IntegrationResult>('/api/chat/threads', {
+        method: 'POST',
+        body: { taskId },
+        getToken,
+      }),
+    onSuccess: invalidateTasks,
+  });
+
+  const createFireIssue = useMutation({
+    mutationFn: (taskId: string) =>
+      apiClient<IntegrationResult>('/api/github/issues', {
+        method: 'POST',
+        body: { taskId },
+        getToken,
+      }),
+    onSuccess: invalidateTasks,
+  });
+
+  const createPetIssue = useMutation({
+    mutationFn: (taskId: string) =>
+      apiClient<IntegrationResult>('/api/github/pet-issues', {
+        method: 'POST',
+        body: { taskId },
+        getToken,
+      }),
+    onSuccess: invalidateTasks,
+  });
+
+  return { createDriveFolder, createChatThread, createFireIssue, createPetIssue };
+}

--- a/frontend/src/hooks/useInviteUser.ts
+++ b/frontend/src/hooks/useInviteUser.ts
@@ -13,7 +13,7 @@ export function useInviteUser() {
 
   return useMutation({
     mutationFn: ({ email, role }: { email: string; role: 'admin' | 'member' }) =>
-      apiClient<{ success: boolean }>('/api/users/invite', {
+      apiClient<{ success: boolean; restored?: boolean }>('/api/users/invite', {
         method: 'POST',
         body: { email, role },
         getToken,

--- a/frontend/src/hooks/useInviteUser.ts
+++ b/frontend/src/hooks/useInviteUser.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+
+/**
+ * メンバー招待
+ * POST /api/users/invite
+ */
+export function useInviteUser() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ email, role }: { email: string; role: 'admin' | 'member' }) =>
+      apiClient<{ success: boolean }>('/api/users/invite', {
+        method: 'POST',
+        body: { email, role },
+        getToken,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.users() });
+    },
+  });
+}

--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -1,0 +1,134 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { useAuth } from './useAuth';
+
+/**
+ * Web Push 通知の購読管理
+ * - ブラウザの通知権限状態を監視
+ * - Service Worker 登録 + Push 購読の開始/停止
+ * - バックエンドへの subscription 登録/削除
+ *
+ * VAPID キー未設定時: ブラウザ通知許可 + バックエンドに「有効」フラグとして保存
+ */
+export function usePushNotifications() {
+  const { getToken } = useAuth();
+  const [permission, setPermission] = useState<NotificationPermission>('default');
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [isSupported, setIsSupported] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // マウント時に権限状態 + 既存 subscription を確認
+  useEffect(() => {
+    if (!('Notification' in window)) {
+      setIsSupported(false);
+      return;
+    }
+    setPermission(Notification.permission);
+
+    // Service Worker がある場合は既存 subscription を確認
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.ready
+        .then((reg) => reg.pushManager.getSubscription())
+        .then((sub) => {
+          if (sub) setIsSubscribed(true);
+        })
+        .catch(() => {});
+    }
+  }, []);
+
+  const subscribe = useMutation({
+    mutationFn: async () => {
+      setError(null);
+
+      // ブラウザ通知許可をリクエスト
+      const perm = await Notification.requestPermission();
+      setPermission(perm);
+      if (perm !== 'granted') {
+        throw new Error('通知の許可が拒否されました');
+      }
+
+      const vapidKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+
+      // VAPID キーがある場合: フル Web Push 購読
+      if (vapidKey && 'serviceWorker' in navigator) {
+        const reg = await navigator.serviceWorker.register('/sw.js');
+        await navigator.serviceWorker.ready;
+
+        const sub = await reg.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: vapidKey,
+        });
+
+        await apiClient('/api/users/me/fcm-tokens', {
+          method: 'POST',
+          body: { token: sub.endpoint },
+          getToken,
+        });
+      } else {
+        // VAPID キー未設定: 通知許可状態だけバックエンドに保存
+        await apiClient('/api/users/me/fcm-tokens', {
+          method: 'POST',
+          body: { token: `notification-granted-${Date.now()}` },
+          getToken,
+        });
+      }
+
+      setIsSubscribed(true);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : '通知の設定に失敗しました');
+    },
+  });
+
+  const unsubscribe = useMutation({
+    mutationFn: async () => {
+      setError(null);
+
+      if ('serviceWorker' in navigator) {
+        try {
+          const reg = await navigator.serviceWorker.ready;
+          const sub = await reg.pushManager.getSubscription();
+          if (sub) {
+            await apiClient('/api/users/me/fcm-tokens', {
+              method: 'DELETE',
+              body: { token: sub.endpoint },
+              getToken,
+            });
+            await sub.unsubscribe();
+          }
+        } catch {
+          // Service Worker 未登録の場合は無視
+        }
+      }
+
+      setIsSubscribed(false);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : '通知の解除に失敗しました');
+    },
+  });
+
+  // subscribe/unsubscribe は useMutation の戻り値で毎回新オブジェクトになるため deps に入れない
+  const subscribeMutate = subscribe.mutate;
+  const unsubscribeMutate = unsubscribe.mutate;
+  const toggle = useCallback(
+    (enabled: boolean) => {
+      if (enabled) {
+        subscribeMutate();
+      } else {
+        unsubscribeMutate();
+      }
+    },
+    [subscribeMutate, unsubscribeMutate]
+  );
+
+  return {
+    isSupported,
+    permission,
+    isSubscribed,
+    isPending: subscribe.isPending || unsubscribe.isPending,
+    error,
+    toggle,
+  };
+}

--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -8,8 +8,6 @@ import { useAuth } from './useAuth';
  * - ブラウザの通知権限状態を監視
  * - Service Worker 登録 + Push 購読の開始/停止
  * - バックエンドへの subscription 登録/削除
- *
- * VAPID キー未設定時: ブラウザ通知許可 + バックエンドに「有効」フラグとして保存
  */
 export function usePushNotifications() {
   const { getToken } = useAuth();
@@ -26,10 +24,11 @@ export function usePushNotifications() {
     }
     setPermission(Notification.permission);
 
-    // Service Worker がある場合は既存 subscription を確認
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.ready
-        .then((reg) => reg.pushManager.getSubscription())
+      // getRegistration で登録有無を安全に確認（ready と違いハングしない）
+      navigator.serviceWorker
+        .getRegistration()
+        .then((reg) => reg?.pushManager.getSubscription())
         .then((sub) => {
           if (sub) setIsSubscribed(true);
         })
@@ -41,7 +40,6 @@ export function usePushNotifications() {
     mutationFn: async () => {
       setError(null);
 
-      // ブラウザ通知許可をリクエスト
       const perm = await Notification.requestPermission();
       setPermission(perm);
       if (perm !== 'granted') {
@@ -50,8 +48,8 @@ export function usePushNotifications() {
 
       const vapidKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
 
-      // VAPID キーがある場合: フル Web Push 購読
       if (vapidKey && 'serviceWorker' in navigator) {
+        // フル Web Push 購読
         const reg = await navigator.serviceWorker.register('/sw.js');
         await navigator.serviceWorker.ready;
 
@@ -65,14 +63,8 @@ export function usePushNotifications() {
           body: { token: sub.endpoint },
           getToken,
         });
-      } else {
-        // VAPID キー未設定: 通知許可状態だけバックエンドに保存
-        await apiClient('/api/users/me/fcm-tokens', {
-          method: 'POST',
-          body: { token: `notification-granted-${Date.now()}` },
-          getToken,
-        });
       }
+      // VAPID未設定: 通知許可のみ（バックエンドにはトークン保存しない）
 
       setIsSubscribed(true);
     },
@@ -86,8 +78,9 @@ export function usePushNotifications() {
       setError(null);
 
       if ('serviceWorker' in navigator) {
-        try {
-          const reg = await navigator.serviceWorker.ready;
+        // getRegistration で安全にチェック（未登録ならnull、ハングしない）
+        const reg = await navigator.serviceWorker.getRegistration();
+        if (reg) {
           const sub = await reg.pushManager.getSubscription();
           if (sub) {
             await apiClient('/api/users/me/fcm-tokens', {
@@ -97,8 +90,6 @@ export function usePushNotifications() {
             });
             await sub.unsubscribe();
           }
-        } catch {
-          // Service Worker 未登録の場合は無視
         }
       }
 
@@ -109,7 +100,6 @@ export function usePushNotifications() {
     },
   });
 
-  // subscribe/unsubscribe は useMutation の戻り値で毎回新オブジェクトになるため deps に入れない
   const subscribeMutate = subscribe.mutate;
   const unsubscribeMutate = unsubscribe.mutate;
   const toggle = useCallback(

--- a/frontend/src/pages/settings/components/AdminTab.tsx
+++ b/frontend/src/pages/settings/components/AdminTab.tsx
@@ -100,7 +100,7 @@ export function AdminTab() {
       {
         onSuccess: (data) => {
           setAddModalOpen(false);
-          const msg = (data as { restored?: boolean }).restored
+          const msg = data.restored
             ? `${email} のアカウントを再有効化しました`
             : `${email} に招待メールを送信しました`;
           setInviteMessage({ type: 'success', text: msg });

--- a/frontend/src/pages/settings/components/AdminTab.tsx
+++ b/frontend/src/pages/settings/components/AdminTab.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Plus, Trash2, ChevronDown, Check } from 'lucide-react';
+import { useState, useMemo } from 'react';
+import { Plus, Trash2, RotateCcw, ChevronDown, Check } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import { Button } from '../../../components/ui/Button';
 import { Spinner } from '../../../components/ui/Spinner';
@@ -8,6 +8,7 @@ import { DeleteMemberModal } from './DeleteMemberModal';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { useUsers } from '../../../hooks/useUsers';
 import { useUpdateUser } from '../../../hooks/useUpdateUser';
+import { useInviteUser } from '../../../hooks/useInviteUser';
 import type { User } from '../../../types';
 
 const TABLE_COLUMNS = [
@@ -80,17 +81,36 @@ export function AdminTab() {
   const { data: currentUser } = useCurrentUser();
   const { data: users = [], isLoading } = useUsers();
   const updateUser = useUpdateUser();
+  const inviteUser = useInviteUser();
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
+  const [inviteMessage, setInviteMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
 
   const handleRoleChange = (userId: string, role: 'admin' | 'member') => {
     if (userId === currentUser?.id) return;
     updateUser.mutate({ userId, data: { role } });
   };
 
-  const handleAddMember = (_email: string, _role: 'Admin' | 'Member') => {
-    // TODO: メンバー追加 API（Clerk ユーザー招待）
-    setAddModalOpen(false);
+  const handleAddMember = (email: string, role: 'Admin' | 'Member') => {
+    inviteUser.mutate(
+      { email, role: role.toLowerCase() as 'admin' | 'member' },
+      {
+        onSuccess: (data) => {
+          setAddModalOpen(false);
+          const msg = (data as { restored?: boolean }).restored
+            ? `${email} のアカウントを再有効化しました`
+            : `${email} に招待メールを送信しました`;
+          setInviteMessage({ type: 'success', text: msg });
+        },
+        onError: (error) => {
+          const msg = error instanceof Error ? error.message : '招待に失敗しました';
+          setInviteMessage({ type: 'error', text: msg });
+        },
+      }
+    );
   };
 
   const handleDeleteMember = () => {
@@ -98,6 +118,13 @@ export function AdminTab() {
     updateUser.mutate({ userId: deleteTarget.id, data: { isAllowed: false } });
     setDeleteTarget(null);
   };
+
+  const handleRestoreMember = (userId: string) => {
+    updateUser.mutate({ userId, data: { isAllowed: true } });
+  };
+
+  const activeUsers = useMemo(() => users.filter((u) => u.isAllowed), [users]);
+  const disabledUsers = useMemo(() => users.filter((u) => !u.isAllowed), [users]);
 
   if (isLoading) {
     return (
@@ -127,6 +154,18 @@ export function AdminTab() {
         </Button>
       </div>
 
+      {inviteMessage && (
+        <div
+          className={`rounded-md px-4 py-3 text-sm ${
+            inviteMessage.type === 'success'
+              ? 'bg-green-50 text-green-700 border border-green-200'
+              : 'bg-red-50 text-red-700 border border-red-200'
+          }`}
+        >
+          {inviteMessage.text}
+        </div>
+      )}
+
       <div className="overflow-hidden rounded-lg border border-border-default bg-bg-primary">
         <div className="flex h-11 items-center gap-4 px-5">
           {TABLE_COLUMNS.map((col) => (
@@ -139,7 +178,7 @@ export function AdminTab() {
           ))}
         </div>
 
-        {users.map((user) => (
+        {activeUsers.map((user) => (
           <div
             key={user.id}
             className="flex h-[52px] items-center gap-4 border-t border-border-default px-5"
@@ -171,6 +210,39 @@ export function AdminTab() {
           </div>
         ))}
       </div>
+
+      {disabledUsers.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium text-text-tertiary">無効化されたメンバー</h3>
+          <div className="overflow-hidden rounded-lg border border-border-default bg-bg-secondary">
+            {disabledUsers.map((user) => (
+              <div
+                key={user.id}
+                className="flex h-[52px] items-center gap-4 border-t border-border-default px-5 first:border-t-0 opacity-60"
+              >
+                <span className="w-[230px] truncate text-sm text-text-tertiary">
+                  {user.displayName}
+                </span>
+                <span className="w-[240px] truncate text-sm text-text-tertiary">{user.email}</span>
+                <span className="w-[170px] truncate text-sm text-text-tertiary">
+                  {user.chatId ?? '-'}
+                </span>
+                <span className="w-[100px] text-xs text-text-tertiary">無効</span>
+                <div className="w-[76px]">
+                  <button
+                    type="button"
+                    onClick={() => handleRestoreMember(user.id)}
+                    className="flex h-7 w-full items-center justify-center gap-1.5 rounded-md border border-border-default text-xs font-medium text-text-secondary transition-colors hover:bg-bg-primary"
+                  >
+                    <RotateCcw size={12} />
+                    復元
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <AddMemberModal
         isOpen={addModalOpen}

--- a/frontend/src/pages/settings/components/IntegrationsTab.tsx
+++ b/frontend/src/pages/settings/components/IntegrationsTab.tsx
@@ -1,9 +1,12 @@
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useAuth } from '@clerk/clerk-react';
 import { HardDrive, Github, MessageCircle } from 'lucide-react';
 import { Button } from '../../../components/ui/Button';
 import { Spinner } from '../../../components/ui/Spinner';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { useUpdateUser } from '../../../hooks/useUpdateUser';
+import { apiClient } from '../../../lib/api';
 
 interface IntegrationCardProps {
   icon: React.ReactNode;
@@ -82,9 +85,16 @@ function IntegrationCard({
 export function IntegrationsTab() {
   const { data: currentUser, isLoading } = useCurrentUser();
   const updateUser = useUpdateUser();
+  const { getToken } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [githubUsername, setGithubUsername] = useState('');
   const [chatUserId, setChatUserId] = useState('');
+  const [driveConnecting, setDriveConnecting] = useState(false);
+  const [driveMessage, setDriveMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
 
   useEffect(() => {
     if (currentUser) {
@@ -93,7 +103,36 @@ export function IntegrationsTab() {
     }
   }, [currentUser]);
 
+  // OAuth コールバック結果の検知
+  useEffect(() => {
+    const driveStatus = searchParams.get('drive');
+    if (driveStatus === 'connected') {
+      setDriveMessage({ type: 'success', text: 'Google Driveとの連携が完了しました' });
+      searchParams.delete('drive');
+      setSearchParams(searchParams, { replace: true });
+    } else if (driveStatus === 'error') {
+      const msg = searchParams.get('message') || '連携に失敗しました';
+      setDriveMessage({ type: 'error', text: msg });
+      searchParams.delete('drive');
+      searchParams.delete('message');
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
   const driveConnected = currentUser?.googleOAuthUpdatedAt != null;
+
+  const handleDriveConnect = async () => {
+    setDriveConnecting(true);
+    try {
+      const data = await apiClient<{ url: string }>('/api/drive/auth-url', {
+        getToken,
+      });
+      window.location.href = data.url;
+    } catch {
+      setDriveMessage({ type: 'error', text: 'OAuth URL の取得に失敗しました' });
+      setDriveConnecting(false);
+    }
+  };
 
   const handleSaveGithub = () => {
     if (!currentUser) return;
@@ -120,13 +159,25 @@ export function IntegrationsTab() {
         <p className="text-sm text-text-secondary">外部サービスとの連携を管理します</p>
       </div>
 
+      {driveMessage && (
+        <div
+          className={`rounded-md px-4 py-3 text-sm ${
+            driveMessage.type === 'success'
+              ? 'bg-green-50 text-green-700 border border-green-200'
+              : 'bg-red-50 text-red-700 border border-red-200'
+          }`}
+        >
+          {driveMessage.text}
+        </div>
+      )}
+
       <IntegrationCard
         icon={<HardDrive size={20} className="text-blue-600" />}
         iconBg="bg-blue-50"
         name="Google Drive"
         description="レポートの自動エクスポート先"
         connected={driveConnected}
-        onConnect={() => {}}
+        onConnect={driveConnecting ? undefined : handleDriveConnect}
       />
 
       <IntegrationCard

--- a/frontend/src/pages/settings/components/IntegrationsTab.tsx
+++ b/frontend/src/pages/settings/components/IntegrationsTab.tsx
@@ -49,9 +49,14 @@ function IntegrationCard({
         {onConnect &&
           !inputField &&
           (connected ? (
-            <span className="flex h-9 items-center rounded-md border border-green-200 bg-green-50 px-4 text-xs font-medium text-green-700">
-              {'✓ 連携済み'}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className="flex h-9 items-center rounded-md border border-green-200 bg-green-50 px-4 text-xs font-medium text-green-700">
+                {'✓ 連携済み'}
+              </span>
+              <Button variant="outline" size="md" className="text-xs" onPress={onConnect}>
+                再連携
+              </Button>
+            </div>
           ) : (
             <Button variant="primary" size="md" className="text-xs gap-1.5" onPress={onConnect}>
               連携する
@@ -175,7 +180,11 @@ export function IntegrationsTab() {
         icon={<HardDrive size={20} className="text-blue-600" />}
         iconBg="bg-blue-50"
         name="Google Drive"
-        description="レポートの自動エクスポート先"
+        description={
+          driveConnected
+            ? 'レポートの自動エクスポート先（連携済み）'
+            : 'レポートの自動エクスポート先'
+        }
         connected={driveConnected}
         onConnect={driveConnecting ? undefined : handleDriveConnect}
       />

--- a/frontend/src/pages/settings/components/NotificationsTab.tsx
+++ b/frontend/src/pages/settings/components/NotificationsTab.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import { BellRing } from 'lucide-react';
 import { cn } from '../../../lib/utils';
+import { usePushNotifications } from '../../../hooks/usePushNotifications';
 
 interface ToggleSwitchProps {
   checked: boolean;
@@ -40,13 +40,17 @@ function ToggleSwitch({
 }
 
 export function NotificationsTab() {
-  const [pushEnabled, setPushEnabled] = useState(true);
-  const [permissionDenied] = useState(false);
+  const { isSupported, permission, isSubscribed, isPending, error, toggle } =
+    usePushNotifications();
 
-  const isDisabled = permissionDenied;
-  const descText = isDisabled
-    ? 'ブラウザの設定から通知を許可してください'
-    : 'タスクの更新やメンションを受け取ります';
+  const isDenied = permission === 'denied';
+  const isDisabled = !isSupported || isDenied || isPending;
+
+  const descText = !isSupported
+    ? 'このブラウザはプッシュ通知に対応していません'
+    : isDenied
+      ? 'ブラウザの設定から通知を許可してください'
+      : 'タスクの更新やメンションを受け取ります';
 
   return (
     <div className="flex flex-col gap-6 py-8 px-10">
@@ -55,6 +59,12 @@ export function NotificationsTab() {
         <h2 className="text-xl font-bold text-text-primary">通知設定</h2>
         <p className="text-sm text-text-secondary">プッシュ通知の受信設定を管理します</p>
       </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
 
       {/* Push Notification Card */}
       <div className="flex items-center justify-between rounded-lg border border-border-default bg-bg-primary p-5">
@@ -66,14 +76,19 @@ export function NotificationsTab() {
             <span id="push-notifications-label" className="text-sm font-medium text-text-primary">
               プッシュ通知
             </span>
-            <span className={cn('text-xs', isDisabled ? 'text-amber-600' : 'text-text-secondary')}>
+            <span
+              className={cn(
+                'text-xs',
+                !isSupported || isDenied ? 'text-amber-600' : 'text-text-secondary'
+              )}
+            >
               {descText}
             </span>
           </div>
         </div>
         <ToggleSwitch
-          checked={!isDisabled && pushEnabled}
-          onChange={setPushEnabled}
+          checked={isSubscribed}
+          onChange={toggle}
           disabled={isDisabled}
           aria-labelledby="push-notifications-label"
         />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,6 +105,7 @@ export interface Task {
   fireIssueUrl?: string | null;
   googleChatThreadUrl?: string | null;
   backlogUrl?: string | null;
+  petIssueUrl?: string | null;
   dueDate?: Date | null;
   priority?: Priority | null;
   order: number;


### PR DESCRIPTION
## Summary
- **#122** Google Drive OAuth連携フロー（auth-url / callback / HMAC署名検証）
- **#123** メンバー追加機能（Clerk Invitation API + 無効化ユーザー再有効化）
- **#124** 外部連携ボタンAPI接続（Drive/Chat/Fire/PET + TaskDetailTab URL表示）
- **#125** Web Pushプッシュ通知設定（Service Worker + subscription管理）
- エラーハンドラ追加（本番ではスタックトレース非公開）
- `.dev.vars` を `.gitignore` に追加

## 手動設定が必要な項目
- Google Cloud Console: リダイレクトURI登録（`/api/drive/callback`）
- VAPIDキー生成 + 環境変数設定（`VITE_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`）
- DBマイグレーション: `cd backend && bun run db:generate && bun run db:migrate`

## Test plan
- [x] `cd frontend && bun run type-check` 通過
- [x] `cd frontend && bun run lint` 通過
- [x] `cd backend && bun run test` 86テスト全パス
- [x] ブラウザ動作確認: ダッシュボード/タスク一覧表示
- [x] メンバー追加/削除/再有効化の動作確認
- [x] FIRE/PET issue作成ボタンの動作確認
- [x] プッシュ通知トグルON/OFFの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Google DriveのOAuth連携を導入（接続フローとコールバック対応）。
  * メール招待によるユーザー招待機能を実装。
  * Web Push通知を追加（Service Workerで受信・クリック処理を実装）。
  * GitHubのPETリポジトリへIssue作成できる機能を追加。

* **改善**
  * タスク詳細に外部連携リンクを表示（存在する連携のみ表示）。
  * 統合ボタンに読み込みインジケータと無効化状態を追加。
  * 管理画面に無効化メンバーの復元と招待結果フィードバックを追加。
  * 通知設定で購読のオン／オフ管理を強化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->