### PR TITLE
🐛 fix(backend): 0003マイグレの重複index作成を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 
 .claude/settings.local.json
 .claude/tmp
+.db-backups/

--- a/backend/src/db/migrations/0003_colossal_human_torch.sql
+++ b/backend/src/db/migrations/0003_colossal_human_torch.sql
@@ -1,5 +1,4 @@
 DROP INDEX "tasks_assignee_ids_idx";--> statement-breakpoint
 ALTER TABLE "tasks" ADD COLUMN "pet_issue_url" text;--> statement-breakpoint
 ALTER TABLE "users" ADD COLUMN "avatar_url" text;--> statement-breakpoint
-CREATE UNIQUE INDEX "task_sessions_user_active_idx" ON "task_sessions" USING btree ("user_id") WHERE "task_sessions"."ended_at" is null;--> statement-breakpoint
 CREATE INDEX "tasks_assignee_ids_idx" ON "tasks" USING gin ("assignee_ids");


### PR DESCRIPTION
## Summary

- 0003 マイグレが 0001 と同名の `task_sessions_user_active_idx` を再作成しようとして衝突していたため、該当行を削除
- `.db-backups/` をローカルDBダンプ置き場として `.gitignore` に追加

## 背景

`Deploy Staging` workflow の `Run migrations` ステップで以下のエラーが発生した:

```
PostgresError: column "pet_issue_url" of relation "tasks" already exists
```

調査の結果、staging DB は `__drizzle_migrations` に 0000〜0002 しか履歴が無く、0003 相当のカラム追加は別経路で実体反映済みという履歴不整合が起きていた。これをリセットしてクリーン再適用しようとすると、今度は次のエラーが発生:

```
PostgresError: relation "task_sessions_user_active_idx" already exists
```

根本原因は **0003 の `drizzle-kit generate` が 0001 の手書きマイグレーションを検知できず、同名 index の再作成 DDL を生成してしまっていた** こと。

## 修正内容

`backend/src/db/migrations/0003_colossal_human_torch.sql` から重複 index 作成の 1 行を削除:

```sql
- CREATE UNIQUE INDEX "task_sessions_user_active_idx" ON "task_sessions" USING btree ("user_id") WHERE "task_sessions"."ended_at" is null;--> statement-breakpoint
```

この index は `0001_timer_unique_active_session.sql` で既に作成されている。

## 本番反映状況

- staging / production DB とも、public/drizzle スキーマを DROP → 0000〜0006 を再適用 → Firestore からデータ再投入 済
- Deploy Staging workflow（run #24628681146）は再実行で success 確認済
- バックアップは `.db-backups/` にローカル保持（ignore 対象）

## Test plan

- [x] staging Neon への `drizzle-kit migrate` がクリーン環境で通ることを確認
- [x] production Neon への `drizzle-kit migrate` がクリーン環境で通ることを確認
- [x] Deploy Staging workflow の再実行が成功
- [x] Firestore 再投入後の件数一致（tasks 175, sessions 1051 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)