### PR TITLE
🔧 Cloudflare Workers/Pages デプロイ対応

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -6,7 +6,7 @@ import type { Env } from '../index';
 import type { Database } from '../db';
 
 // prefix一致でスキップするパス
-const SKIP_PREFIX_PATHS = ['/api/files/'];
+const SKIP_PREFIX_PATHS = ['/api/files/', '/api/backlog/webhook'];
 // 完全一致でスキップするパス（クエリパラメータは無視）
 const SKIP_EXACT_PATHS = ['/api/drive/callback'];
 // isAllowed チェックをスキップするパス（ID移行フローで未登録ユーザーがアクセスする）

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
@@ -469,6 +470,8 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -618,6 +621,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",


### PR DESCRIPTION
## Summary
- Backlog webhookの認証スキップを追加（`/api/backlog/webhook` を `SKIP_PREFIX_PATHS` に追加）
- フロントエンドのビルドに必要な `@types/node` を devDependencies に追加

## 背景
Cloudflare Workers/Pagesへの初回デプロイに伴い、以下の対応を実施:
- Workers: Backlogからのwebhookリクエストが認証なしで通るように修正
- Pages: npm環境でのビルドエラー（`path`, `__dirname` 未解決）を修正

## デプロイ済み環境
- API (Workers): `https://chumo-api.y-yamamoto-ced.workers.dev`
- フロント (Pages): `https://chumo-ekd.pages.dev`
- DB: Neon staging ブランチに Firestore データ移行済み

## Test plan
- [x] Workers デプロイ・動作確認
- [x] Backlog webhook 疎通テスト
- [x] Pages デプロイ・CORS確認
- [x] Firestore → Neon データ移行（staging）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **その他**
  * 認証ミドルウェアの処理フローを調整し、特定のエンドポイントの処理要件を更新しました。
  * フロントエンド開発環境の依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->