### PR TITLE
プレビューモード・シード・Docker統一・ドキュメント整備

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -5,7 +5,7 @@
 ## 前提条件
 
 - [Bun](https://bun.sh/) がインストールされていること
-- [Docker](https://www.docker.com/) がインストールされていること（ローカルDB用���
+- [Docker](https://www.docker.com/) がインストールされていること（ローカルDB用）
 - [gitleaks](https://github.com/gitleaks/gitleaks) がインストールされていること（機密情報チェック用）
 
 ## 1. 依存関係のインストール
@@ -58,7 +58,7 @@ brew install gitleaks
 
 ### lefthookの自動セットアップ
 
-`bun install` を実行すると、`prepare` スクリプトによ���自動的にlefthookがセットアップされます。
+`bun install` を実行すると、`prepare` スクリプトにより自動的にlefthookがセットアップされます。
 
 ### pre-commitで実行されるチェック
 
@@ -67,17 +67,50 @@ brew install gitleaks
 3. **tsc**: 型チェック（フロントエンド + バックエンド）
 4. **oxfmt**: コードフォーマット（自動修正あり）
 
-## 4. 開発サーバーの起動
+## 4. ローカルDBの起動とセットアップ
+
+ローカル開発には Docker で PostgreSQL を起動します。
 
 ```bash
-# フロントエンド + ��ックエンド同時起動
+# PostgreSQL コンテナを起動（初回は自動でイメージをダウンロード）
+docker compose up -d postgres
+
+# テーブル作成（Drizzle スキーマを直接反映）
+DATABASE_URL=postgresql://chumo:chumo_dev@localhost:5432/chumo_dev \
+  bunx drizzle-kit push --force
+```
+
+初回起動時にテスト用DB `chumo_test` も自動作成されます（`scripts/init-test-db.sh`）。
+
+### シードデータの投入
+
+デモ用のユーザー・タスク・セッションなどを投入できます。
+
+```bash
+bun run db:seed              # ローカルDBに投入
+bun run db:seed:staging      # Neon staging DBに投入
+```
+
+### Neon（staging）からデータを同期
+
+本番に近いデータで開発したい場合:
+
+```bash
+# backend/.env.neon に DATABASE_URL=postgresql://... を記載してから
+bun run db:sync-from-neon
+```
+
+## 5. 開発サーバーの起動
+
+```bash
+# フロントエンド + バックエンド同時起動（DBも自動起動）
 bun run dev
 ```
 
 - フロントエンド: `http://localhost:3000`
 - バックエンド: `http://localhost:8787`
 
-## 5. GitHub CLIの設定
+## 6. GitHub CLIの設定
 
 PRやIssueの確認にGitHub CLIを使用します。
 
@@ -100,6 +133,9 @@ bun run test              # バックエンドテスト
 bun run backend:deploy    # バックエンドデプロイ
 bun run backend:db:generate  # Drizzle マイグレーション生成
 bun run backend:db:migrate   # Drizzle マイグレーション適用
+bun run db:seed              # デモデータ投入（ローカル）
+bun run db:seed:staging      # デモデータ投入（staging）
+bun run db:sync-from-neon    # Neonからデータ同期
 ```
 
 ## トラブルシューティング

--- a/SETUP.md
+++ b/SETUP.md
@@ -82,6 +82,18 @@ DATABASE_URL=postgresql://chumo:chumo_dev@localhost:5432/chumo_dev \
 
 初回起動時にテスト用DB `chumo_test` も自動作成されます（`scripts/init-test-db.sh`）。
 
+### DBをリセットしたい場合
+
+ボリュームごと削除して初期状態に戻せます。
+
+```bash
+docker compose down -v        # コンテナ + ボリューム削除
+docker compose up -d postgres # 再作成（chumo_test DBも自動作成）
+# スキーマ再適用
+DATABASE_URL=postgresql://chumo:chumo_dev@localhost:5432/chumo_dev \
+  bunx drizzle-kit push --force
+```
+
 ### シードデータの投入
 
 デモ用のユーザー・タスク・セッションなどを投入できます。

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,6 +37,8 @@ export type Env = {
     INTERNAL_API_KEY: string;
     BACKLOG_WEBHOOK_SECRET: string;
     UPLOAD_BUCKET: R2Bucket;
+    PREVIEW_ACCESS_TOKEN?: string;
+    PREVIEW_USER_ID?: string;
   };
 };
 
@@ -53,7 +55,7 @@ app.use(
       return allowed.includes(origin) ? origin : allowed[0];
     },
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-    allowHeaders: ['Content-Type', 'Authorization'],
+    allowHeaders: ['Content-Type', 'Authorization', 'X-Preview-Token'],
   })
 );
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -70,6 +70,19 @@ export const authMiddleware = createMiddleware<
     return await next();
   }
 
+  // プレビューアカウント認証（production以外で有効）
+  const previewToken = c.req.header('X-Preview-Token');
+  if (
+    previewToken &&
+    c.env.PREVIEW_ACCESS_TOKEN &&
+    c.env.PREVIEW_USER_ID &&
+    c.env.ENVIRONMENT !== 'production' &&
+    previewToken === c.env.PREVIEW_ACCESS_TOKEN
+  ) {
+    c.set('userId', c.env.PREVIEW_USER_ID);
+    return await next();
+  }
+
   // Clerk JWT認証
   const authHeader = c.req.header('Authorization');
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -82,9 +82,24 @@ app.get('/me', async (c) => {
     return c.json({ user: await resolveAvatarUrl(user, c.env) });
   }
 
-  // プレビューユーザーはClerk上に存在しないため、DB未登録なら404で終了
+  // プレビューユーザーはClerk上に存在しないため、DB未登録ならモックデータを返す
   if (userId === c.env.PREVIEW_USER_ID) {
-    return c.json({ error: 'User not found' }, 404);
+    return c.json({
+      user: {
+        id: userId,
+        email: 'preview@example.com',
+        displayName: 'プレビューユーザー',
+        role: 'member' as const,
+        isAllowed: true,
+        avatarUrl: null,
+        avatarColor: null,
+        githubUsername: null,
+        chatId: null,
+        googleOAuthUpdatedAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    });
   }
 
   // Clerk IDで見つからない場合、Clerkからメールを取得してメールで検索

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -82,6 +82,11 @@ app.get('/me', async (c) => {
     return c.json({ user: await resolveAvatarUrl(user, c.env) });
   }
 
+  // プレビューユーザーはClerk上に存在しないため、DB未登録なら404で終了
+  if (userId === c.env.PREVIEW_USER_ID) {
+    return c.json({ error: 'User not found' }, 404);
+  }
+
   // Clerk IDで見つからない場合、Clerkからメールを取得してメールで検索
   try {
     const clerkClient = createClerkClient({ secretKey: c.env.CLERK_SECRET_KEY });

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -19,6 +19,8 @@ name = "chumo-api-staging"
 ENVIRONMENT = "staging"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"
 REPORT_TEMPLATE_ID = "1Z7SJbouRw7lq99_CVUuKa0Sckcz1PPFB"
+PREVIEW_USER_ID = "preview-user"
+# PREVIEW_ACCESS_TOKEN は wrangler secret で設定
 [[env.staging.r2_buckets]]
 binding = "UPLOAD_BUCKET"
 bucket_name = "chumo-uploads-staging"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./scripts/init-test-db.sh:/docker-entrypoint-initdb.d/init-test-db.sh:ro
     shm_size: 128mb
 
 volumes:

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -4,6 +4,7 @@ import { Navigate, Outlet, useNavigate } from 'react-router-dom';
 import { Spinner } from '../ui/Spinner';
 import { Button } from '../ui/Button';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { usePreviewMode } from '../../hooks/usePreviewMode';
 import { HttpError } from '../../lib/api';
 
 /**
@@ -36,6 +37,7 @@ function ForceSignOut() {
  * <Route element={<AuthGuard />}> で使う
  */
 export function AuthGuard() {
+  const { isPreview } = usePreviewMode();
   const { isLoaded, isSignedIn } = useClerkAuth();
   const { data: currentUser, isLoading, error, refetch } = useCurrentUser();
 
@@ -45,6 +47,10 @@ export function AuthGuard() {
       void refetch();
     }
   }, [isSignedIn, refetch]);
+
+  if (isPreview) {
+    return <Outlet />;
+  }
 
   // Clerk ローディング中 or API ローディング中
   if (!isLoaded || (isSignedIn && isLoading)) {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import { Avatar } from '../ui/Avatar';
 import { useTheme } from '../../hooks/useTheme';
 import { useAuth } from '../../hooks/useAuth';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { usePreviewMode } from '../../hooks/usePreviewMode';
 
 const NAV_ITEMS = [
   { path: '/dashboard', label: 'ダッシュボード', icon: <LayoutDashboard size={20} /> },
@@ -34,6 +35,15 @@ export function Sidebar() {
   const { theme, toggleTheme } = useTheme();
   const { user: clerkUser, logout } = useAuth();
   const { data: currentUser } = useCurrentUser();
+  const { isPreview } = usePreviewMode();
+
+  const displayName =
+    currentUser?.displayName ?? clerkUser?.fullName ?? (isPreview ? 'プレビューユーザー' : '');
+  const displayRole = currentUser?.role
+    ? (ROLE_LABELS[currentUser.role] ?? currentUser.role)
+    : isPreview
+      ? 'プレビュー'
+      : '';
 
   return (
     <aside className="flex h-full w-60 shrink-0 flex-col bg-teal-950 border-r border-teal-800 px-4 py-6">
@@ -94,18 +104,14 @@ export function Sidebar() {
         <DialogTrigger>
           <AriaButton className="flex w-full items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-teal-800/50 cursor-pointer">
             <Avatar
-              name={currentUser?.displayName ?? clerkUser?.fullName ?? '?'}
+              name={displayName || '?'}
               imageUrl={currentUser?.avatarUrl ?? undefined}
               colorName={currentUser?.avatarColor}
               size="md"
             />
             <div className="min-w-0 flex-1 text-left">
-              <p className="truncate text-sm font-medium text-white">
-                {currentUser?.displayName ?? clerkUser?.fullName ?? ''}
-              </p>
-              <p className="truncate text-xs text-teal-400">
-                {currentUser?.role ? (ROLE_LABELS[currentUser.role] ?? currentUser.role) : ''}
-              </p>
+              <p className="truncate text-sm font-medium text-white">{displayName}</p>
+              <p className="truncate text-xs text-teal-400">{displayRole}</p>
             </div>
           </AriaButton>
           <Popover

--- a/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
+++ b/frontend/src/components/shared/TaskDrawer/DrawerActionBar.tsx
@@ -3,7 +3,6 @@ import { Button } from '../../ui/Button';
 import { IntegrationLinkButton } from '../../ui/IntegrationLinkButton';
 import { useActiveSession, useTimer, useElapsedTime } from '../../../hooks/useTimer';
 import { useIntegrationActions } from '../../../hooks/useIntegrationActions';
-import { openExternal } from '../../../lib/utils';
 import type { Task } from '../../../types';
 
 interface DrawerActionBarProps {
@@ -13,7 +12,7 @@ interface DrawerActionBarProps {
 export function DrawerActionBar({ task }: DrawerActionBarProps) {
   const { data: activeSession } = useActiveSession();
   const { start, stop } = useTimer();
-  const { drive, chat, fire, pet } = useIntegrationActions(task);
+  const { drive, chat, fire, pet, backlog } = useIntegrationActions(task);
 
   const isThisTaskActive = activeSession != null && activeSession.taskId === task.id;
   const isOtherTaskActive = activeSession != null && !isThisTaskActive;
@@ -76,12 +75,12 @@ export function DrawerActionBar({ task }: DrawerActionBarProps) {
       <Button
         variant="primary"
         size="lg"
-        onPress={() => task.backlogUrl && openExternal(task.backlogUrl)}
-        isDisabled={!task.backlogUrl}
+        onPress={backlog.onClick}
+        isDisabled={!backlog.active}
         className="w-full"
       >
         <ExternalLink size={16} />
-        BACKLOGを開く
+        {backlog.label}
       </Button>
     </div>
   );

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useAuth as useClerkAuth, useUser as useClerkUser } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
+import { usePreviewMode } from './usePreviewMode';
 
 export interface UseAuthResult {
   isLoaded: boolean;
@@ -11,6 +12,8 @@ export interface UseAuthResult {
   logout: () => Promise<void>;
 }
 
+const PREVIEW_GET_TOKEN = async () => null;
+
 /**
  * Clerk 認証をラップしたフック
  * getToken / userId / isSignedIn / logout を提供
@@ -19,18 +22,36 @@ export function useAuth(): UseAuthResult {
   const { isLoaded, isSignedIn, userId, getToken, signOut } = useClerkAuth();
   const { user } = useClerkUser();
   const navigate = useNavigate();
+  const { isPreview, logoutPreview } = usePreviewMode();
+
+  const clerkGetToken = useCallback(() => getToken(), [getToken]);
 
   const logout = useCallback(async () => {
+    if (isPreview) {
+      logoutPreview();
+      return;
+    }
     await signOut();
     navigate('/login');
-  }, [signOut, navigate]);
+  }, [isPreview, logoutPreview, signOut, navigate]);
+
+  if (isPreview) {
+    return {
+      isLoaded: true,
+      isSignedIn: true,
+      userId: 'preview-user',
+      user: null,
+      getToken: PREVIEW_GET_TOKEN,
+      logout,
+    };
+  }
 
   return {
     isLoaded,
     isSignedIn: isSignedIn ?? false,
     userId: userId ?? null,
     user,
-    getToken: useCallback(() => getToken(), [getToken]),
+    getToken: clerkGetToken,
     logout,
   };
 }

--- a/frontend/src/hooks/useIntegrationActions.ts
+++ b/frontend/src/hooks/useIntegrationActions.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { useIntegrations, type IntegrationResult } from './useIntegrations';
+import { usePreviewMode } from './usePreviewMode';
 import { useToast } from './useToast';
 import { HttpError } from '../lib/api';
 import { openExternal } from '../lib/utils';
@@ -17,7 +18,12 @@ export function useIntegrationActions(task: Task) {
   const navigate = useNavigate();
   const { createDriveFolder, createChatThread, createFireIssue, createPetIssue } =
     useIntegrations();
+  const { isPreview } = usePreviewMode();
   const { addToast } = useToast();
+
+  const previewBlock = useCallback(() => {
+    addToast('プレビューモードでは外部サービスへの連携はできません', 'warning');
+  }, [addToast]);
 
   const makeCreateHandler = useCallback(
     (mutation: IntegrationMutation, opts?: { onAuthError?: () => void }) => () => {
@@ -38,8 +44,10 @@ export function useIntegrationActions(task: Task) {
     [task.id, addToast]
   );
 
-  const makeClickHandler = (url: string | null | undefined, createHandler: () => void) =>
-    url ? () => openExternal(url) : createHandler;
+  const makeClickHandler = (url: string | null | undefined, createHandler: () => void) => {
+    if (isPreview) return previewBlock;
+    return url ? () => openExternal(url) : createHandler;
+  };
 
   const handleDriveCreate = makeCreateHandler(createDriveFolder, {
     onAuthError: () => navigate('/settings?tab=integrations'),
@@ -72,6 +80,15 @@ export function useIntegrationActions(task: Task) {
       isPending: createPetIssue.isPending,
       active: !!task.petIssueUrl,
       label: task.petIssueUrl ? 'PET開く' : 'PET issue作成',
+    },
+    backlog: {
+      onClick: isPreview
+        ? previewBlock
+        : () => {
+            if (task.backlogUrl) openExternal(task.backlogUrl);
+          },
+      active: !!task.backlogUrl,
+      label: 'BACKLOGを開く',
     },
   };
 }

--- a/frontend/src/hooks/usePreviewMode.ts
+++ b/frontend/src/hooks/usePreviewMode.ts
@@ -9,16 +9,18 @@ export const PREVIEW_ENABLED = import.meta.env.VITE_PREVIEW_ENABLED === 'true';
  * localStorage でログイン状態を保持し、Clerk認証をバイパスする
  */
 export function usePreviewMode() {
+  const storedToken = localStorage.getItem(PREVIEW_TOKEN_KEY);
   const isPreview =
     PREVIEW_ENABLED &&
     localStorage.getItem(PREVIEW_KEY) === 'true' &&
-    Boolean(localStorage.getItem(PREVIEW_TOKEN_KEY));
+    typeof storedToken === 'string' &&
+    storedToken.trim().length > 0;
 
   const loginAsPreview = () => {
     const token = import.meta.env.VITE_PREVIEW_TOKEN;
-    if (!PREVIEW_ENABLED || !token) return;
+    if (!PREVIEW_ENABLED || !token?.trim()) return;
     localStorage.setItem(PREVIEW_KEY, 'true');
-    localStorage.setItem(PREVIEW_TOKEN_KEY, token);
+    localStorage.setItem(PREVIEW_TOKEN_KEY, token.trim());
     window.location.href = '/dashboard';
   };
 

--- a/frontend/src/hooks/usePreviewMode.ts
+++ b/frontend/src/hooks/usePreviewMode.ts
@@ -9,11 +9,16 @@ export const PREVIEW_ENABLED = import.meta.env.VITE_PREVIEW_ENABLED === 'true';
  * localStorage でログイン状態を保持し、Clerk認証をバイパスする
  */
 export function usePreviewMode() {
-  const isPreview = localStorage.getItem(PREVIEW_KEY) === 'true';
+  const isPreview =
+    PREVIEW_ENABLED &&
+    localStorage.getItem(PREVIEW_KEY) === 'true' &&
+    Boolean(localStorage.getItem(PREVIEW_TOKEN_KEY));
 
   const loginAsPreview = () => {
+    const token = import.meta.env.VITE_PREVIEW_TOKEN;
+    if (!PREVIEW_ENABLED || !token) return;
     localStorage.setItem(PREVIEW_KEY, 'true');
-    localStorage.setItem(PREVIEW_TOKEN_KEY, import.meta.env.VITE_PREVIEW_TOKEN ?? '');
+    localStorage.setItem(PREVIEW_TOKEN_KEY, token);
     window.location.href = '/dashboard';
   };
 

--- a/frontend/src/hooks/usePreviewMode.ts
+++ b/frontend/src/hooks/usePreviewMode.ts
@@ -1,0 +1,27 @@
+const PREVIEW_KEY = 'preview-mode';
+export const PREVIEW_TOKEN_KEY = 'preview-token';
+
+/** プレビュー機能が有効か（ビルド時に決定） */
+export const PREVIEW_ENABLED = import.meta.env.VITE_PREVIEW_ENABLED === 'true';
+
+/**
+ * プレビューモード管理フック
+ * localStorage でログイン状態を保持し、Clerk認証をバイパスする
+ */
+export function usePreviewMode() {
+  const isPreview = localStorage.getItem(PREVIEW_KEY) === 'true';
+
+  const loginAsPreview = () => {
+    localStorage.setItem(PREVIEW_KEY, 'true');
+    localStorage.setItem(PREVIEW_TOKEN_KEY, import.meta.env.VITE_PREVIEW_TOKEN ?? '');
+    window.location.href = '/dashboard';
+  };
+
+  const logoutPreview = () => {
+    localStorage.removeItem(PREVIEW_KEY);
+    localStorage.removeItem(PREVIEW_TOKEN_KEY);
+    window.location.href = '/login';
+  };
+
+  return { isPreview, loginAsPreview, logoutPreview };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { PREVIEW_TOKEN_KEY } from '../hooks/usePreviewMode';
+import { PREVIEW_TOKEN_KEY, PREVIEW_ENABLED } from '../hooks/usePreviewMode';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
 
@@ -41,7 +41,7 @@ export async function apiClient<T>(
 
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
-  } else {
+  } else if (PREVIEW_ENABLED) {
     const previewToken = localStorage.getItem(PREVIEW_TOKEN_KEY);
     if (previewToken) {
       headers['X-Preview-Token'] = previewToken;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { PREVIEW_TOKEN_KEY } from '../hooks/usePreviewMode';
+
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
 
 export class HttpError extends Error {
@@ -39,6 +41,11 @@ export async function apiClient<T>(
 
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
+  } else {
+    const previewToken = localStorage.getItem(PREVIEW_TOKEN_KEY);
+    if (previewToken) {
+      headers['X-Preview-Token'] = previewToken;
+    }
   }
 
   const response = await fetch(`${API_BASE_URL}${path}`, {

--- a/frontend/src/pages/contacts/ContactPage.tsx
+++ b/frontend/src/pages/contacts/ContactPage.tsx
@@ -8,6 +8,8 @@ import { ContactFormDrawer } from './components/ContactFormDrawer';
 import type { ContactFormData } from './components/ContactFormDrawer';
 import { useContacts, useCreateContact, useUpdateContactStatus } from '../../hooks/useContacts';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
+import { usePreviewMode } from '../../hooks/usePreviewMode';
+import { useToast } from '../../hooks/useToast';
 
 export function ContactPage() {
   const [showResolved, setShowResolved] = useState(false);
@@ -19,6 +21,8 @@ export function ContactPage() {
   const createContact = useCreateContact();
   const updateStatus = useUpdateContactStatus();
   const { data: currentUser } = useCurrentUser();
+  const { isPreview } = usePreviewMode();
+  const { addToast } = useToast();
 
   const handleStatusChange = useCallback(
     (contactId: string, newStatus: 'pending' | 'resolved') => {
@@ -71,7 +75,17 @@ export function ContactPage() {
           <CircleCheckBig size={16} />
           {showResolved ? '対応中を表示' : '解決済みを表示'}
         </Button>
-        <Button variant="primary" size="sm" onPress={() => setIsDrawerOpen(true)}>
+        <Button
+          variant="primary"
+          size="sm"
+          onPress={() => {
+            if (isPreview) {
+              addToast('プレビューモードではお問い合わせの作成はできません', 'warning');
+              return;
+            }
+            setIsDrawerOpen(true);
+          }}
+        >
           <Plus size={16} />
           新規作成
         </Button>

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,10 +1,13 @@
 import { SignIn } from '@clerk/clerk-react';
 import { Navigate } from 'react-router-dom';
-import { ShieldX } from 'lucide-react';
+import { Eye, ShieldX } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
+import { usePreviewMode, PREVIEW_ENABLED } from '../../hooks/usePreviewMode';
+import { Button } from '../../components/ui/Button';
 
 export function LoginPage() {
   const { isSignedIn, isLoaded } = useAuth();
+  const { loginAsPreview } = usePreviewMode();
   const accessDenied = sessionStorage.getItem('access-denied') === 'true';
 
   // 認証済みならダッシュボードへ（フラグもクリア）
@@ -37,6 +40,17 @@ export function LoginPage() {
             },
           }}
         />
+        {PREVIEW_ENABLED && (
+          <Button
+            variant="outline"
+            size="lg"
+            onPress={loginAsPreview}
+            className="w-full max-w-[400px] text-text-secondary"
+          >
+            <Eye size={16} />
+            プレビューモードでログイン
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/reports/components/ReportToolbar.tsx
+++ b/frontend/src/pages/reports/components/ReportToolbar.tsx
@@ -1,6 +1,8 @@
 import { ChevronLeft, ChevronRight, Calendar, Upload, Loader2, ExternalLink } from 'lucide-react';
 import { Button } from '../../../components/ui/Button';
 import { IconButton } from '../../../components/ui/IconButton';
+import { usePreviewMode } from '../../../hooks/usePreviewMode';
+import { useToast } from '../../../hooks/useToast';
 
 const REPORT_DRIVE_FOLDER_URL =
   'https://drive.google.com/drive/u/1/folders/1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH';
@@ -26,6 +28,13 @@ export function ReportToolbar({
   showDateRange = false,
   onToggleDateRange,
 }: ReportToolbarProps) {
+  const { isPreview } = usePreviewMode();
+  const { addToast } = useToast();
+
+  const handlePreviewBlock = () => {
+    addToast('プレビューモードでは外部サービスへの連携はできません', 'warning');
+  };
+
   return (
     <div className="flex h-10 items-center justify-between">
       <div className="flex items-center gap-4">
@@ -67,14 +76,21 @@ export function ReportToolbar({
         <Button
           variant="secondary"
           size="sm"
-          onPress={() => window.open(REPORT_DRIVE_FOLDER_URL, '_blank')}
+          onPress={
+            isPreview ? handlePreviewBlock : () => window.open(REPORT_DRIVE_FOLDER_URL, '_blank')
+          }
         >
           <ExternalLink size={16} />
           Drive
         </Button>
 
         {/* スプレッドシート出力 */}
-        <Button variant="primary" size="sm" onPress={onExport} isDisabled={isExporting}>
+        <Button
+          variant="primary"
+          size="sm"
+          onPress={isPreview ? handlePreviewBlock : onExport}
+          isDisabled={isExporting}
+        >
           {isExporting ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
           {isExporting ? '出力中...' : 'スプレッドシートに出力'}
         </Button>

--- a/frontend/src/pages/settings/components/AdminTab.tsx
+++ b/frontend/src/pages/settings/components/AdminTab.tsx
@@ -9,6 +9,8 @@ import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { useUsers } from '../../../hooks/useUsers';
 import { useUpdateUser } from '../../../hooks/useUpdateUser';
 import { useInviteUser } from '../../../hooks/useInviteUser';
+import { usePreviewMode } from '../../../hooks/usePreviewMode';
+import { useToast } from '../../../hooks/useToast';
 import type { User } from '../../../types';
 
 const TABLE_COLUMNS = [
@@ -82,6 +84,8 @@ export function AdminTab() {
   const { data: users = [], isLoading } = useUsers();
   const updateUser = useUpdateUser();
   const inviteUser = useInviteUser();
+  const { isPreview } = usePreviewMode();
+  const { addToast } = useToast();
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
   const [inviteMessage, setInviteMessage] = useState<{
@@ -147,7 +151,13 @@ export function AdminTab() {
           variant="primary"
           size="md"
           className="gap-1.5 text-sm"
-          onPress={() => setAddModalOpen(true)}
+          onPress={() => {
+            if (isPreview) {
+              addToast('プレビューモードではメンバー管理はできません', 'warning');
+              return;
+            }
+            setAddModalOpen(true);
+          }}
         >
           <Plus size={16} />
           メンバー追加

--- a/frontend/src/pages/settings/components/AdminTab.tsx
+++ b/frontend/src/pages/settings/components/AdminTab.tsx
@@ -119,11 +119,20 @@ export function AdminTab() {
 
   const handleDeleteMember = () => {
     if (!deleteTarget) return;
+    if (isPreview) {
+      addToast('プレビューモードではメンバー管理はできません', 'warning');
+      setDeleteTarget(null);
+      return;
+    }
     updateUser.mutate({ userId: deleteTarget.id, data: { isAllowed: false } });
     setDeleteTarget(null);
   };
 
   const handleRestoreMember = (userId: string) => {
+    if (isPreview) {
+      addToast('プレビューモードではメンバー管理はできません', 'warning');
+      return;
+    }
     updateUser.mutate({ userId, data: { isAllowed: true } });
   };
 

--- a/frontend/src/pages/tasks/components/TaskDetailActionBar.tsx
+++ b/frontend/src/pages/tasks/components/TaskDetailActionBar.tsx
@@ -3,7 +3,6 @@ import { Button } from '../../../components/ui/Button';
 import { IntegrationLinkButton } from '../../../components/ui/IntegrationLinkButton';
 import { useActiveSession, useTimer, useElapsedTime } from '../../../hooks/useTimer';
 import { useIntegrationActions } from '../../../hooks/useIntegrationActions';
-import { openExternal } from '../../../lib/utils';
 import type { Task } from '../../../types';
 
 interface TaskDetailActionBarProps {
@@ -13,7 +12,7 @@ interface TaskDetailActionBarProps {
 export function TaskDetailActionBar({ task }: TaskDetailActionBarProps) {
   const { data: activeSession } = useActiveSession();
   const { start, stop } = useTimer();
-  const { drive, chat, fire, pet } = useIntegrationActions(task);
+  const { drive, chat, fire, pet, backlog } = useIntegrationActions(task);
 
   const isThisTaskActive = activeSession != null && activeSession.taskId === task.id;
   const isOtherTaskActive = activeSession != null && !isThisTaskActive;
@@ -66,12 +65,12 @@ export function TaskDetailActionBar({ task }: TaskDetailActionBarProps) {
       <Button
         variant="outline"
         size="sm"
-        onPress={() => task.backlogUrl && openExternal(task.backlogUrl)}
-        isDisabled={!task.backlogUrl}
+        onPress={backlog.onClick}
+        isDisabled={!backlog.active}
         className="border-teal-200 bg-bg-brand-subtle text-xs text-primary-default hover:bg-teal-100"
       >
         <ExternalLink size={16} />
-        BACKLOGを開く
+        {backlog.label}
       </Button>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "backend:db:generate": "cd backend && bun run db:generate",
     "backend:db:migrate": "cd backend && bun run db:migrate",
     "backend:db:studio": "cd backend && bun run db:studio",
+    "db:seed": "bash scripts/db-seed.sh",
+    "db:seed:staging": "bash scripts/db-seed.sh --staging",
     "db:sync-from-neon": "bash scripts/sync-from-neon.sh",
     "mcp:serena": "uvx --from git+https://github.com/oraios/serena serena start-mcp-server"
   },

--- a/scripts/db-seed.sh
+++ b/scripts/db-seed.sh
@@ -42,7 +42,7 @@ case "$TARGET" in
     fi
 
     echo "🌱 Neon staging DB にシード投入中..."
-    psql "$DB_URL" -f "$SEED_SQL"
+    psql -v ON_ERROR_STOP=1 "$DB_URL" -f "$SEED_SQL"
     echo "✅ staging シード完了！"
     ;;
 

--- a/scripts/db-seed.sh
+++ b/scripts/db-seed.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==============================================================
+# シードデータ投入スクリプト
+#
+# 使い方:
+#   ./scripts/db-seed.sh              # ローカル Docker DB に投入
+#   ./scripts/db-seed.sh --staging    # Neon staging DB に投入
+#
+# ローカル前提:
+#   - Docker コンテナ chumo-postgres が起動中
+# staging 前提:
+#   - backend/.dev.vars の NEON_DATABASE_URL、または
+#     backend/.env.neon の DATABASE_URL が設定されている
+# ==============================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEED_SQL="$SCRIPT_DIR/seed.sql"
+
+if [ ! -f "$SEED_SQL" ]; then
+  echo "❌ seed.sql が見つかりません: $SEED_SQL"
+  exit 1
+fi
+
+TARGET="${1:-local}"
+
+case "$TARGET" in
+  --staging)
+    # Neon staging DB に接続
+    if [ -n "${NEON_DATABASE_URL:-}" ]; then
+      DB_URL="$NEON_DATABASE_URL"
+    elif [ -f "$SCRIPT_DIR/../backend/.env.neon" ]; then
+      DB_URL=$(grep '^DATABASE_URL=' "$SCRIPT_DIR/../backend/.env.neon" | cut -d= -f2-)
+    else
+      echo "❌ Neon の DATABASE_URL が見つかりません"
+      echo ""
+      echo "以下のいずれかで指定してください:"
+      echo "  1) 環境変数: NEON_DATABASE_URL='postgresql://...' ./scripts/db-seed.sh --staging"
+      echo "  2) ファイル: backend/.env.neon に DATABASE_URL=postgresql://... を記載"
+      exit 1
+    fi
+
+    echo "🌱 Neon staging DB にシード投入中..."
+    psql "$DB_URL" -f "$SEED_SQL"
+    echo "✅ staging シード完了！"
+    ;;
+
+  *)
+    # ローカル Docker DB に投入
+    # .dev.vars の DATABASE_URL をパースして Docker 経由で接続
+    DEV_VARS="$SCRIPT_DIR/../backend/.dev.vars"
+    if [ -f "$DEV_VARS" ]; then
+      DB_URL=$(grep '^DATABASE_URL=' "$DEV_VARS" | head -1 | cut -d= -f2-)
+    fi
+
+    if [ -z "${DB_URL:-}" ]; then
+      echo "❌ backend/.dev.vars に DATABASE_URL が見つかりません"
+      exit 1
+    fi
+
+    # postgresql://user:pass@host:port/dbname からパース
+    DB_USER=$(echo "$DB_URL" | sed -n 's|postgresql://\([^:]*\):.*|\1|p')
+    DB_PORT=$(echo "$DB_URL" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+    DB_NAME=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+
+    # ポートにバインドされている Docker コンテナを探す
+    CONTAINER=$(docker ps --format '{{.Names}} {{.Ports}}' | grep "0.0.0.0:${DB_PORT}->" | awk '{print $1}' | head -1)
+
+    if [ -z "$CONTAINER" ]; then
+      echo "❌ ポート ${DB_PORT} にバインドされた Docker コンテナが見つかりません"
+      echo "   → docker start chumo-postgres または bun run backend:dev で起動"
+      exit 1
+    fi
+
+    echo "🌱 ローカル DB にシード投入中..."
+    echo "   → コンテナ: ${CONTAINER}, DB: ${DB_NAME}"
+    docker exec -i "$CONTAINER" psql -v ON_ERROR_STOP=1 -U "$DB_USER" -d "$DB_NAME" < "$SEED_SQL"
+    echo "✅ ローカルシード完了！"
+    ;;
+esac

--- a/scripts/db-sync-from-neon.sh
+++ b/scripts/db-sync-from-neon.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 #   ./scripts/db-sync-from-neon.sh
 #
 # 前提:
-#   - Docker コンテナ chumo-test-postgres が起動中
+#   - Docker コンテナ chumo-postgres が起動中
 #   - ローカル DB にマイグレーション適用済み
 #   - NEON_DATABASE_URL が設定されている（引数 or .env.neon）
 # ==============================================================
 
-CONTAINER="chumo-test-postgres"
+CONTAINER="chumo-postgres"
 LOCAL_USER="chumo"
 LOCAL_DB="chumo_dev"
 

--- a/scripts/init-test-db.sh
+++ b/scripts/init-test-db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Docker初期化時にテスト用DBを自動作成
+set -e
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+  SELECT 'CREATE DATABASE chumo_test OWNER $POSTGRES_USER'
+  WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'chumo_test')\gexec
+EOSQL

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -1,0 +1,120 @@
+-- ==============================================================
+-- Staging / ローカル用シードデータ
+-- プレビューユーザー + デモ用ラベル・タスク・セッション・コメント
+-- ==============================================================
+
+BEGIN;
+
+-- ===== 既存シードデータクリア（外部キー考慮で依存順に削除） =====
+-- シードIDを明示列挙し、非シードデータを誤削除しない
+DELETE FROM task_comments WHERE id IN ('comment-001','comment-002','comment-003','comment-004','comment-005');
+DELETE FROM task_sessions WHERE id IN ('session-001','session-002','session-003','session-004','session-005','session-006');
+DELETE FROM task_activities WHERE task_id IN ('task-001','task-002','task-003','task-004','task-005','task-006','task-007','task-008','task-009','task-010','task-011','task-012');
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'task_pins') THEN
+    EXECUTE 'DELETE FROM task_pins WHERE id IN (''pin-001'',''pin-002'')';
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'notifications') THEN
+    EXECUTE 'DELETE FROM notifications WHERE task_id IN (''task-001'',''task-002'',''task-003'',''task-004'',''task-005'',''task-006'',''task-007'',''task-008'',''task-009'',''task-010'',''task-011'',''task-012'')';
+  END IF;
+END $$;
+DELETE FROM task_externals WHERE task_id IN ('task-001','task-002','task-003','task-004','task-005','task-006','task-007','task-008','task-009','task-010','task-011','task-012');
+DELETE FROM tasks WHERE id IN ('task-001','task-002','task-003','task-004','task-005','task-006','task-007','task-008','task-009','task-010','task-011','task-012');
+DELETE FROM labels WHERE id IN ('kubun-unyo','kubun-kaihatsu','kubun-design','kubun-other');
+DELETE FROM users WHERE id IN ('preview-user', 'demo-user-1', 'demo-user-2');
+
+-- ===== ユーザー =====
+INSERT INTO users (id, email, display_name, role, is_allowed, created_at, updated_at)
+VALUES
+  ('preview-user', 'preview@example.com', 'プレビューユーザー', 'admin', true, NOW(), NOW()),
+  ('demo-user-1', 'tanaka@example.com', '田中 太郎', 'member', true, NOW(), NOW()),
+  ('demo-user-2', 'suzuki@example.com', '鈴木 花子', 'member', true, NOW(), NOW())
+ON CONFLICT (id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  role = EXCLUDED.role,
+  is_allowed = EXCLUDED.is_allowed,
+  updated_at = NOW();
+
+-- ===== ラベル（区分） =====
+INSERT INTO labels (id, name, color, project_id, owner_id, created_at, updated_at)
+VALUES
+  ('kubun-unyo',     '運用',     '#10B981', NULL, 'preview-user', NOW(), NOW()),
+  ('kubun-kaihatsu', '開発',     '#3B82F6', NULL, 'preview-user', NOW(), NOW()),
+  ('kubun-design',   'デザイン', '#F59E0B', NULL, 'preview-user', NOW(), NOW()),
+  ('kubun-other',    'その他',   '#6B7280', NULL, 'preview-user', NOW(), NOW())
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  color = EXCLUDED.color,
+  updated_at = NOW();
+
+-- ===== タスク =====
+-- ディレクション
+INSERT INTO tasks (id, project_type, title, description, flow_status, progress_status, assignee_ids, kubun_label_id, priority, "order", created_by, it_up_date, release_date, created_at, updated_at)
+VALUES
+  ('task-001', 'REG2017', 'トップページリニューアル', 'ファーストビューのレイアウト変更とヒーロー画像差し替え', 'ディレクション', '仕様確認', ARRAY['preview-user', 'demo-user-1'], 'kubun-kaihatsu', 'high', 1, 'preview-user', NOW() + INTERVAL '14 days', NOW() + INTERVAL '21 days', NOW() - INTERVAL '3 days', NOW()),
+  ('task-002', 'REG2017', 'お知らせ一覧ページ追加', 'CMS連携のお知らせ一覧・詳細ページを新規作成', 'ディレクション', '仕様確認', ARRAY['demo-user-2'], 'kubun-kaihatsu', 'medium', 2, 'preview-user', NOW() + INTERVAL '10 days', NOW() + INTERVAL '17 days', NOW() - INTERVAL '2 days', NOW()),
+  ('task-003', 'BRGREG', 'FAQ追加: ログイン不具合', 'ログインできない場合のFAQを追加', 'ディレクション', '仕様確認', ARRAY['preview-user'], 'kubun-unyo', 'medium', 3, 'preview-user', NOW() + INTERVAL '5 days', NOW() + INTERVAL '7 days', NOW() - INTERVAL '1 day', NOW()),
+  ('task-004', 'DES_FIRE', 'ボタンコンポーネント改修', 'アクセシビリティ対応とバリアント追加', 'ディレクション', '仕様確認', ARRAY['demo-user-1'], 'kubun-design', 'low', 4, 'demo-user-1', NULL, NULL, NOW() - INTERVAL '1 day', NOW()),
+
+-- コーディング
+  ('task-005', 'REG2017', 'フォームバリデーション改善', '入力チェックのリアルタイム表示とエラーメッセージ統一', 'コーディング', 'コーディング', ARRAY['preview-user'], 'kubun-kaihatsu', 'high', 5, 'preview-user', NOW() + INTERVAL '3 days', NOW() + INTERVAL '5 days', NOW() - INTERVAL '7 days', NOW()),
+  ('task-006', 'MONO', 'レスポンシブ対応: 商品一覧', 'SP/タブレット表示の崩れ修正', 'コーディング', 'コーディング', ARRAY['demo-user-1', 'preview-user'], 'kubun-kaihatsu', 'medium', 6, 'demo-user-1', NOW() + INTERVAL '2 days', NOW() + INTERVAL '4 days', NOW() - INTERVAL '5 days', NOW()),
+
+-- 対応中
+  ('task-007', 'BRGREG', 'メール配信停止リンク修正', '配信停止URLが404になる不具合の修正', '対応中', 'コーディング', ARRAY['preview-user'], 'kubun-unyo', 'urgent', 7, 'preview-user', NOW() + INTERVAL '1 day', NOW() + INTERVAL '2 days', NOW() - INTERVAL '4 days', NOW()),
+
+-- 待ち
+  ('task-008', 'REG2017', 'クライアント確認待ち: デザインカンプ', '第2案のデザインカンプについてクライアント返答待ち', '待ち', '待ち', ARRAY['demo-user-2'], 'kubun-design', 'medium', 8, 'demo-user-2', NULL, NULL, NOW() - INTERVAL '6 days', NOW()),
+
+-- 完了
+  ('task-009', 'MONO', 'OGP画像設定', '各ページのOGP画像とmeta情報を設定', '完了', NULL, ARRAY['preview-user'], 'kubun-kaihatsu', 'low', 9, 'preview-user', NOW() - INTERVAL '3 days', NOW() - INTERVAL '1 day', NOW() - INTERVAL '14 days', NOW() - INTERVAL '1 day'),
+  ('task-010', 'BRGREG', 'SSL証明書更新', 'ステージング環境のSSL証明書を更新', '完了', NULL, ARRAY['demo-user-1'], 'kubun-unyo', 'high', 10, 'demo-user-1', NOW() - INTERVAL '7 days', NOW() - INTERVAL '5 days', NOW() - INTERVAL '10 days', NOW() - INTERVAL '5 days'),
+
+-- 未着手
+  ('task-011', 'REG2017', 'パフォーマンス計測ツール導入', 'Core Web Vitals の計測基盤を構築', '未着手', NULL, ARRAY[]::text[], 'kubun-kaihatsu', 'low', 11, 'preview-user', NULL, NULL, NOW(), NOW()),
+  ('task-012', 'DES_FIRE', 'アイコンセット更新', 'Lucide Icons v0.300 への更新と不要アイコン削除', '未着手', NULL, ARRAY['demo-user-2'], 'kubun-design', 'low', 12, 'demo-user-2', NULL, NULL, NOW(), NOW())
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  description = EXCLUDED.description,
+  flow_status = EXCLUDED.flow_status,
+  progress_status = EXCLUDED.progress_status,
+  assignee_ids = EXCLUDED.assignee_ids,
+  priority = EXCLUDED.priority,
+  it_up_date = EXCLUDED.it_up_date,
+  release_date = EXCLUDED.release_date,
+  updated_at = NOW();
+
+-- ===== タイマーセッション（完了済み） =====
+INSERT INTO task_sessions (id, task_id, project_type, user_id, started_at, ended_at, duration_sec)
+VALUES
+  ('session-001', 'task-005', 'REG2017', 'preview-user', NOW() - INTERVAL '6 days' - INTERVAL '2 hours', NOW() - INTERVAL '6 days', 7200),
+  ('session-002', 'task-005', 'REG2017', 'preview-user', NOW() - INTERVAL '5 days' - INTERVAL '90 minutes', NOW() - INTERVAL '5 days', 5400),
+  ('session-003', 'task-007', 'BRGREG', 'preview-user', NOW() - INTERVAL '3 days' - INTERVAL '45 minutes', NOW() - INTERVAL '3 days', 2700),
+  ('session-004', 'task-006', 'MONO', 'demo-user-1', NOW() - INTERVAL '4 days' - INTERVAL '3 hours', NOW() - INTERVAL '4 days', 10800),
+  ('session-005', 'task-009', 'MONO', 'preview-user', NOW() - INTERVAL '8 days' - INTERVAL '1 hour', NOW() - INTERVAL '8 days', 3600),
+  ('session-006', 'task-010', 'BRGREG', 'demo-user-1', NOW() - INTERVAL '7 days' - INTERVAL '30 minutes', NOW() - INTERVAL '7 days', 1800)
+ON CONFLICT (id) DO NOTHING;
+
+-- ===== コメント =====
+INSERT INTO task_comments (id, task_id, project_type, author_id, content, mentioned_user_ids, read_by, created_at, updated_at)
+VALUES
+  ('comment-001', 'task-001', 'REG2017', 'demo-user-1', '<p>ヒーロー画像の候補を3パターン用意しました。確認お願いします。</p>', ARRAY['preview-user'], ARRAY['preview-user', 'demo-user-1'], NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
+  ('comment-002', 'task-001', 'REG2017', 'preview-user', '<p>パターンBが良さそうです。レスポンシブの崩れだけ確認してもらえますか？</p>', ARRAY['demo-user-1'], ARRAY['preview-user'], NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day'),
+  ('comment-003', 'task-005', 'REG2017', 'preview-user', '<p>バリデーションルールをZodに統一しました。テストも追加済みです。</p>', ARRAY[]::text[], ARRAY['preview-user'], NOW() - INTERVAL '4 days', NOW() - INTERVAL '4 days'),
+  ('comment-004', 'task-007', 'BRGREG', 'demo-user-2', '<p>配信停止URLのパスが変わっていたようです。修正PRを出しています。</p>', ARRAY['preview-user'], ARRAY['demo-user-2'], NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
+  ('comment-005', 'task-007', 'BRGREG', 'preview-user', '<p>確認しました。マージしてデプロイお願いします。</p>', ARRAY['demo-user-2'], ARRAY['preview-user'], NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day')
+ON CONFLICT (id) DO NOTHING;
+
+-- ===== ピン留め（テーブルが存在する場合のみ） =====
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'task_pins') THEN
+    INSERT INTO task_pins (id, user_id, task_id, "order", pinned_at)
+    VALUES
+      ('pin-001', 'preview-user', 'task-007', 0, NOW() - INTERVAL '3 days'),
+      ('pin-002', 'preview-user', 'task-005', 1, NOW() - INTERVAL '5 days')
+    ON CONFLICT (user_id, task_id) DO NOTHING;
+  END IF;
+END $$;
+
+COMMIT;

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -8,7 +8,7 @@ BEGIN;
 -- ===== 既存シードデータクリア（外部キー考慮で依存順に削除） =====
 -- シードIDを明示列挙し、非シードデータを誤削除しない
 DELETE FROM task_comments WHERE id IN ('comment-001','comment-002','comment-003','comment-004','comment-005');
-DELETE FROM task_sessions WHERE id IN ('session-001','session-002','session-003','session-004','session-005','session-006');
+DELETE FROM task_sessions WHERE id IN ('session-001','session-002','session-003','session-004','session-005','session-006','session-007','session-008','session-009','session-010','session-011','session-012');
 DELETE FROM task_activities WHERE task_id IN ('task-001','task-002','task-003','task-004','task-005','task-006','task-007','task-008','task-009','task-010','task-011','task-012');
 DO $$ BEGIN
   IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'task_pins') THEN
@@ -21,6 +21,7 @@ END $$;
 DELETE FROM task_externals WHERE task_id IN ('task-001','task-002','task-003','task-004','task-005','task-006','task-007','task-008','task-009','task-010','task-011','task-012');
 DELETE FROM tasks WHERE id IN ('task-001','task-002','task-003','task-004','task-005','task-006','task-007','task-008','task-009','task-010','task-011','task-012');
 DELETE FROM labels WHERE id IN ('kubun-unyo','kubun-kaihatsu','kubun-design','kubun-other');
+DELETE FROM contacts WHERE id IN ('contact-001','contact-002','contact-003');
 DELETE FROM users WHERE id IN ('preview-user', 'demo-user-1', 'demo-user-2');
 
 -- ===== ユーザー =====
@@ -54,11 +55,11 @@ VALUES
   ('task-001', 'REG2017', 'トップページリニューアル', 'ファーストビューのレイアウト変更とヒーロー画像差し替え', 'ディレクション', '仕様確認', ARRAY['preview-user', 'demo-user-1'], 'kubun-kaihatsu', 'high', 1, 'preview-user', NOW() + INTERVAL '14 days', NOW() + INTERVAL '21 days', NOW() - INTERVAL '3 days', NOW()),
   ('task-002', 'REG2017', 'お知らせ一覧ページ追加', 'CMS連携のお知らせ一覧・詳細ページを新規作成', 'ディレクション', '仕様確認', ARRAY['demo-user-2'], 'kubun-kaihatsu', 'medium', 2, 'preview-user', NOW() + INTERVAL '10 days', NOW() + INTERVAL '17 days', NOW() - INTERVAL '2 days', NOW()),
   ('task-003', 'BRGREG', 'FAQ追加: ログイン不具合', 'ログインできない場合のFAQを追加', 'ディレクション', '仕様確認', ARRAY['preview-user'], 'kubun-unyo', 'medium', 3, 'preview-user', NOW() + INTERVAL '5 days', NOW() + INTERVAL '7 days', NOW() - INTERVAL '1 day', NOW()),
-  ('task-004', 'DES_FIRE', 'ボタンコンポーネント改修', 'アクセシビリティ対応とバリアント追加', 'ディレクション', '仕様確認', ARRAY['demo-user-1'], 'kubun-design', 'low', 4, 'demo-user-1', NULL, NULL, NOW() - INTERVAL '1 day', NOW()),
+  ('task-004', 'BRGREG', 'ボタンコンポーネント改修', 'アクセシビリティ対応とバリアント追加', 'ディレクション', '仕様確認', ARRAY['demo-user-1'], 'kubun-design', 'low', 4, 'demo-user-1', NULL, NULL, NOW() - INTERVAL '1 day', NOW()),
 
 -- コーディング
-  ('task-005', 'REG2017', 'フォームバリデーション改善', '入力チェックのリアルタイム表示とエラーメッセージ統一', 'コーディング', 'コーディング', ARRAY['preview-user'], 'kubun-kaihatsu', 'high', 5, 'preview-user', NOW() + INTERVAL '3 days', NOW() + INTERVAL '5 days', NOW() - INTERVAL '7 days', NOW()),
-  ('task-006', 'MONO', 'レスポンシブ対応: 商品一覧', 'SP/タブレット表示の崩れ修正', 'コーディング', 'コーディング', ARRAY['demo-user-1', 'preview-user'], 'kubun-kaihatsu', 'medium', 6, 'demo-user-1', NOW() + INTERVAL '2 days', NOW() + INTERVAL '4 days', NOW() - INTERVAL '5 days', NOW()),
+  ('task-005', 'REG2017', 'フォームバリデーション改善', '入力チェックのリアルタイム表示とエラーメッセージ統一', 'コーディング', 'コーディング', ARRAY['preview-user'], 'kubun-unyo', 'high', 5, 'preview-user', NOW() + INTERVAL '3 days', NOW() + INTERVAL '5 days', NOW() - INTERVAL '7 days', NOW()),
+  ('task-006', 'REG2017', 'レスポンシブ対応: 商品一覧', 'SP/タブレット表示の崩れ修正', 'コーディング', 'コーディング', ARRAY['demo-user-1', 'preview-user'], 'kubun-unyo', 'medium', 6, 'demo-user-1', NOW() + INTERVAL '2 days', NOW() + INTERVAL '4 days', NOW() - INTERVAL '5 days', NOW()),
 
 -- 対応中
   ('task-007', 'BRGREG', 'メール配信停止リンク修正', '配信停止URLが404になる不具合の修正', '対応中', 'コーディング', ARRAY['preview-user'], 'kubun-unyo', 'urgent', 7, 'preview-user', NOW() + INTERVAL '1 day', NOW() + INTERVAL '2 days', NOW() - INTERVAL '4 days', NOW()),
@@ -67,12 +68,12 @@ VALUES
   ('task-008', 'REG2017', 'クライアント確認待ち: デザインカンプ', '第2案のデザインカンプについてクライアント返答待ち', '待ち', '待ち', ARRAY['demo-user-2'], 'kubun-design', 'medium', 8, 'demo-user-2', NULL, NULL, NOW() - INTERVAL '6 days', NOW()),
 
 -- 完了
-  ('task-009', 'MONO', 'OGP画像設定', '各ページのOGP画像とmeta情報を設定', '完了', NULL, ARRAY['preview-user'], 'kubun-kaihatsu', 'low', 9, 'preview-user', NOW() - INTERVAL '3 days', NOW() - INTERVAL '1 day', NOW() - INTERVAL '14 days', NOW() - INTERVAL '1 day'),
+  ('task-009', 'REG2017', 'OGP画像設定', '各ページのOGP画像とmeta情報を設定', '完了', NULL, ARRAY['preview-user'], 'kubun-unyo', 'low', 9, 'preview-user', NOW() - INTERVAL '3 days', NOW() - INTERVAL '1 day', NOW() - INTERVAL '14 days', NOW() - INTERVAL '1 day'),
   ('task-010', 'BRGREG', 'SSL証明書更新', 'ステージング環境のSSL証明書を更新', '完了', NULL, ARRAY['demo-user-1'], 'kubun-unyo', 'high', 10, 'demo-user-1', NOW() - INTERVAL '7 days', NOW() - INTERVAL '5 days', NOW() - INTERVAL '10 days', NOW() - INTERVAL '5 days'),
 
 -- 未着手
   ('task-011', 'REG2017', 'パフォーマンス計測ツール導入', 'Core Web Vitals の計測基盤を構築', '未着手', NULL, ARRAY[]::text[], 'kubun-kaihatsu', 'low', 11, 'preview-user', NULL, NULL, NOW(), NOW()),
-  ('task-012', 'DES_FIRE', 'アイコンセット更新', 'Lucide Icons v0.300 への更新と不要アイコン削除', '未着手', NULL, ARRAY['demo-user-2'], 'kubun-design', 'low', 12, 'demo-user-2', NULL, NULL, NOW(), NOW())
+  ('task-012', 'BRGREG', 'アイコンセット更新', 'Lucide Icons v0.300 への更新と不要アイコン削除', '未着手', NULL, ARRAY['demo-user-2'], 'kubun-design', 'low', 12, 'demo-user-2', NULL, NULL, NOW(), NOW())
 ON CONFLICT (id) DO UPDATE SET
   title = EXCLUDED.title,
   description = EXCLUDED.description,
@@ -84,15 +85,28 @@ ON CONFLICT (id) DO UPDATE SET
   release_date = EXCLUDED.release_date,
   updated_at = NOW();
 
--- ===== タイマーセッション（完了済み） =====
+-- ===== タイマーセッション（完了済み・レポート確認用に多めに配置） =====
 INSERT INTO task_sessions (id, task_id, project_type, user_id, started_at, ended_at, duration_sec)
 VALUES
-  ('session-001', 'task-005', 'REG2017', 'preview-user', NOW() - INTERVAL '6 days' - INTERVAL '2 hours', NOW() - INTERVAL '6 days', 7200),
-  ('session-002', 'task-005', 'REG2017', 'preview-user', NOW() - INTERVAL '5 days' - INTERVAL '90 minutes', NOW() - INTERVAL '5 days', 5400),
-  ('session-003', 'task-007', 'BRGREG', 'preview-user', NOW() - INTERVAL '3 days' - INTERVAL '45 minutes', NOW() - INTERVAL '3 days', 2700),
-  ('session-004', 'task-006', 'MONO', 'demo-user-1', NOW() - INTERVAL '4 days' - INTERVAL '3 hours', NOW() - INTERVAL '4 days', 10800),
-  ('session-005', 'task-009', 'MONO', 'preview-user', NOW() - INTERVAL '8 days' - INTERVAL '1 hour', NOW() - INTERVAL '8 days', 3600),
-  ('session-006', 'task-010', 'BRGREG', 'demo-user-1', NOW() - INTERVAL '7 days' - INTERVAL '30 minutes', NOW() - INTERVAL '7 days', 1800)
+  -- task-001: トップページリニューアル (REG2017)
+  ('session-001', 'task-001', 'REG2017', 'preview-user', NOW() - INTERVAL '3 days' - INTERVAL '1 hour 30 minutes', NOW() - INTERVAL '3 days', 5400),
+  ('session-002', 'task-001', 'REG2017', 'demo-user-1',  NOW() - INTERVAL '2 days' - INTERVAL '2 hours', NOW() - INTERVAL '2 days', 7200),
+  -- task-003: FAQ追加 (BRGREG)
+  ('session-003', 'task-003', 'BRGREG',  'preview-user', NOW() - INTERVAL '1 day' - INTERVAL '45 minutes', NOW() - INTERVAL '1 day', 2700),
+  -- task-005: フォームバリデーション (REG2017)
+  ('session-004', 'task-005', 'REG2017', 'preview-user', NOW() - INTERVAL '6 days' - INTERVAL '2 hours', NOW() - INTERVAL '6 days', 7200),
+  ('session-005', 'task-005', 'REG2017', 'preview-user', NOW() - INTERVAL '5 days' - INTERVAL '1 hour 30 minutes', NOW() - INTERVAL '5 days', 5400),
+  ('session-006', 'task-005', 'REG2017', 'demo-user-2',  NOW() - INTERVAL '4 days' - INTERVAL '1 hour', NOW() - INTERVAL '4 days', 3600),
+  -- task-006: レスポンシブ対応 (REG2017)
+  ('session-007', 'task-006', 'REG2017', 'demo-user-1',  NOW() - INTERVAL '4 days' - INTERVAL '3 hours', NOW() - INTERVAL '4 days', 10800),
+  ('session-008', 'task-006', 'REG2017', 'preview-user', NOW() - INTERVAL '3 days' - INTERVAL '50 minutes', NOW() - INTERVAL '3 days', 3000),
+  -- task-007: メール配信停止リンク修正 (BRGREG)
+  ('session-009', 'task-007', 'BRGREG',  'preview-user', NOW() - INTERVAL '3 days' - INTERVAL '45 minutes', NOW() - INTERVAL '3 days', 2700),
+  ('session-010', 'task-007', 'BRGREG',  'preview-user', NOW() - INTERVAL '2 days' - INTERVAL '1 hour 15 minutes', NOW() - INTERVAL '2 days', 4500),
+  -- task-009: OGP画像設定 (REG2017, 完了)
+  ('session-011', 'task-009', 'REG2017', 'preview-user', NOW() - INTERVAL '8 days' - INTERVAL '1 hour', NOW() - INTERVAL '8 days', 3600),
+  -- task-010: SSL証明書更新 (BRGREG, 完了)
+  ('session-012', 'task-010', 'BRGREG',  'demo-user-1',  NOW() - INTERVAL '7 days' - INTERVAL '30 minutes', NOW() - INTERVAL '7 days', 1800)
 ON CONFLICT (id) DO NOTHING;
 
 -- ===== コメント =====
@@ -104,6 +118,18 @@ VALUES
   ('comment-004', 'task-007', 'BRGREG', 'demo-user-2', '<p>配信停止URLのパスが変わっていたようです。修正PRを出しています。</p>', ARRAY['preview-user'], ARRAY['demo-user-2'], NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
   ('comment-005', 'task-007', 'BRGREG', 'preview-user', '<p>確認しました。マージしてデプロイお願いします。</p>', ARRAY['demo-user-2'], ARRAY['preview-user'], NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day')
 ON CONFLICT (id) DO NOTHING;
+
+-- ===== お問い合わせ =====
+INSERT INTO contacts (id, type, title, content, user_id, user_name, user_email, status, created_at, updated_at)
+VALUES
+  ('contact-001', 'feature', 'ダッシュボードにグラフ表示がほしい', '月別のタスク完了数をグラフで可視化できると進捗が把握しやすいです。棒グラフか折れ線グラフで表示できると嬉しいです。', 'demo-user-1', '田中 太郎', 'tanaka@example.com', 'pending', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days'),
+  ('contact-002', 'error', 'タイマーが停止できない場合がある', 'ネットワークが不安定な環境でタイマー停止ボタンを押すと、ローディングのまま止まらないことがあります。再読み込みすると停止されていますが、UIが追従しません。', 'demo-user-2', '鈴木 花子', 'suzuki@example.com', 'pending', NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days'),
+  ('contact-003', 'feature', 'タスクの一括ステータス変更', '複数タスクを選択してまとめてステータスを変更できる機能がほしいです。月末のクローズ作業が楽になります。', 'preview-user', 'プレビューユーザー', 'preview@example.com', 'resolved', NOW() - INTERVAL '10 days', NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  content = EXCLUDED.content,
+  status = EXCLUDED.status,
+  updated_at = NOW();
 
 -- ===== ピン留め（テーブルが存在する場合のみ） =====
 DO $$

--- a/scripts/sync-from-neon.sh
+++ b/scripts/sync-from-neon.sh
@@ -66,7 +66,7 @@ if [[ -z "$NEON_URL" ]]; then
 fi
 
 # --- Docker コンテナ確認 ---
-if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'chumo-postgres\|chumo-test-postgres'; then
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'chumo-postgres'; then
   warn "ローカルの PostgreSQL コンテナが起動していません。起動します..."
   docker compose -f "$ROOT_DIR/docker-compose.yml" up -d postgres
   sleep 2

--- a/scripts/sync-from-neon.sh
+++ b/scripts/sync-from-neon.sh
@@ -66,7 +66,7 @@ if [[ -z "$NEON_URL" ]]; then
 fi
 
 # --- Docker コンテナ確認 ---
-if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'chumo-postgres'; then
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^chumo-postgres$'; then
   warn "ローカルの PostgreSQL コンテナが起動していません。起動します..."
   docker compose -f "$ROOT_DIR/docker-compose.yml" up -d postgres
   sleep 2


### PR DESCRIPTION
## Summary

- **プレビューモード**: ステージング環境をポートフォリオとして公開するための認証バイパス機能を追加。外部連携（Drive/Chat/GitHub/Backlog）とお問い合わせ作成はプレビュー時にブロック
- **シードデータ**: デモ用ユーザー・タスク12件・セッション12件・コメント5件・お問い合わせ3件の投入スクリプトを追加
- **Docker統一**: chumo-test-postgres を廃止し chumo-postgres に一本化。不要イメージも削除
- **ドキュメント**: SETUP.md にDB起動・シード・同期手順を追加。README/CLAUDE.md を現行スタックに更新

## 変更ファイル

### プレビューモード
- `backend/src/middleware/auth.ts` — X-Preview-Token 認証バイパス（production以外）
- `backend/src/index.ts` — Env型拡張 + CORS対応
- `backend/src/routes/users.ts` — プレビューユーザーのClerk fallbackスキップ
- `frontend/src/hooks/usePreviewMode.ts` — 新規: localStorage管理フック
- `frontend/src/hooks/useAuth.ts` — プレビュー時Clerkバイパス
- `frontend/src/components/auth/AuthGuard.tsx` — プレビュー時認証スキップ
- `frontend/src/pages/login/LoginPage.tsx` — プレビューログインボタン
- `frontend/src/hooks/useIntegrationActions.ts` — 外部連携ブロック（Backlog含む）
- `frontend/src/pages/reports/components/ReportToolbar.tsx` — Drive/スプレッドシートブロック
- `frontend/src/pages/settings/components/AdminTab.tsx` — メンバー追加ブロック
- `frontend/src/pages/contacts/ContactPage.tsx` — お問い合わせ作成ブロック
- `frontend/src/components/layout/Sidebar.tsx` — プレビューユーザー名フォールバック

### シード・Docker
- `scripts/seed.sql` — デモデータ定義
- `scripts/db-seed.sh` — ローカル/staging投入スクリプト
- `scripts/init-test-db.sh` — chumo_test DB自動作成
- `docker-compose.yml` — init script マウント追加
- `backend/wrangler.toml` — staging vars追加

### ドキュメント
- `SETUP.md` — DB起動・シード手順追加、文字化け修正
- `README.md` — 現行スタックに更新
- `CLAUDE.md` — lint/type-checkコメント統一

## Test plan

- [ ] `bun run type-check` パス
- [ ] `bun run lint` パス
- [ ] `bun run test` 全122テストパス
- [ ] プレビューログイン → ダッシュボード表示確認
- [ ] 外部連携ボタン（Drive/Chat/FIRE/PET/Backlog）→ トースト表示
- [ ] レポートページのDrive/スプレッドシートボタン → トースト表示
- [ ] メンバー追加ボタン → トースト表示
- [ ] お問い合わせ新規作成ボタン → トースト表示
- [ ] お問い合わせステータス変更 → 正常動作（ブロックしない）
- [ ] `bun run db:seed` でシード投入・冪等実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * プレビューモードを追加：ログイン画面から切替え可能、プレビュー時は疑似ログインで主要画面に入れる。

* **UX改善**
  * プレビュー中は外部連携（Drive、BACKLOG等）や一部作成/管理操作をブロックし、警告トーストで案内。
  * サイドバーとプロフィール表示にプレビュー用の表示名/役割を追加。

* **Documentation**
  * セットアップ手順を更新：ローカルDB起動、初期化、シード、同期、およびリセット手順を明確化。文言修正。  

* **Chores**
  * DBシード・初期化スクリプトと起動連携を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->