### PR TITLE
🐛 fix(users): メンバー招待のエラーハンドリング強化と原因可視化

### DIFF
--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -1,12 +1,39 @@
-import { describe, it, expect, afterAll, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, afterEach, beforeEach, vi } from 'vitest';
+import { createClerkClient } from '@clerk/backend';
 import { createTestApp, db, client } from './test-app';
 import { cleanDatabase } from '../db/test-helpers';
 import * as schema from '../db/schema';
 import { eq } from 'drizzle-orm';
 
+// Clerk SDK 全体をモック化。
+// /me の Clerk fallback は getUser が reject されれば 404 に落ちるだけなので既存テストに無害。
+// /invite 系は各テスト内で createInvitation の挙動を上書きする。
+vi.mock('@clerk/backend', () => ({
+  createClerkClient: vi.fn(),
+}));
+
+const mockedCreateClerkClient = vi.mocked(createClerkClient);
+
+function setClerkMock(overrides: {
+  createInvitation?: ReturnType<typeof vi.fn>;
+  getUser?: ReturnType<typeof vi.fn>;
+}) {
+  mockedCreateClerkClient.mockReturnValue({
+    invitations: {
+      createInvitation: overrides.createInvitation ?? vi.fn().mockResolvedValue({ id: 'inv_mock' }),
+    },
+    users: {
+      getUser: overrides.getUser ?? vi.fn().mockRejectedValue(new Error('clerk mock not set')),
+    },
+  } as unknown as ReturnType<typeof createClerkClient>);
+}
+
 const app = createTestApp();
 
 beforeEach(async () => {
+  // 各テストの先頭で Clerk モックをデフォルト状態にリセット
+  setClerkMock({});
+
   await db.insert(schema.users).values({
     id: 'test-user',
     email: 'test@example.com',
@@ -243,6 +270,117 @@ describe('Users API', () => {
       expect(String(body.error)).toContain('APP_ORIGIN');
 
       // 早期 return なので DB にプレースホルダーは作られない
+      const [shouldNotExist] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, 'new@example.com'));
+      expect(shouldNotExist).toBeUndefined();
+    });
+
+    it('APP_ORIGIN が URL 形式不正なら 500 を返す', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const res = await adminApp.request(
+        '/api/users/invite',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+        },
+        { APP_ORIGIN: 'localhost:3000' }
+      );
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as any;
+      expect(String(body.error)).toContain('APP_ORIGIN');
+    });
+
+    it('Clerk が 4xx を返したら 400 で詳細メッセージを返す', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const clerkErr = {
+        status: 422,
+        errors: [
+          {
+            long_message: 'redirect_url is not allowed for this instance',
+            code: 'redirect_url_not_allowed',
+          },
+        ],
+      };
+      setClerkMock({
+        createInvitation: vi.fn().mockRejectedValue(clerkErr),
+      });
+
+      const res = await adminApp.request(
+        '/api/users/invite',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+        },
+        { APP_ORIGIN: 'https://example.com' }
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as any;
+      expect(body.error).toContain('redirect_url is not allowed');
+
+      // DB プレースホルダーは補償削除されている
+      const [shouldNotExist] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, 'new@example.com'));
+      expect(shouldNotExist).toBeUndefined();
+    });
+
+    it('Clerk が 5xx / 例外なら 500 で汎用メッセージを返し内部エラーを露出しない', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      setClerkMock({
+        createInvitation: vi
+          .fn()
+          .mockRejectedValue(new Error('Internal Clerk error: secret_leak_xyz')),
+      });
+
+      const res = await adminApp.request(
+        '/api/users/invite',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+        },
+        { APP_ORIGIN: 'https://example.com' }
+      );
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as any;
+      // 内部メッセージは漏らさない
+      expect(body.error).not.toContain('secret_leak_xyz');
+      // 汎用メッセージは返す
+      expect(body.error).toContain('招待の送信に失敗');
+
+      // 補償削除されている
       const [shouldNotExist] = await db
         .select()
         .from(schema.users)

--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -156,6 +156,101 @@ describe('Users API', () => {
     });
   });
 
