### PR TITLE
develop を main へマージ（本番Worker名修正の反映）

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -27,7 +27,7 @@ bucket_name = "chumo-uploads-staging"
 
 # --- Production ---
 [env.production]
-name = "chumo-api-production"
+name = "chumo-api"
 [env.production.vars]
 ENVIRONMENT = "production"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"


### PR DESCRIPTION
## Summary

- `backend/wrangler.toml` の本番Worker名を `chumo-api-production` → `chumo-api` に修正（#141）
- 本番 auto deploy が本物の `chumo-api` Worker を更新できるようにする

## 背景

本番環境で以下の不具合が発生していた:

- KPIカードの完了件数が0のまま（フロント側の `includeCompleted=true` 修正が反映されず）
- セッション未記録通知が動かない（neon-http 対応の修正が反映されず）

原因は `wrangler.toml` の Worker 名ミスマッチで、`wrangler deploy --env production` が本物の本番 Worker ではなく別 Worker を新規作成していたため。
本 PR を main へ取り込むと、main push で `Deploy Production` ワークフローが発火し、本物の `chumo-api` Worker が最新コードに更新される。

## Test plan

- [ ] マージ後、`Deploy Production` ワークフローが成功すること
- [ ] CF ダッシュボードで `chumo-api` Worker の更新日時が最新になっていること
- [ ] 本番ダッシュボードで KPI カードの完了件数が集計されること
- [ ] 本番でセッション未記録通知が送信できること
- [ ] 不要な `chumo-api-production` Worker を CF ダッシュボードから削除（手動）

🤖 Generated with [Claude Code](https://claude.ai/code)