### PR TITLE
🔧 chore(backend): Workers observability 有効化 + backlog webhook 診断ログ追加

### DIFF
--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -23,9 +23,18 @@ const app = new Hono<BacklogEnv>();
 // --- POST /webhook ---
 
 app.post('/webhook', async (c) => {
+  const ua = c.req.header('User-Agent') ?? '';
+  const hasSecretHeader = Boolean(c.req.header('X-Backlog-Webhook-Secret'));
+  const hasSecretQuery = Boolean(c.req.query('secret'));
+  console.info('[backlog/webhook] received', { ua, hasSecretHeader, hasSecretQuery });
+
   // Webhook認証: 共有シークレットで検証
   const secret = c.req.header('X-Backlog-Webhook-Secret') ?? c.req.query('secret');
   if (!secret || secret !== c.env.BACKLOG_WEBHOOK_SECRET) {
+    console.warn('[backlog/webhook] rejected: invalid secret', {
+      hasSecretHeader,
+      hasSecretQuery,
+    });
     return c.json({ error: 'Invalid webhook secret' }, 401);
   }
 
@@ -34,18 +43,28 @@ app.post('/webhook', async (c) => {
 
   // ペイロードから課題情報を抽出
   const { issueKey, issueId, title, description, customFields } = extractIssueFromPayload(body);
+  console.info('[backlog/webhook] parsed', {
+    issueKey,
+    issueId,
+    hasTitle: Boolean(title),
+    hasDescription: description !== undefined,
+    customFieldsCount: customFields?.length ?? 0,
+  });
 
   if (!issueKey) {
+    console.warn('[backlog/webhook] rejected: missing issueKey');
     return c.json({ error: 'Missing issueKey in webhook payload' }, 400);
   }
 
   // 課題番号からプロジェクトタイプを抽出
   const projectType = extractProjectTypeFromIssueKey(issueKey);
   if (!projectType) {
+    console.warn('[backlog/webhook] rejected: unknown projectType', { issueKey });
     return c.json({ error: `Could not extract project type from issueKey: ${issueKey}` }, 400);
   }
 
   if (!title) {
+    console.warn('[backlog/webhook] rejected: missing title', { issueKey });
     return c.json({ error: 'Missing title in webhook payload' }, 400);
   }
 
@@ -98,6 +117,12 @@ app.post('/webhook', async (c) => {
       })
       .where(eq(taskExternals.taskId, existingExternal.taskId));
 
+    console.info('[backlog/webhook] updated task', {
+      taskId: existingExternal.taskId,
+      issueKey,
+      projectType,
+    });
+
     return c.json({
       success: true,
       taskId: existingExternal.taskId,
@@ -138,6 +163,8 @@ app.post('/webhook', async (c) => {
     lastSyncedAt: now,
     syncStatus: 'ok',
   });
+
+  console.info('[backlog/webhook] created task', { taskId, issueKey, projectType });
 
   return c.json({ success: true, taskId, projectType, issueKey });
 });

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -3,6 +3,10 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [vars]
 ENVIRONMENT = "development"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -19,6 +19,9 @@ bucket_name = "chumo-uploads"
 # --- Staging ---
 [env.staging]
 name = "chumo-api-staging"
+[env.staging.observability]
+enabled = true
+head_sampling_rate = 1
 [env.staging.vars]
 ENVIRONMENT = "staging"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"
@@ -32,6 +35,9 @@ bucket_name = "chumo-uploads-staging"
 # --- Production ---
 [env.production]
 name = "chumo-api"
+[env.production.observability]
+enabled = true
+head_sampling_rate = 1
 [env.production.vars]
 ENVIRONMENT = "production"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"


### PR DESCRIPTION
## Summary

- Backlog からのタスク同期が 2026-04-16 以降停止していた件の調査対応
- Cloudflare Workers の observability を dev / staging / production で有効化し、過去ログ（7日分）を検索可能に
- `/api/backlog/webhook` に診断ログ（受信・解析・保存・拒否理由）を追加

## 背景

- 本番 `chumo-api` は observability 無効で、過去ログの生データが残っていなかった
- DB 上、`task_externals.source='backlog'` の `last_synced_at` 最終値が `2026-04-16 02:25 UTC` で 5 日以上停止
- Backlog 側は新規課題が追加され続けており、疎通不能 or Worker 側でエラーで弾いている可能性が高い

## 変更点

- `backend/wrangler.toml`: top-level / `[env.staging]` / `[env.production]` に `[observability]` セクションを追加（Wrangler の environment は top-level を継承しないため個別指定）
- `backend/src/routes/backlog.ts`: webhook 処理の入口・解析結果・DB 書込結果・拒否パスに `console.info` / `console.warn` を追加

## 検証

- [x] `bun run type-check`
- [x] `bun run lint`
- [x] `bun run test` — backlog テスト 10 件 pass
- [x] staging にデプロイ済み（`chumo-api-staging`）
- [x] Backlog 管理画面の「Webhook テスト」から staging URL に送信 → ログ出力確認OK
  - `[backlog/webhook] received` → `parsed` → `rejected: unknown projectType`
  - ※ テストペイロードは `PROJECT_TYPES` に含まれない projectType だったため想定動作

## 次アクション（このPR後）

- develop → main でマージ後、本番 `chumo-api` にもデプロイ
- 本番で webhook が到達し、実際にどの projectType が来ているか観測
- 未登録の projectType があれば `backend/src/lib/backlog.ts` の `PROJECT_TYPES` / `BACKLOG_CUSTOM_FIELDS` に追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* バックエンドシステムの内部監視機能を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->