### PR TITLE
🚀 release: Backlog webhook observability 有効化を本番反映

### DIFF
--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -23,9 +23,18 @@ const app = new Hono<BacklogEnv>();
 // --- POST /webhook ---
 
 app.post('/webhook', async (c) => {
+  const ua = c.req.header('User-Agent') ?? '';
+  const hasSecretHeader = Boolean(c.req.header('X-Backlog-Webhook-Secret'));
+  const hasSecretQuery = Boolean(c.req.query('secret'));
+  console.info('[backlog/webhook] received', { ua, hasSecretHeader, hasSecretQuery });
+
   // Webhook認証: 共有シークレットで検証
   const secret = c.req.header('X-Backlog-Webhook-Secret') ?? c.req.query('secret');
   if (!secret || secret !== c.env.BACKLOG_WEBHOOK_SECRET) {
+    console.warn('[backlog/webhook] rejected: invalid secret', {
+      hasSecretHeader,
+      hasSecretQuery,
+    });
     return c.json({ error: 'Invalid webhook secret' }, 401);
   }
 
@@ -34,18 +43,28 @@ app.post('/webhook', async (c) => {
 
   // ペイロードから課題情報を抽出
   const { issueKey, issueId, title, description, customFields } = extractIssueFromPayload(body);
+  console.info('[backlog/webhook] parsed', {
+    issueKey,
+    issueId,
+    hasTitle: Boolean(title),
+    hasDescription: description !== undefined,
+    customFieldsCount: customFields?.length ?? 0,
+  });
 
   if (!issueKey) {
+    console.warn('[backlog/webhook] rejected: missing issueKey');
     return c.json({ error: 'Missing issueKey in webhook payload' }, 400);
   }
 
   // 課題番号からプロジェクトタイプを抽出
   const projectType = extractProjectTypeFromIssueKey(issueKey);
   if (!projectType) {
+    console.warn('[backlog/webhook] rejected: unknown projectType', { issueKey });
     return c.json({ error: `Could not extract project type from issueKey: ${issueKey}` }, 400);
   }
 
   if (!title) {
+    console.warn('[backlog/webhook] rejected: missing title', { issueKey });
     return c.json({ error: 'Missing title in webhook payload' }, 400);
   }
 
@@ -98,6 +117,12 @@ app.post('/webhook', async (c) => {
       })
       .where(eq(taskExternals.taskId, existingExternal.taskId));
 
+    console.info('[backlog/webhook] updated task', {
+      taskId: existingExternal.taskId,
+      issueKey,
+      projectType,
+    });
+
     return c.json({
       success: true,
       taskId: existingExternal.taskId,
@@ -138,6 +163,8 @@ app.post('/webhook', async (c) => {
     lastSyncedAt: now,
     syncStatus: 'ok',
   });
+
+  console.info('[backlog/webhook] created task', { taskId, issueKey, projectType });
 
   return c.json({ success: true, taskId, projectType, issueKey });
 });

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -3,6 +3,10 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [vars]
 ENVIRONMENT = "development"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -19,6 +19,9 @@ bucket_name = "chumo-uploads"
 # --- Staging ---
 [env.staging]
 name = "chumo-api-staging"
+[env.staging.observability]
+enabled = true
+head_sampling_rate = 1
 [env.staging.vars]
 ENVIRONMENT = "staging"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"
@@ -32,6 +35,9 @@ bucket_name = "chumo-uploads-staging"
 # --- Production ---
 [env.production]
 name = "chumo-api"
+[env.production.observability]
+enabled = true
+head_sampling_rate = 1
 [env.production.vars]
 ENVIRONMENT = "production"
 REPORT_DRIVE_PARENT_ID = "1fw86FpPA_5dWAo6WW7RKM8DuU0aD5YNH"


### PR DESCRIPTION
## Summary

- #143 のマージ分を本番 (`chumo-api`) に反映するためのリリースPR
- Cloudflare Workers の observability を有効化し、過去ログ（7日分）を検索可能に
- `/api/backlog/webhook` に診断ログを追加

## 含まれる変更

- 🔧 chore(backend): Workers observability 有効化 + backlog webhook 診断ログ追加 (#143)
- 🔧 chore(backend): staging/production にも observability 設定を追加 (#143)

## 背景

- Backlog からのタスク同期が 2026-04-16 以降停止している件の調査対応
- staging (`chumo-api-staging`) では observability 有効化＋診断ログ追加済み
- Backlog 管理画面の Webhook テストで staging への疎通は確認済み
- 本番反映後、実際に届く webhook ペイロードをログから観測する

## デプロイ後の確認手順

1. 本番 Worker の observability が `enabled=true` になっていることを確認
   ```bash
   # ダッシュボード: Workers & Pages → chumo-api → Settings → Observability
   ```
2. Backlog 側から実 webhook が届いたら Logs を検索
   ```
   message: "[backlog/webhook]"
   ```
3. `[backlog/webhook] rejected: unknown projectType` が出ていたら `issueKey` を確認し、`backend/src/lib/backlog.ts` の `PROJECT_TYPES` / `BACKLOG_CUSTOM_FIELDS` に追加する

## Test plan

- [x] staging で diagnostic ログの出力確認済み（Backlog Webhook テスト経由）
- [ ] 本番デプロイ後、Cloudflare ダッシュボードから観測ログが取得できることを確認
- [ ] Backlog から実リクエストが届き、想定どおりのログが出力されることを確認