### PR TITLE
🐛 fix(users): APP_ORIGIN の http(s) スキーマ検証を厳格化（#148 フォローアップ）

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -293,11 +293,18 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       500
     );
   }
-  // APP_ORIGIN がプロトコル抜け等の不正 URL だと Clerk 側で 400 になるため、ここで弾く
+  // APP_ORIGIN がプロトコル抜け等の不正 URL だと Clerk 側で 400 になるため、ここで弾く。
+  // new URL('localhost:3000') は throw しない（'localhost:' をスキーマ扱いする）ので
+  // http(s) であることまで明示的に検証する。
+  let isValidHttpUrl = false;
   try {
-    new URL(appOrigin);
+    const parsed = new URL(appOrigin);
+    isValidHttpUrl = parsed.protocol === 'http:' || parsed.protocol === 'https:';
   } catch {
-    console.error('[invite] APP_ORIGIN is not a valid URL', { appOrigin });
+    isValidHttpUrl = false;
+  }
+  if (!isValidHttpUrl) {
+    console.error('[invite] APP_ORIGIN is not a valid http(s) URL', { appOrigin });
     return c.json({ error: 'サーバー設定エラー: APP_ORIGIN の形式が不正です' }, 500);
   }
 


### PR DESCRIPTION
## 背景

PR #148 マージ後、ローカルでテスト実行したら 1 件落ちることに気づいた。

\`\`\`
× POST /api/users/invite > APP_ORIGIN が URL 形式不正なら 500 を返す
  expected 200 to be 500
\`\`\`

## 原因

\`new URL('localhost:3000')\` は **throw されない**。\`localhost:\` をスキーマとして解釈してしまうため、\`try-catch\` だけでは弾けない。

## 修正

URL parse 成功時に \`protocol === 'http:' || 'https:'\` であることを明示的に検証する。

\`\`\`ts
let isValidHttpUrl = false;
try {
  const parsed = new URL(appOrigin);
  isValidHttpUrl = parsed.protocol === 'http:' || parsed.protocol === 'https:';
} catch {
  isValidHttpUrl = false;
}
if (!isValidHttpUrl) {
  console.error('[invite] APP_ORIGIN is not a valid http(s) URL', { appOrigin });
  return c.json({ error: 'サーバー設定エラー: APP_ORIGIN の形式が不正です' }, 500);
}
\`\`\`

## 検証

ローカルで \`bun run test\` 実行し **19/19 全件 pass**。

\`\`\`
✓ APP_ORIGIN 未設定なら 500 で明示メッセージを返す
✓ APP_ORIGIN が URL 形式不正なら 500 を返す  ← 今回の修正対象
✓ Clerk が 4xx を返したら 400 で詳細メッセージを返す
✓ Clerk が 5xx / 例外なら 500 で汎用メッセージを返し内部エラーを露出しない
（他 15 件）
\`\`\`

🤖 Generated with [Claude Code](https://claude.ai/code)