### PR TITLE
ステージングデプロイCIのトリガーブランチ修正

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,12 +3,52 @@ name: Deploy Staging
 on:
   push:
     branches:
-      - feature/backend-migration
+      - develop
     paths:
       - 'backend/**'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: chumo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: backend
+        run: bun install
+
+      - name: Run tests
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/chumo_test
+          CLERK_SECRET_KEY: test_secret_key
+          INTERNAL_API_KEY: test_internal_key
+        run: bun run test
+
+      - name: Type check
+        working-directory: backend
+        run: bunx tsc --noEmit
+
   deploy-backend:
+    needs: test
     runs-on: ubuntu-latest
     environment: staging
 


### PR DESCRIPTION
## Summary
- ステージングデプロイのトリガーブランチを `feature/backend-migration`（もう使われてない）→ `develop` に修正
- デプロイ前にテスト+型チェックのゲートを追加し、壊れたコードがステージングに上がるのを防止

## Background
タスク一覧ページで `projectType is required` エラーが発生していた。原因はフロントエンド（最新）とバックエンド（古い `feature/backend-migration` 時点のコード）のバージョンのズレ。バックエンドの自動デプロイが死んでいたため、`GET /api/tasks` で `projectType` が必須だった旧コードがステージングに残り続けていた。

## Test plan
- [ ] `develop` に backend 配下の変更をpushしてCIが発火することを確認
- [ ] テスト失敗時にデプロイがスキップされることを確認
- [ ] デプロイ後、`/tasks` ページでタスク一覧が正常に取得できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境へのデプロイ前に自動テストとTypeScriptの型チェックが実行されるようになりました。
  * デプロイメントワークフローが改善され、より信頼性の高い本番環境への反映が実現されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->