+  describe('POST /api/users/invite', () => {
+    it('管理者以外は403', async () => {
+      const res = await app.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('既存の有効なメールは409', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const res = await adminApp.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'test@example.com', role: 'member' }),
+      });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('無効化されたユーザーは再有効化される', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      await db.insert(schema.users).values({
+        id: 'disabled-user',
+        email: 'disabled@example.com',
+        displayName: 'Disabled',
+        role: 'member',
+        isAllowed: false,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const res = await adminApp.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'disabled@example.com', role: 'admin' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.restored).toBe(true);
+
+      const [restored] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, 'disabled-user'));
+      expect(restored.isAllowed).toBe(true);
+      expect(restored.role).toBe('admin');
+    });
+
+    it('APP_ORIGIN 未設定なら 500 で明示メッセージを返す', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      // APP_ORIGIN が空のままリクエスト
+      const res = await adminApp.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+      });
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as any;
+      expect(String(body.error)).toContain('APP_ORIGIN');
+
+      // 早期 return なので DB にプレースホルダーは作られない
+      const [shouldNotExist] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, 'new@example.com'));
+      expect(shouldNotExist).toBeUndefined();
+    });
+  });
+
   describe('POST /api/users/me/fcm-tokens', () => {
     it('FCMトークンを追加できる', async () => {
       const res = await app.request('/api/users/me/fcm-tokens', {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -293,6 +293,13 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       500
     );
   }
+  // APP_ORIGIN がプロトコル抜け等の不正 URL だと Clerk 側で 400 になるため、ここで弾く
+  try {
+    new URL(appOrigin);
+  } catch {
+    console.error('[invite] APP_ORIGIN is not a valid URL', { appOrigin });
+    return c.json({ error: 'サーバー設定エラー: APP_ORIGIN の形式が不正です' }, 500);
+  }
 
   // DBにプレースホルダーユーザーを先に作成（整合性確保）
   const invitedId = `invited_${crypto.randomUUID()}`;
@@ -325,8 +332,10 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       errors?: Array<{ message?: string; long_message?: string; code?: string }>;
     };
     const clerkErrors = Array.isArray(clerkErr.errors) ? clerkErr.errors : [];
+    // PII を生で残さないようメアドはマスクしてログ
+    const maskedEmail = email.replace(/(^.).*(@.*$)/, '$1***$2');
     console.error('[invite] Clerk invitation failed', {
-      email,
+      email: maskedEmail,
       role,
       redirectUrl: `${appOrigin}/login`,
       status: clerkErr.status,
@@ -334,18 +343,17 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       raw: e instanceof Error ? e.message : String(e),
     });
 
-    // 4xx は Clerk が返した詳細メッセージをそのまま返し、500 は汎用メッセージで返す
-    const detail = clerkErrors
-      .map((err) => err.long_message || err.message || '')
-      .filter(Boolean)
-      .join(' / ');
-    const fallback = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
-    const message = detail || fallback;
+    // 4xx は Clerk が返した詳細メッセージをそのまま返す。5xx は内部情報露出を避けて固定文言
     const status = clerkErr.status;
     if (status && status >= 400 && status < 500) {
-      return c.json({ error: message }, 400);
+      const detail = clerkErrors
+        .map((err) => err.long_message || err.message || '')
+        .filter(Boolean)
+        .join(' / ');
+      const fallback = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+      return c.json({ error: detail || fallback }, 400);
     }
-    return c.json({ error: message }, 500);
+    return c.json({ error: '招待の送信に失敗しました。時間をおいて再試行してください。' }, 500);
   }
 
   return c.json({ success: true });

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -284,6 +284,16 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
     return c.json({ error: 'このメールアドレスは既に登録されています' }, 409);
   }
 
+  // APP_ORIGIN が未設定だと Clerk が redirectUrl を弾いて Bad Request になるため、事前に検知する
+  const appOrigin = c.env.APP_ORIGIN;
+  if (!appOrigin) {
+    console.error('[invite] APP_ORIGIN is not configured');
+    return c.json(
+      { error: 'サーバー設定エラー: APP_ORIGIN が未設定のため招待を送信できません' },
+      500
+    );
+  }
+
   // DBにプレースホルダーユーザーを先に作成（整合性確保）
   const invitedId = `invited_${crypto.randomUUID()}`;
   await db.insert(users).values({
@@ -296,7 +306,6 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
 
   // Clerk 招待送信（DB insert 成功後）
   const clerkClient = createClerkClient({ secretKey: c.env.CLERK_SECRET_KEY });
-  const appOrigin = c.env.APP_ORIGIN;
 
   try {
     await clerkClient.invitations.createInvitation({
@@ -309,7 +318,33 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       .delete(users)
       .where(eq(users.id, invitedId))
       .catch(() => {});
-    const message = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+
+    // Clerk SDK の例外から詳細を取り出し、構造化ログに残す
+    const clerkErr = e as {
+      status?: number;
+      errors?: Array<{ message?: string; long_message?: string; code?: string }>;
+    };
+    const clerkErrors = Array.isArray(clerkErr.errors) ? clerkErr.errors : [];
+    console.error('[invite] Clerk invitation failed', {
+      email,
+      role,
+      redirectUrl: `${appOrigin}/login`,
+      status: clerkErr.status,
+      errors: clerkErrors,
+      raw: e instanceof Error ? e.message : String(e),
+    });
+
+    // 4xx は Clerk が返した詳細メッセージをそのまま返し、500 は汎用メッセージで返す
+    const detail = clerkErrors
+      .map((err) => err.long_message || err.message || '')
+      .filter(Boolean)
+      .join(' / ');
+    const fallback = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+    const message = detail || fallback;
+    const status = clerkErr.status;
+    if (status && status >= 400 && status < 500) {
+      return c.json({ error: message }, 400);
+    }
     return c.json({ error: message }, 500);
   }
 


### PR DESCRIPTION
## 背景

メンバー招待で 500 エラーが発生。画面には `Bad Request` という生メッセージのみ表示されており、原因が特定できない状態だった。

ログ調査の結果、`/api/users/invite` で 500 を返している箇所は Clerk 招待呼び出しの catch のみで、`console.error` が無いためサーバーログにも詳細が残らない。

## 主な仮説

- `APP_ORIGIN` が secret として未設定（または不正値）で `redirectUrl: ${undefined}/login` になり、Clerk が `Bad Request` を返している可能性が最有力
- 新規メアド（Clerk にも未登録）で再現していることもこの仮説と整合

## 変更内容

### `backend/src/routes/users.ts`

- `APP_ORIGIN` 未設定を Clerk 呼び出し前に検知し、明示メッセージで 500 を返す（DB プレースホルダーも作らない）
- Clerk SDK の例外から `status` / `errors[]` / `long_message` を抜き出し、構造化ログを `console.error` で出力
- Clerk が返した 4xx は **400** でクライアントへ転送（500 から変更）
- 画面に "Bad Request" ではなく、Clerk が返した `long_message`（例: `redirect_url is not a valid URL`）を表示できる

### `backend/src/routes/users.test.ts`

Clerk 到達前の分岐に対するテストを追加：

- 管理者以外 → 403
- 既存有効メール → 409
- 無効化ユーザーは再有効化 → 200 `{ restored: true }`
- `APP_ORIGIN` 未設定 → 500、DB プレースホルダー未作成

## 検証手順

1. このブランチを develop へマージ→ デプロイ
2. 再度メンバー招待を実施
3. 画面のエラーメッセージで具体的な原因が判明する想定
4. `APP_ORIGIN` が未設定なら `bunx wrangler secret put APP_ORIGIN` で設定

## 並行で確認したいこと

- `bunx wrangler secret list`（chumo-api） に `APP_ORIGIN` が存在するか
- 存在する場合、値が `https://chumo-ekd.pages.dev` 等の正しい URL になっているか

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ユーザー招待機能のエラーハンドリングを改善しました。設定欠落時の早期検出とAPI失敗時の詳細なエラー情報をログに記録するようになりました。

* **Tests**
  * ユーザー招待機能に関する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->