### PR TITLE
✨ feat(tasks): プロジェクト区分 FAQ_IMP を追加

### DIFF
--- a/backend/src/db/migrations/0007_chemical_fixer.sql
+++ b/backend/src/db/migrations/0007_chemical_fixer.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."project_type" ADD VALUE 'FAQ_IMP';

--- a/backend/src/db/migrations/meta/0007_snapshot.json
+++ b/backend/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1311 @@
+{
+  "id": "c44e4ee7-10e5-404b-9de2-eb62bbe72aba",
+  "prevId": "b39fd73e-0e90-4de3-91a7-da3b6660b1ac",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "contact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_report_details": {
+          "name": "error_report_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_idx": {
+          "name": "notifications_recipient_id_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_task_id_tasks_id_fk": {
+          "name": "notifications_task_id_tasks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "backlog_project_key": {
+          "name": "backlog_project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_parent_id": {
+          "name": "drive_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_activities": {
+      "name": "task_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_activities_task_id_idx": {
+          "name": "task_activities_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_activities_task_id_tasks_id_fk": {
+          "name": "task_activities_task_id_tasks_id_fk",
+          "tableFrom": "task_activities",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_ids": {
+          "name": "mentioned_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "read_by": {
+          "name": "read_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_comments_task_id_idx": {
+          "name": "task_comments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_comments_author_id_idx": {
+          "name": "task_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_comments_task_id_tasks_id_fk": {
+          "name": "task_comments_task_id_tasks_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_externals": {
+      "name": "task_externals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "external_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_externals_task_id_tasks_id_fk": {
+          "name": "task_externals_task_id_tasks_id_fk",
+          "tableFrom": "task_externals",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_externals_task_id_unique": {
+          "name": "task_externals_task_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pins": {
+      "name": "task_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pins_user_task_idx": {
+          "name": "task_pins_user_task_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_user_id_idx": {
+          "name": "task_pins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pins_task_id_tasks_id_fk": {
+          "name": "task_pins_task_id_tasks_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_sessions": {
+      "name": "task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_sessions_task_id_idx": {
+          "name": "task_sessions_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_id_idx": {
+          "name": "task_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_ended_at_idx": {
+          "name": "task_sessions_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_active_idx": {
+          "name": "task_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_sessions_task_id_tasks_id_fk": {
+          "name": "task_sessions_task_id_tasks_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flow_status": {
+          "name": "flow_status",
+          "type": "flow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'未着手'"
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_ids": {
+          "name": "assignee_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "it_up_date": {
+          "name": "it_up_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kubun_label_id": {
+          "name": "kubun_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_drive_url": {
+          "name": "google_drive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fire_issue_url": {
+          "name": "fire_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_chat_thread_url": {
+          "name": "google_chat_thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlog_url": {
+          "name": "backlog_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_issue_url": {
+          "name": "pet_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "over3_reason": {
+          "name": "over3_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_reminders": {
+          "name": "session_reminders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_project_type_idx": {
+          "name": "tasks_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_flow_status_idx": {
+          "name": "tasks_flow_status_idx",
+          "columns": [
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_assignee_ids_idx": {
+          "name": "tasks_assignee_ids_idx",
+          "columns": [
+            {
+              "expression": "assignee_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "tasks_order_idx": {
+          "name": "tasks_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_project_type_flow_status_idx": {
+          "name": "tasks_project_type_flow_status_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_allowed": {
+          "name": "is_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_color": {
+          "name": "avatar_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_oauth_updated_at": {
+          "name": "google_oauth_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcm_tokens": {
+          "name": "fcm_tokens",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": ["sync", "timerStart", "timerStop", "update", "driveCreate", "fireCreate"]
+    },
+    "public.contact_status": {
+      "name": "contact_status",
+      "schema": "public",
+      "values": ["pending", "resolved"]
+    },
+    "public.contact_type": {
+      "name": "contact_type",
+      "schema": "public",
+      "values": ["error", "feature", "other"]
+    },
+    "public.external_source": {
+      "name": "external_source",
+      "schema": "public",
+      "values": ["backlog"]
+    },
+    "public.flow_status": {
+      "name": "flow_status",
+      "schema": "public",
+      "values": ["未着手", "ディレクション", "コーディング", "デザイン", "待ち", "対応中", "完了"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["mention", "session_reminder"]
+    },
+    "public.priority": {
+      "name": "priority",
+      "schema": "public",
+      "values": ["low", "medium", "high", "urgent"]
+    },
+    "public.progress_status": {
+      "name": "progress_status",
+      "schema": "public",
+      "values": [
+        "未着手",
+        "仕様確認",
+        "待ち",
+        "調査",
+        "見積",
+        "CO",
+        "ロック解除待ち",
+        "デザイン",
+        "コーディング",
+        "品管チェック",
+        "FAQ公開申請",
+        "IT連絡済み",
+        "ST連絡済み",
+        "SENJU登録",
+        "親課題"
+      ]
+    },
+    "public.project_type": {
+      "name": "project_type",
+      "schema": "public",
+      "values": [
+        "REG2017",
+        "BRGREG",
+        "MONO",
+        "MONO_ADMIN",
+        "DES_FIRE",
+        "DesignSystem",
+        "DMREG2",
+        "monosus",
+        "PRREG",
+        "FAQ_IMP"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["ok", "failed"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775894757939,
       "tag": "0006_dazzling_frog_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1780367091692,
+      "tag": "0007_chemical_fixer",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.test.ts
+++ b/backend/src/db/schema.test.ts
@@ -1,9 +1,36 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { eq } from 'drizzle-orm';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { createTestDb, cleanDatabase } from './test-helpers';
 import * as schema from './schema';
+import { projectTypeEnum } from './schema';
 
 const { db, client } = createTestDb();
+
+/**
+ * ドリフト検知: frontend の PROJECT_TYPES は手動メンテのため、
+ * DB enum (project_type) と値がズレていないかをここで保証する。
+ * frontend↔backend は別パッケージで定数を共有できないため、ソースを読んで突き合わせる。
+ */
+describe('schema: project_type enum とフロントの同期', () => {
+  it('frontend の PROJECT_TYPES が project_type enum と一致する', () => {
+    const frontendTypesPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../../frontend/src/types/index.ts'
+    );
+    const src = readFileSync(frontendTypesPath, 'utf-8');
+
+    const block = src.match(/export const PROJECT_TYPES = \[([\s\S]*?)\] as const;/);
+    expect(block, 'frontend に PROJECT_TYPES 定義が見つからない').not.toBeNull();
+
+    const frontendValues = [...block![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+
+    // 値の集合が一致すること（表示順の差異は許容するため sort で比較）
+    expect([...frontendValues].sort()).toEqual([...projectTypeEnum.enumValues].sort());
+  });
+});
 
 afterEach(async () => {
   await cleanDatabase(db);

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -56,6 +56,7 @@ export const projectTypeEnum = pgEnum('project_type', [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ]);
 
 export const contactTypeEnum = pgEnum('contact_type', ['error', 'feature', 'other']);

--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -22,6 +22,10 @@ describe('Backlog ユーティリティ', () => {
       expect(extractProjectTypeFromIssueKey('MONO-100')).toBe('MONO');
     });
 
+    it('FAQ_IMP-10 → FAQ_IMP（アンダースコア入りキー）', () => {
+      expect(extractProjectTypeFromIssueKey('FAQ_IMP-10')).toBe('FAQ_IMP');
+    });
+
     it('不明なプロジェクトキー → null', () => {
       expect(extractProjectTypeFromIssueKey('UNKNOWN-100')).toBeNull();
     });
@@ -108,6 +112,11 @@ describe('Backlog ユーティリティ', () => {
     it('MONOは空オブジェクトを返す', () => {
       const config = getCustomFieldConfig('MONO');
       expect(config.itUpDate).toBeUndefined();
+    });
+
+    it('FAQ_IMPは空オブジェクトを返す', () => {
+      const config = getCustomFieldConfig('FAQ_IMP');
+      expect(config).toEqual({});
     });
 
     it('不明なプロジェクトは空オブジェクトを返す', () => {

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -12,6 +12,7 @@ const PROJECT_TYPES = [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ] as const;
 
 type ProjectType = (typeof PROJECT_TYPES)[number];
@@ -33,6 +34,7 @@ const BACKLOG_CUSTOM_FIELDS: Record<ProjectType, BacklogCustomFieldConfig> = {
   DesignSystem: {},
   DMREG2: { itUpDate: 1073767877, releaseDate: 1073767878 },
   monosus: {},
+  FAQ_IMP: {},
 };
 
 export function getCustomFieldConfig(projectType: string): BacklogCustomFieldConfig {

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -2,20 +2,12 @@
  * Backlog連携ユーティリティ
  */
 
-const PROJECT_TYPES = [
-  'REG2017',
-  'BRGREG',
-  'MONO',
-  'MONO_ADMIN',
-  'DES_FIRE',
-  'DesignSystem',
-  'DMREG2',
-  'monosus',
-  'PRREG',
-  'FAQ_IMP',
-] as const;
+import { projectTypeEnum } from '../db/schema';
 
-type ProjectType = (typeof PROJECT_TYPES)[number];
+/** project_type enum を唯一のソースとして参照（重複定義しない） */
+const PROJECT_TYPES = projectTypeEnum.enumValues;
+
+type ProjectType = (typeof projectTypeEnum.enumValues)[number];
 
 // --- カスタムフィールド設定 ---
 

--- a/backend/src/routes/reports.test.ts
+++ b/backend/src/routes/reports.test.ts
@@ -56,6 +56,26 @@ async function seedReportData() {
     createdBy: 'test-user',
   });
 
+  // タスク: FAQ_IMP + 運用（レポート対象 faq_imp、normalからは除外される）
+  await db.insert(schema.tasks).values({
+    id: 'task-faq-unyo',
+    projectType: 'FAQ_IMP',
+    title: 'FAQ_IMP運用タスク',
+    kubunLabelId: 'kubun-unyo',
+    order: 1,
+    createdBy: 'test-user',
+  });
+
+  // タスク: FAQ_IMP + 開発（区分不問で faq_imp に含まれることの検証用）
+  await db.insert(schema.tasks).values({
+    id: 'task-faq-dev',
+    projectType: 'FAQ_IMP',
+    title: 'FAQ_IMP開発タスク',
+    kubunLabelId: 'kubun-kaihatsu',
+    order: 2,
+    createdBy: 'test-user',
+  });
+
   // タスク: MONO + 開発（レポート対象外）
   await db.insert(schema.tasks).values({
     id: 'task-mono-dev',
@@ -134,6 +154,28 @@ async function seedReportData() {
     durationSec: 14400,
   });
 
+  // セッション: task-faq-unyo に 30分（1800秒）
+  await db.insert(schema.taskSessions).values({
+    id: 'session-faq-1',
+    taskId: 'task-faq-unyo',
+    projectType: 'FAQ_IMP',
+    userId: 'test-user',
+    startedAt: new Date(baseDate.getTime()),
+    endedAt: new Date(baseDate.getTime() + 1800 * 1000),
+    durationSec: 1800,
+  });
+
+  // セッション: task-faq-dev に 15分（900秒、区分=開発でも faq_imp に含まれる）
+  await db.insert(schema.taskSessions).values({
+    id: 'session-faq-2',
+    taskId: 'task-faq-dev',
+    projectType: 'FAQ_IMP',
+    userId: 'test-user',
+    startedAt: new Date(baseDate.getTime()),
+    endedAt: new Date(baseDate.getTime() + 900 * 1000),
+    durationSec: 900,
+  });
+
   // セッション: 対象期間外（レポートに含まれない）
   await db.insert(schema.taskSessions).values({
     id: 'session-out-of-range',
@@ -194,6 +236,31 @@ describe('Reports API', () => {
       expect(body.items).toHaveLength(1);
       expect(body.totalDurationSec).toBe(7200);
       expect(body.items[0].taskId).toBe('task-brg-1');
+    });
+
+    it('faq_impタイプは区分不問でFAQ_IMPの全タスクを集計する', async () => {
+      await seedReportData();
+
+      const res = await app.request('/api/reports/time?from=2025-06-01&to=2025-06-30&type=faq_imp');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      // faq_imp = FAQ_IMP全タスク（区分不問）→ task-faq-unyo(1800) + task-faq-dev(900)
+      expect(body.items).toHaveLength(2);
+      expect(body.totalDurationSec).toBe(1800 + 900);
+
+      const taskIds = body.items.map((i: { taskId: string }) => i.taskId).sort();
+      expect(taskIds).toEqual(['task-faq-dev', 'task-faq-unyo']);
+    });
+
+    it('normalタイプはFAQ_IMP（運用区分）を含まない', async () => {
+      await seedReportData();
+
+      const res = await app.request('/api/reports/time?from=2025-06-01&to=2025-06-30&type=normal');
+      const body = (await res.json()) as any;
+
+      const faqTask = body.items.find((i: { taskId: string }) => i.taskId === 'task-faq-unyo');
+      expect(faqTask).toBeUndefined();
     });
 
     it('開発区分のタスクはレポートに含まれない', async () => {

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod/v4';
 import { zValidator } from '@hono/zod-validator';
 import { eq, and, gte, lte, isNull, inArray } from 'drizzle-orm';
-import { tasks, taskSessions, labels, users } from '../db/schema';
+import { tasks, taskSessions, labels, users, projectTypeEnum } from '../db/schema';
 import {
   getAccessToken,
   driveSearchFiles,
@@ -22,20 +22,30 @@ const app = new Hono<ReportEnv>();
 /** レポート集計の種別 */
 type ReportFetchType = 'normal' | 'brg' | 'faq_imp';
 
+type ProjectTypeValue = (typeof projectTypeEnum.enumValues)[number];
+
 /** 独立してレポート集計するプロジェクトタイプ（集計種別 → projectType） */
-const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, string> = {
+const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, ProjectTypeValue> = {
   brg: 'BRGREG',
   faq_imp: 'FAQ_IMP',
 };
 
+const STANDALONE_PROJECT_TYPES = new Set<string>(Object.values(STANDALONE_REPORT_PROJECT));
+
 /** 独立集計タイプ（通常集計からは除外する） */
 function isStandaloneReportProject(projectType: string): boolean {
-  return Object.values(STANDALONE_REPORT_PROJECT).includes(projectType);
+  return STANDALONE_PROJECT_TYPES.has(projectType);
 }
 
 /** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
 function normalizeReportType(value: string | undefined): ReportFetchType {
-  return value === 'brg' || value === 'faq_imp' ? value : 'normal';
+  return value && value in STANDALONE_REPORT_PROJECT ? (value as ReportFetchType) : 'normal';
+}
+
+/** 「運用」区分ラベルのIDを取得（無ければ null） */
+async function getUnyoLabelId(db: Database): Promise<string | null> {
+  const allLabels = await db.select().from(labels).where(isNull(labels.projectId));
+  return allLabels.find((l) => l.name === '運用')?.id ?? null;
 }
 
 /** CSVインジェクション防止: 先頭が数式トリガー文字の場合にシングルクォートをプレフィクス */
@@ -70,17 +80,15 @@ async function fetchReportData(
   fromDate: Date,
   toDate: Date,
   type: ReportFetchType,
+  unyoLabelId: string | null,
   userId?: string
 ): Promise<{ items: ReportItem[]; totalDurationSec: number }> {
-  // 1. 「運用」区分ラベルのIDを取得
-  const allLabels = await db.select().from(labels).where(isNull(labels.projectId));
-
-  const unyoLabel = allLabels.find((l) => l.name === '運用');
-  if (!unyoLabel) {
+  // 「運用」区分ラベルが無ければ集計対象なし
+  if (!unyoLabelId) {
     return { items: [], totalDurationSec: 0 };
   }
 
-  // 2. 対象タスクを取得
+  // 対象タスクを取得
   // 独立集計タイプ(BRG/FAQ_IMP): projectType一致の全タスク（kubunLabelId不問）
   // 通常タイプ: kubunLabelId=運用 のタスクのうち、独立集計タイプを除外
   const taskSelect = {
@@ -93,18 +101,15 @@ async function fetchReportData(
 
   let targetTasks: TaskRow[];
   if (type !== 'normal') {
-    const targetProjectType = STANDALONE_REPORT_PROJECT[type];
     targetTasks = await db
       .select(taskSelect)
       .from(tasks)
-      .where(
-        eq(tasks.projectType, targetProjectType as (typeof tasks.projectType.enumValues)[number])
-      );
+      .where(eq(tasks.projectType, STANDALONE_REPORT_PROJECT[type]));
   } else {
     const allTasks = await db
       .select(taskSelect)
       .from(tasks)
-      .where(eq(tasks.kubunLabelId, unyoLabel.id));
+      .where(eq(tasks.kubunLabelId, unyoLabelId));
     targetTasks = allTasks.filter((t) => !isStandaloneReportProject(t.projectType));
   }
 
@@ -198,7 +203,15 @@ app.get('/time', async (c) => {
   toDate.setHours(23, 59, 59, 999);
 
   const userId = c.get('userId');
-  const { items, totalDurationSec } = await fetchReportData(db, fromDate, toDate, type, userId);
+  const unyoLabelId = await getUnyoLabelId(db);
+  const { items, totalDurationSec } = await fetchReportData(
+    db,
+    fromDate,
+    toDate,
+    type,
+    unyoLabelId,
+    userId
+  );
 
   return c.json({ items, totalDurationSec });
 });
@@ -226,7 +239,8 @@ app.get('/time/csv', async (c) => {
 
   toDate.setHours(23, 59, 59, 999);
 
-  const { items } = await fetchReportData(db, fromDate, toDate, type);
+  const unyoLabelId = await getUnyoLabelId(db);
+  const { items } = await fetchReportData(db, fromDate, toDate, type, unyoLabelId);
 
   // CSV生成（UTF-8+BOM/CRLF）
   const BOM = '\uFEFF';
@@ -457,10 +471,11 @@ app.post('/time/export', zValidator('json', exportSchema), async (c) => {
   );
   toDate.setHours(23, 59, 59, 999);
 
+  const unyoLabelId = await getUnyoLabelId(db);
   const [normalData, brgData, faqImpData] = await Promise.all([
-    fetchReportData(db, fromDate, toDate, 'normal'),
-    fetchReportData(db, fromDate, toDate, 'brg'),
-    fetchReportData(db, fromDate, toDate, 'faq_imp'),
+    fetchReportData(db, fromDate, toDate, 'normal', unyoLabelId),
+    fetchReportData(db, fromDate, toDate, 'brg', unyoLabelId),
+    fetchReportData(db, fromDate, toDate, 'faq_imp', unyoLabelId),
   ]);
 
   // 「データ」シートにデータ書き込み

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -29,6 +29,7 @@ const PROJECT_TYPES = [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ] as const;
 
 function isBRGREGProject(projectType: string): boolean {

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -19,21 +19,23 @@ type ReportEnv = Env & { Variables: { db: Database; userId: string } };
 
 const app = new Hono<ReportEnv>();
 
-const PROJECT_TYPES = [
-  'REG2017',
-  'BRGREG',
-  'MONO',
-  'MONO_ADMIN',
-  'DES_FIRE',
-  'DesignSystem',
-  'DMREG2',
-  'monosus',
-  'PRREG',
-  'FAQ_IMP',
-] as const;
+/** レポート集計の種別 */
+type ReportFetchType = 'normal' | 'brg' | 'faq_imp';
 
-function isBRGREGProject(projectType: string): boolean {
-  return projectType === 'BRGREG';
+/** 独立してレポート集計するプロジェクトタイプ（集計種別 → projectType） */
+const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, string> = {
+  brg: 'BRGREG',
+  faq_imp: 'FAQ_IMP',
+};
+
+/** 独立集計タイプ（通常集計からは除外する） */
+function isStandaloneReportProject(projectType: string): boolean {
+  return Object.values(STANDALONE_REPORT_PROJECT).includes(projectType);
+}
+
+/** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
+function normalizeReportType(value: string | undefined): ReportFetchType {
+  return value === 'brg' || value === 'faq_imp' ? value : 'normal';
 }
 
 /** CSVインジェクション防止: 先頭が数式トリガー文字の場合にシングルクォートをプレフィクス */
@@ -67,7 +69,7 @@ async function fetchReportData(
   db: Database,
   fromDate: Date,
   toDate: Date,
-  type: 'normal' | 'brg',
+  type: ReportFetchType,
   userId?: string
 ): Promise<{ items: ReportItem[]; totalDurationSec: number }> {
   // 1. 「運用」区分ラベルのIDを取得
@@ -78,14 +80,9 @@ async function fetchReportData(
     return { items: [], totalDurationSec: 0 };
   }
 
-  // 2. 対象プロジェクトタイプをフィルタ
-  const targetTypes = PROJECT_TYPES.filter((pt) =>
-    type === 'brg' ? isBRGREGProject(pt) : !isBRGREGProject(pt)
-  );
-
-  // 3. 対象タスクを取得
-  // BRGタイプ: projectType=BRGREG の全タスク（kubunLabelId不問）
-  // 通常タイプ: kubunLabelId=運用 のタスクのみ
+  // 2. 対象タスクを取得
+  // 独立集計タイプ(BRG/FAQ_IMP): projectType一致の全タスク（kubunLabelId不問）
+  // 通常タイプ: kubunLabelId=運用 のタスクのうち、独立集計タイプを除外
   const taskSelect = {
     id: tasks.id,
     title: tasks.title,
@@ -95,16 +92,20 @@ async function fetchReportData(
   };
 
   let targetTasks: TaskRow[];
-  if (type === 'brg') {
-    targetTasks = await db.select(taskSelect).from(tasks).where(eq(tasks.projectType, 'BRGREG'));
+  if (type !== 'normal') {
+    const targetProjectType = STANDALONE_REPORT_PROJECT[type];
+    targetTasks = await db
+      .select(taskSelect)
+      .from(tasks)
+      .where(
+        eq(tasks.projectType, targetProjectType as (typeof tasks.projectType.enumValues)[number])
+      );
   } else {
     const allTasks = await db
       .select(taskSelect)
       .from(tasks)
       .where(eq(tasks.kubunLabelId, unyoLabel.id));
-    targetTasks = allTasks.filter((t) =>
-      targetTypes.includes(t.projectType as (typeof PROJECT_TYPES)[number])
-    );
+    targetTasks = allTasks.filter((t) => !isStandaloneReportProject(t.projectType));
   }
 
   if (targetTasks.length === 0) {
@@ -180,7 +181,7 @@ app.get('/time', async (c) => {
   const db = c.get('db');
   const from = c.req.query('from');
   const to = c.req.query('to');
-  const type = (c.req.query('type') ?? 'normal') as 'normal' | 'brg';
+  const type = normalizeReportType(c.req.query('type'));
 
   if (!from || !to) {
     return c.json({ error: 'Missing required parameters: from, to' }, 400);
@@ -210,7 +211,7 @@ app.get('/time/csv', async (c) => {
   const db = c.get('db');
   const from = c.req.query('from');
   const to = c.req.query('to');
-  const type = (c.req.query('type') ?? 'normal') as 'normal' | 'brg';
+  const type = normalizeReportType(c.req.query('type'));
 
   if (!from || !to) {
     return c.json({ error: 'Missing required parameters: from, to' }, 400);
@@ -264,25 +265,31 @@ function formatDuration(sec: number): string {
  */
 function buildDataSheetRows(
   normalItems: ReportItem[],
-  brgItems: ReportItem[]
+  brgItems: ReportItem[],
+  faqImpItems: ReportItem[]
 ): (string | number)[][] {
   const rows: (string | number)[][] = [];
 
+  const pushSection = (heading: string, items: ReportItem[]) => {
+    rows.push([heading, '', '']);
+    rows.push(['案件名', '実績時間', '3時間超内容']);
+    for (const item of items) {
+      rows.push([item.title, formatDuration(item.durationSec), item.over3hours || '']);
+    }
+  };
+
   // 通常セクション
-  rows.push(['■通常■', '', '']);
-  rows.push(['案件名', '実績時間', '3時間超内容']);
-  for (const item of normalItems) {
-    rows.push([item.title, formatDuration(item.durationSec), item.over3hours || '']);
-  }
+  pushSection('■通常■', normalItems);
 
   rows.push(['', '', '']); // 空行
 
   // BRGセクション
-  rows.push(['■BRG■', '', '']);
-  rows.push(['案件名', '実績時間', '3時間超内容']);
-  for (const item of brgItems) {
-    rows.push([item.title, formatDuration(item.durationSec), item.over3hours || '']);
-  }
+  pushSection('■BRG■', brgItems);
+
+  rows.push(['', '', '']); // 空行
+
+  // FAQ_IMPセクション
+  pushSection('■FAQ_IMP■', faqImpItems);
 
   return rows;
 }
@@ -450,13 +457,14 @@ app.post('/time/export', zValidator('json', exportSchema), async (c) => {
   );
   toDate.setHours(23, 59, 59, 999);
 
-  const [normalData, brgData] = await Promise.all([
+  const [normalData, brgData, faqImpData] = await Promise.all([
     fetchReportData(db, fromDate, toDate, 'normal'),
     fetchReportData(db, fromDate, toDate, 'brg'),
+    fetchReportData(db, fromDate, toDate, 'faq_imp'),
   ]);
 
   // 「データ」シートにデータ書き込み
-  const rows = buildDataSheetRows(normalData.items, brgData.items);
+  const rows = buildDataSheetRows(normalData.items, brgData.items, faqImpData.items);
   const range = `データ!A1:C${rows.length}`;
   const written = await sheetsUpdateValues(accessToken, spreadsheetId, range, rows);
   if (!written) {

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -21,9 +21,13 @@ export type { ReportItem };
 
 /**
  * レポートデータを取得
- * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg
+ * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg|faq_imp
  */
-export function useReportData(type: 'normal' | 'brg', fromDate: string, toDate: string) {
+export function useReportData(
+  type: 'normal' | 'brg' | 'faq_imp',
+  fromDate: string,
+  toDate: string
+) {
   const { getToken, isSignedIn } = useAuth();
 
   return useQuery({
@@ -40,7 +44,7 @@ export function useReportData(type: 'normal' | 'brg', fromDate: string, toDate: 
  * レポートCSVをダウンロード
  */
 export async function downloadReportCsv(
-  type: 'normal' | 'brg',
+  type: 'normal' | 'brg' | 'faq_imp',
   fromDate: string,
   toDate: string,
   getToken: () => Promise<string | null>

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../lib/api';
 import { queryKeys } from '../lib/queryKeys';
 import { useAuth } from './useAuth';
+import type { ReportType } from '../types';
 
 interface ReportItem {
   title: string;
@@ -23,11 +24,7 @@ export type { ReportItem };
  * レポートデータを取得
  * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg|faq_imp
  */
-export function useReportData(
-  type: 'normal' | 'brg' | 'faq_imp',
-  fromDate: string,
-  toDate: string
-) {
+export function useReportData(type: ReportType, fromDate: string, toDate: string) {
   const { getToken, isSignedIn } = useAuth();
 
   return useQuery({
@@ -44,7 +41,7 @@ export function useReportData(
  * レポートCSVをダウンロード
  */
 export async function downloadReportCsv(
-  type: 'normal' | 'brg' | 'faq_imp',
+  type: ReportType,
   fromDate: string,
   toDate: string,
   getToken: () => Promise<string | null>

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -222,6 +222,7 @@ export function ReportPage() {
           <TabList>
             <Tab id="all">通常</Tab>
             <Tab id="brg">BRG</Tab>
+            <Tab id="faq_imp">FAQ_IMP</Tab>
           </TabList>
 
           <div className="mt-6 space-y-6">
@@ -249,6 +250,9 @@ export function ReportPage() {
                   <ReportTable entries={entries} onRowClick={handleRowClick} />
                 </TabPanel>
                 <TabPanel id="brg">
+                  <ReportTable entries={entries} onRowClick={handleRowClick} />
+                </TabPanel>
+                <TabPanel id="faq_imp">
                   <ReportTable entries={entries} onRowClick={handleRowClick} />
                 </TabPanel>
               </>

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -18,6 +18,12 @@ import { useToast } from '../../hooks/useToast';
 import { HttpError } from '../../lib/api';
 import type { ReportEntry, ReportType, TaskSession } from '../../types';
 
+const REPORT_TABS: { id: ReportType | 'all'; label: string }[] = [
+  { id: 'all', label: '通常' },
+  { id: 'brg', label: 'BRG' },
+  { id: 'faq_imp', label: 'FAQ_IMP' },
+];
+
 function getLastDayOfMonth(year: number, month: number): number {
   return new Date(year, month, 0).getDate();
 }
@@ -220,9 +226,11 @@ export function ReportPage() {
 
         <Tabs selectedKey={activeTab} onSelectionChange={handleTabChange}>
           <TabList>
-            <Tab id="all">通常</Tab>
-            <Tab id="brg">BRG</Tab>
-            <Tab id="faq_imp">FAQ_IMP</Tab>
+            {REPORT_TABS.map((t) => (
+              <Tab key={t.id} id={t.id}>
+                {t.label}
+              </Tab>
+            ))}
           </TabList>
 
           <div className="mt-6 space-y-6">
@@ -245,17 +253,11 @@ export function ReportPage() {
                 レポートの取得に失敗しました: {error.message}
               </div>
             ) : (
-              <>
-                <TabPanel id="all">
+              REPORT_TABS.map((t) => (
+                <TabPanel key={t.id} id={t.id}>
                   <ReportTable entries={entries} onRowClick={handleRowClick} />
                 </TabPanel>
-                <TabPanel id="brg">
-                  <ReportTable entries={entries} onRowClick={handleRowClick} />
-                </TabPanel>
-                <TabPanel id="faq_imp">
-                  <ReportTable entries={entries} onRowClick={handleRowClick} />
-                </TabPanel>
-              </>
+              ))
             )}
           </div>
         </Tabs>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -213,7 +213,7 @@ export interface AppNotification {
   createdAt: string;
 }
 
-export type ReportType = 'normal' | 'brg';
+export type ReportType = 'normal' | 'brg' | 'faq_imp';
 
 export interface ReportEntry {
   id: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,7 @@ export const PROJECT_TYPES = [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ] as const;
 
 export type ProjectType = (typeof PROJECT_TYPES)[number];


### PR DESCRIPTION
## 概要

タスクのプロジェクト区分（`project_type`）に新しく `FAQ_IMP` を追加します。Backlog の issueKey 接頭辞（例 `FAQ_IMP-123`）としても利用できます。

## 変更内容

| ファイル | 変更 |
|---|---|
| `backend/src/db/schema.ts` | `projectTypeEnum` に `'FAQ_IMP'` を追加 |
| `backend/src/db/migrations/0007_chemical_fixer.sql`（新規） | `ALTER TYPE "public"."project_type" ADD VALUE 'FAQ_IMP';` |
| `backend/src/lib/backlog.ts` | `PROJECT_TYPES` + `BACKLOG_CUSTOM_FIELDS` に `FAQ_IMP: {}` を追加 |
| `backend/src/routes/reports.ts` | `PROJECT_TYPES` に追加 |
| `frontend/src/types/index.ts` | `PROJECT_TYPES` に追加（フィルタ・作成フォームへ自動反映） |

## 補足

- Backlog カスタムフィールド（ITアップ日 / リリース日）は **なし（空 `{}`）** で登録。必要になれば後から追加可能。
- enum は **末尾** に追加（`PRREG` の後）。

## 動作確認

- ✅ `bun run type-check` パス
- ✅ `bun run lint` パス（0 errors）
- ✅ `bun run test` 123/123 パス（ローカル Docker Postgres にて）

## ⚠️ デプロイ時の手動ステップ

各環境で DB マイグレーションの適用が必要です。

```bash
bun run backend:db:migrate   # development
# staging / production はデプロイ手順に従って 0007 を適用
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しいプロジェクトタイプ「FAQ_IMP」をシステムに追加しました。プロジェクト管理、レポート生成、カスタムフィールド設定など、システム全体で利用可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->