### PR TITLE
🐛 fix(backend): 本番Worker名をchumo-apiに修正

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -27,7 +27,7 @@ bucket_name = "chumo-uploads-staging"
 
 # --- Production ---
 [env.production]
-name = "chumo-api-production"
+name = "chumo-api"
 [env.production.vars]
 ENVIRONMENT = "production"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"


### PR DESCRIPTION
## Summary

- `backend/wrangler.toml` の `[env.production]` の `name` を `chumo-api-production` → `chumo-api` に修正
- これまで `wrangler deploy --env production` が本物の本番Worker `chumo-api` ではなく、別Worker `chumo-api-production` を新規作成してしまっていた

## 背景

本番環境で以下の不具合が発生していた:

- **KPIカードの完了件数が0のまま**（`includeCompleted=true` を付けて取得するフロントの最新修正が反映されず）
- **セッション未記録通知が動かない**（neon-http 対応の修正が反映されず）

原因は `wrangler.toml` の Worker 名ミスマッチで、実際の本番 Worker が 7 日以上前のまま放置されていたこと。
GitHub Actions のデプロイログ上は「成功」に見えるが、存在しない／誰も使っていない `chumo-api-production` Worker を生成していた。

ステージングは `chumo-api-staging` で動作しており、本番もルート直下の `name = "chumo-api"` と揃える形に戻す。

## Test plan

- [ ] PR マージ後、`Deploy Production` ワークフローが発火し `chumo-api` Worker が更新されること
- [ ] CF ダッシュボードで `chumo-api` Worker の更新日時が最新になっていること
- [ ] 本番ダッシュボードで KPI カードの完了件数が正しく集計されること
- [ ] 本番でセッション未記録通知が送信できること
- [ ] 不要になった `chumo-api-production` Worker を CF ダッシュボードから削除する（手動）

🤖 Generated with [Claude Code](https://claude.ai/code)