### PR TITLE
✨ feat: partner ロールとパートナー稼働時間レポート

### DIFF
--- a/backend/src/db/migrations/0008_lush_moira_mactaggert.sql
+++ b/backend/src/db/migrations/0008_lush_moira_mactaggert.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."user_role" ADD VALUE 'partner';

--- a/backend/src/db/migrations/meta/0008_snapshot.json
+++ b/backend/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1311 @@
+{
+  "id": "9fb05396-5730-4520-9dbc-c4d807e624ab",
+  "prevId": "c44e4ee7-10e5-404b-9de2-eb62bbe72aba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "contact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_report_details": {
+          "name": "error_report_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_idx": {
+          "name": "notifications_recipient_id_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_task_id_tasks_id_fk": {
+          "name": "notifications_task_id_tasks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "backlog_project_key": {
+          "name": "backlog_project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_parent_id": {
+          "name": "drive_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_activities": {
+      "name": "task_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_activities_task_id_idx": {
+          "name": "task_activities_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_activities_task_id_tasks_id_fk": {
+          "name": "task_activities_task_id_tasks_id_fk",
+          "tableFrom": "task_activities",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_ids": {
+          "name": "mentioned_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "read_by": {
+          "name": "read_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_comments_task_id_idx": {
+          "name": "task_comments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_comments_author_id_idx": {
+          "name": "task_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_comments_task_id_tasks_id_fk": {
+          "name": "task_comments_task_id_tasks_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_externals": {
+      "name": "task_externals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "external_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_externals_task_id_tasks_id_fk": {
+          "name": "task_externals_task_id_tasks_id_fk",
+          "tableFrom": "task_externals",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_externals_task_id_unique": {
+          "name": "task_externals_task_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pins": {
+      "name": "task_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pins_user_task_idx": {
+          "name": "task_pins_user_task_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_user_id_idx": {
+          "name": "task_pins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pins_task_id_tasks_id_fk": {
+          "name": "task_pins_task_id_tasks_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_sessions": {
+      "name": "task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_sessions_task_id_idx": {
+          "name": "task_sessions_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_id_idx": {
+          "name": "task_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_ended_at_idx": {
+          "name": "task_sessions_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_active_idx": {
+          "name": "task_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_sessions_task_id_tasks_id_fk": {
+          "name": "task_sessions_task_id_tasks_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flow_status": {
+          "name": "flow_status",
+          "type": "flow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'未着手'"
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_ids": {
+          "name": "assignee_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "it_up_date": {
+          "name": "it_up_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kubun_label_id": {
+          "name": "kubun_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_drive_url": {
+          "name": "google_drive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fire_issue_url": {
+          "name": "fire_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_chat_thread_url": {
+          "name": "google_chat_thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlog_url": {
+          "name": "backlog_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_issue_url": {
+          "name": "pet_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "over3_reason": {
+          "name": "over3_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_reminders": {
+          "name": "session_reminders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_project_type_idx": {
+          "name": "tasks_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_flow_status_idx": {
+          "name": "tasks_flow_status_idx",
+          "columns": [
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_assignee_ids_idx": {
+          "name": "tasks_assignee_ids_idx",
+          "columns": [
+            {
+              "expression": "assignee_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "tasks_order_idx": {
+          "name": "tasks_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_project_type_flow_status_idx": {
+          "name": "tasks_project_type_flow_status_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_allowed": {
+          "name": "is_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_color": {
+          "name": "avatar_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_oauth_updated_at": {
+          "name": "google_oauth_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcm_tokens": {
+          "name": "fcm_tokens",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": ["sync", "timerStart", "timerStop", "update", "driveCreate", "fireCreate"]
+    },
+    "public.contact_status": {
+      "name": "contact_status",
+      "schema": "public",
+      "values": ["pending", "resolved"]
+    },
+    "public.contact_type": {
+      "name": "contact_type",
+      "schema": "public",
+      "values": ["error", "feature", "other"]
+    },
+    "public.external_source": {
+      "name": "external_source",
+      "schema": "public",
+      "values": ["backlog"]
+    },
+    "public.flow_status": {
+      "name": "flow_status",
+      "schema": "public",
+      "values": ["未着手", "ディレクション", "コーディング", "デザイン", "待ち", "対応中", "完了"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["mention", "session_reminder"]
+    },
+    "public.priority": {
+      "name": "priority",
+      "schema": "public",
+      "values": ["low", "medium", "high", "urgent"]
+    },
+    "public.progress_status": {
+      "name": "progress_status",
+      "schema": "public",
+      "values": [
+        "未着手",
+        "仕様確認",
+        "待ち",
+        "調査",
+        "見積",
+        "CO",
+        "ロック解除待ち",
+        "デザイン",
+        "コーディング",
+        "品管チェック",
+        "FAQ公開申請",
+        "IT連絡済み",
+        "ST連絡済み",
+        "SENJU登録",
+        "親課題"
+      ]
+    },
+    "public.project_type": {
+      "name": "project_type",
+      "schema": "public",
+      "values": [
+        "REG2017",
+        "BRGREG",
+        "MONO",
+        "MONO_ADMIN",
+        "DES_FIRE",
+        "DesignSystem",
+        "DMREG2",
+        "monosus",
+        "PRREG",
+        "FAQ_IMP"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["ok", "failed"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "member", "partner"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1780367091692,
       "tag": "0007_chemical_fixer",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782201791257,
+      "tag": "0008_lush_moira_mactaggert",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.test.ts
+++ b/backend/src/db/schema.test.ts
@@ -60,6 +60,20 @@ describe('schema: users', () => {
     expect(user.createdAt).toBeInstanceOf(Date);
   });
 
+  it('partner ロールを保存できる', async () => {
+    await db.insert(schema.users).values({
+      id: 'user-partner',
+      email: 'partner@example.com',
+      displayName: 'パートナーユーザー',
+      role: 'partner',
+      isAllowed: true,
+    });
+
+    const [user] = await db.select().from(schema.users).where(eq(schema.users.id, 'user-partner'));
+
+    expect(user.role).toBe('partner');
+  });
+
   it('fcmTokens 配列を保存できる', async () => {
     await db.insert(schema.users).values({
       id: 'user-2',

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -14,7 +14,7 @@ import { sql } from 'drizzle-orm';
 
 // --- Enums ---
 
-export const userRoleEnum = pgEnum('user_role', ['admin', 'member']);
+export const userRoleEnum = pgEnum('user_role', ['admin', 'member', 'partner']);
 
 export const flowStatusEnum = pgEnum('flow_status', [
   '未着手',

--- a/backend/src/routes/reports.test.ts
+++ b/backend/src/routes/reports.test.ts
@@ -616,5 +616,105 @@ describe('Reports API', () => {
       const res = await app.request('/api/reports/time/partners?from=invalid&to=2025-06-30');
       expect(res.status).toBe(400);
     });
+
+    it('存在しない日付（2025-02-30 等）は400を返す', async () => {
+      const res = await app.request('/api/reports/time/partners?from=2025-02-30&to=2025-06-30');
+      expect(res.status).toBe(400);
+    });
+
+    it('from > to は400を返す', async () => {
+      const res = await app.request('/api/reports/time/partners?from=2025-06-30&to=2025-06-01');
+      expect(res.status).toBe(400);
+    });
+
+    it('月またぎセッションは期間内の重なり時間で按分される', async () => {
+      // セットアップ: partner + task
+      await db.insert(schema.users).values({
+        id: 'partner-cross',
+        email: 'partner-cross@example.com',
+        displayName: '月またぎパートナー',
+        role: 'partner',
+        isAllowed: true,
+      });
+      await db.insert(schema.labels).values({
+        id: 'kubun-cross',
+        name: 'cross-kubun',
+        color: '#888888',
+        projectId: null,
+        ownerId: 'partner-cross',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'cross-task',
+        projectType: 'MONO',
+        title: '月またぎタスク',
+        kubunLabelId: 'kubun-cross',
+        order: 1,
+        createdBy: 'partner-cross',
+      });
+      // 5/31 23:00 → 6/1 02:00（3時間 = 10800秒）
+      await db.insert(schema.taskSessions).values({
+        id: 'cross-session',
+        taskId: 'cross-task',
+        projectType: 'MONO',
+        userId: 'partner-cross',
+        startedAt: new Date('2025-05-31T23:00:00Z'),
+        endedAt: new Date('2025-06-01T02:00:00Z'),
+        durationSec: 10800,
+      });
+
+      // 6月レポートを取得（期間と重なるのは 6/1 00:00 ～ 6/1 02:00 = 7200秒）
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      const partner = body.partners.find((p: { userId: string }) => p.userId === 'partner-cross');
+      expect(partner).toBeDefined();
+      expect(partner.totalDurationSec).toBe(7200);
+      expect(partner.tasks[0].durationSec).toBe(7200);
+
+      // 5月レポートを取得（期間と重なるのは 5/31 23:00 ～ 5/31 24:00 = 3600秒）
+      const res5 = await app.request('/api/reports/time/partners?from=2025-05-01&to=2025-05-31');
+      const body5 = (await res5.json()) as any;
+      const partner5 = body5.partners.find((p: { userId: string }) => p.userId === 'partner-cross');
+      expect(partner5).toBeDefined();
+      expect(partner5.totalDurationSec).toBe(3600);
+    });
+  });
+
+  describe('GET /api/reports/time (月またぎ按分)', () => {
+    it('月またぎセッションは normal レポートでも期間内の重なり時間で按分される', async () => {
+      await db.insert(schema.labels).values({
+        id: 'kubun-unyo',
+        name: '運用',
+        color: '#00897B',
+        projectId: null,
+        ownerId: 'test-user',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'task-cross',
+        projectType: 'MONO',
+        title: 'normal月またぎタスク',
+        kubunLabelId: 'kubun-unyo',
+        order: 1,
+        createdBy: 'test-user',
+      });
+      // 5/31 22:00 → 6/1 02:00（4時間 = 14400秒）。6月の重なりは2時間 = 7200秒
+      await db.insert(schema.taskSessions).values({
+        id: 'cross-normal',
+        taskId: 'task-cross',
+        projectType: 'MONO',
+        userId: 'test-user',
+        startedAt: new Date('2025-05-31T22:00:00Z'),
+        endedAt: new Date('2025-06-01T02:00:00Z'),
+        durationSec: 14400,
+      });
+
+      const res = await app.request('/api/reports/time?from=2025-06-01&to=2025-06-30&type=normal');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      const task = body.items.find((i: { taskId: string }) => i.taskId === 'task-cross');
+      expect(task).toBeDefined();
+      expect(task.durationSec).toBe(7200);
+    });
   });
 });

--- a/backend/src/routes/reports.test.ts
+++ b/backend/src/routes/reports.test.ts
@@ -368,4 +368,253 @@ describe('Reports API', () => {
       expect(res.status).toBe(400);
     });
   });
+
+  describe('GET /api/reports/time/partners', () => {
+    /**
+     * パートナー稼働時間レポート用のシード
+     * - partner1: 2タスクで合計1時間30分
+     * - partner2: 1タスクで2時間
+     * - admin: セッションあるがレポート対象外
+     * - 無効化partner: セッションあるが is_allowed=false
+     */
+    async function seedPartnerReportData() {
+      await db.insert(schema.users).values([
+        {
+          id: 'admin-user',
+          email: 'admin@example.com',
+          displayName: 'Admin User',
+          role: 'admin',
+          isAllowed: true,
+        },
+        {
+          id: 'partner-1',
+          email: 'partner1@example.com',
+          displayName: 'パートナー1',
+          role: 'partner',
+          isAllowed: true,
+          avatarColor: 'teal',
+        },
+        {
+          id: 'partner-2',
+          email: 'partner2@example.com',
+          displayName: 'パートナー2',
+          role: 'partner',
+          isAllowed: true,
+        },
+        {
+          id: 'partner-disabled',
+          email: 'disabled@example.com',
+          displayName: '無効化パートナー',
+          role: 'partner',
+          isAllowed: false,
+        },
+      ]);
+
+      await db.insert(schema.labels).values({
+        id: 'p-kubun',
+        name: 'テスト区分',
+        color: '#888888',
+        projectId: null,
+        ownerId: 'admin-user',
+      });
+
+      await db.insert(schema.tasks).values({
+        id: 'p-task-1',
+        projectType: 'MONO',
+        title: 'パートナータスク1',
+        kubunLabelId: 'p-kubun',
+        order: 1,
+        createdBy: 'admin-user',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'p-task-2',
+        projectType: 'BRGREG',
+        title: 'パートナータスク2',
+        kubunLabelId: 'p-kubun',
+        order: 2,
+        createdBy: 'admin-user',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'p-task-3',
+        projectType: 'MONO',
+        title: 'パートナータスク3',
+        kubunLabelId: 'p-kubun',
+        order: 3,
+        createdBy: 'admin-user',
+      });
+
+      const baseDate = new Date('2025-06-15T10:00:00Z');
+
+      await db.insert(schema.taskSessions).values([
+        // partner-1: p-task-1 で 1時間
+        {
+          id: 'ps-1',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-1',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 3600 * 1000),
+          durationSec: 3600,
+        },
+        // partner-1: p-task-2 で 30分
+        {
+          id: 'ps-2',
+          taskId: 'p-task-2',
+          projectType: 'BRGREG',
+          userId: 'partner-1',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 1800 * 1000),
+          durationSec: 1800,
+        },
+        // partner-2: p-task-3 で 2時間
+        {
+          id: 'ps-3',
+          taskId: 'p-task-3',
+          projectType: 'MONO',
+          userId: 'partner-2',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 7200 * 1000),
+          durationSec: 7200,
+        },
+        // admin: p-task-1 で 1時間（partnerじゃないので集計外）
+        {
+          id: 'ps-admin',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'admin-user',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 3600 * 1000),
+          durationSec: 3600,
+        },
+        // partner-disabled: p-task-1 で 1時間（is_allowed=false でも過去稼働は集計対象）
+        {
+          id: 'ps-disabled',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-disabled',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 3600 * 1000),
+          durationSec: 3600,
+        },
+        // partner-1: 期間外（集計外）
+        {
+          id: 'ps-out',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-1',
+          startedAt: new Date('2025-01-01T10:00:00Z'),
+          endedAt: new Date('2025-01-01T11:00:00Z'),
+          durationSec: 3600,
+        },
+        // partner-1: 未完了セッション（集計外）
+        {
+          id: 'ps-active',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-1',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: null,
+          durationSec: 0,
+        },
+      ]);
+    }
+
+    it('パートナーごとの稼働時間とタスク一覧を返す', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      // partner-1 + partner-2 + partner-disabled = 3人（adminは除外、無効化は含む）
+      expect(body.partners).toHaveLength(3);
+
+      // 合計時間の降順 → partner-2(7200) が先頭
+      expect(body.partners[0].userId).toBe('partner-2');
+      expect(body.partners[0].displayName).toBe('パートナー2');
+      expect(body.partners[0].totalDurationSec).toBe(7200);
+      expect(body.partners[0].tasks).toHaveLength(1);
+      expect(body.partners[0].tasks[0]).toMatchObject({
+        taskId: 'p-task-3',
+        title: 'パートナータスク3',
+        projectType: 'MONO',
+        durationSec: 7200,
+      });
+
+      // partner-1: 3600 + 1800 = 5400秒、2タスク
+      expect(body.partners[1].userId).toBe('partner-1');
+      expect(body.partners[1].totalDurationSec).toBe(5400);
+      expect(body.partners[1].tasks).toHaveLength(2);
+      // タスクは durationSec 降順
+      expect(body.partners[1].tasks[0].taskId).toBe('p-task-1');
+      expect(body.partners[1].tasks[0].durationSec).toBe(3600);
+      expect(body.partners[1].tasks[1].taskId).toBe('p-task-2');
+      expect(body.partners[1].tasks[1].durationSec).toBe(1800);
+
+      // partner-disabled: 3600秒（無効化されても過去稼働は集計）
+      expect(body.partners[2].userId).toBe('partner-disabled');
+      expect(body.partners[2].totalDurationSec).toBe(3600);
+
+      // 全体合計
+      expect(body.grandTotalDurationSec).toBe(7200 + 5400 + 3600);
+    });
+
+    it('isAllowed=false のパートナーも集計に含まれる（過去の稼働実績は精算対象）', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      const body = (await res.json()) as any;
+
+      const disabled = body.partners.find(
+        (p: { userId: string }) => p.userId === 'partner-disabled'
+      );
+      expect(disabled).toBeDefined();
+      expect(disabled.totalDurationSec).toBe(3600);
+    });
+
+    it('admin/memberロールのセッションは含まれない', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      const body = (await res.json()) as any;
+
+      // admin-user は出てこない
+      const admin = body.partners.find((p: { userId: string }) => p.userId === 'admin-user');
+      expect(admin).toBeUndefined();
+
+      // partner-1 の totalDurationSec には admin の 1時間が含まれていない
+      const p1 = body.partners.find((p: { userId: string }) => p.userId === 'partner-1');
+      expect(p1.totalDurationSec).toBe(5400);
+    });
+
+    it('avatar情報を返す', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      const body = (await res.json()) as any;
+
+      const p1 = body.partners.find((p: { userId: string }) => p.userId === 'partner-1');
+      expect(p1.avatarColor).toBe('teal');
+      expect(p1.avatarUrl).toBeNull();
+    });
+
+    it('パートナーが居ない場合は空配列を返す', async () => {
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      expect(body.partners).toEqual([]);
+      expect(body.grandTotalDurationSec).toBe(0);
+    });
+
+    it('from/toが未指定だと400', async () => {
+      const res = await app.request('/api/reports/time/partners');
+      expect(res.status).toBe(400);
+    });
+
+    it('不正な日付だと400', async () => {
+      const res = await app.request('/api/reports/time/partners?from=invalid&to=2025-06-30');
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -35,12 +35,35 @@ const STANDALONE_PROJECT_TYPES_ARRAY = Object.values(STANDALONE_REPORT_PROJECT);
 
 /** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
 function normalizeReportType(value: string | undefined): ReportFetchType {
-  return value && value in STANDALONE_REPORT_PROJECT ? (value as ReportFetchType) : 'normal';
+  if (!value) return 'normal';
+  // `in` だと toString / constructor 等プロトタイプ上のキーも true になるため、自身プロパティだけ判定
+  return Object.prototype.hasOwnProperty.call(STANDALONE_REPORT_PROJECT, value)
+    ? (value as Exclude<ReportFetchType, 'normal'>)
+    : 'normal';
+}
+
+/**
+ * YYYY-MM-DD 形式の日付文字列を厳格にパース
+ * - new Date() の寛容仕様（'2025-02-30' → '2025-03-02' に自動補正）を防ぐため、
+ *   regex で形式を縛った上で「パース結果が元の数値と一致するか」も検証する
+ */
+function parseStrictYmd(value: string): Date | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return null;
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== mo - 1 || dt.getUTCDate() !== d) {
+    return null;
+  }
+  return dt;
 }
 
 /**
  * レポート系API共通: from/to クエリのパース・検証
- * - 必須チェック、ISO日付検証、toDate を 23:59:59.999 まで含むよう調整
+ * - 必須チェック、YYYY-MM-DD 厳格検証、from <= to の順序検証、
+ *   toDate を 23:59:59.999 まで含むよう調整
  */
 function parseReportDateRange(
   from: string | undefined,
@@ -49,12 +72,16 @@ function parseReportDateRange(
   if (!from || !to) {
     return { error: 'Missing required parameters: from, to', status: 400 };
   }
-  const fromDate = new Date(from);
-  const toDate = new Date(to);
-  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+  const fromDate = parseStrictYmd(from);
+  const toDate = parseStrictYmd(to);
+  if (!fromDate || !toDate) {
     return { error: 'Invalid date format', status: 400 };
   }
-  toDate.setHours(23, 59, 59, 999);
+  if (fromDate > toDate) {
+    return { error: '`from` must be earlier than or equal to `to`', status: 400 };
+  }
+  // 実行環境のタイムゾーン依存を避けるため UTC で末尾時刻を設定
+  toDate.setUTCHours(23, 59, 59, 999);
   return { fromDate, toDate };
 }
 
@@ -97,11 +124,12 @@ function computeSessionDurationInRangeSec(
   if (session.startedAt >= fromDate && session.endedAt <= toDate) return total;
 
   // 期間と重なる秒数 / セッション全体の秒数 で按分
+  // toDate は 23:59:59.999 まで含むため round で 1ms 誤差を吸収
   const overlapStart = session.startedAt > fromDate ? session.startedAt : fromDate;
   const overlapEnd = session.endedAt < toDate ? session.endedAt : toDate;
   const overlapSec = Math.max(
     0,
-    Math.floor((overlapEnd.getTime() - overlapStart.getTime()) / 1000)
+    Math.round((overlapEnd.getTime() - overlapStart.getTime()) / 1000)
   );
   const sessionRealSec = Math.max(
     1,

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod/v4';
 import { zValidator } from '@hono/zod-validator';
-import { eq, and, gte, lte, isNull, inArray } from 'drizzle-orm';
+import { eq, and, gte, lte, isNull, inArray, notInArray } from 'drizzle-orm';
 import { tasks, taskSessions, labels, users, projectTypeEnum } from '../db/schema';
 import {
   getAccessToken,
@@ -12,6 +12,7 @@ import {
   sheetsUpdateValues,
   sheetsClearValues,
 } from '../lib/google-api';
+import { resolveAvatarUrl, type SignEnv } from './users';
 import type { Env } from '../index';
 import type { Database } from '../db';
 
@@ -30,16 +31,84 @@ const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, Proj
   faq_imp: 'FAQ_IMP',
 };
 
-const STANDALONE_PROJECT_TYPES = new Set<string>(Object.values(STANDALONE_REPORT_PROJECT));
-
-/** 独立集計タイプ（通常集計からは除外する） */
-function isStandaloneReportProject(projectType: string): boolean {
-  return STANDALONE_PROJECT_TYPES.has(projectType);
-}
+const STANDALONE_PROJECT_TYPES_ARRAY = Object.values(STANDALONE_REPORT_PROJECT);
 
 /** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
 function normalizeReportType(value: string | undefined): ReportFetchType {
   return value && value in STANDALONE_REPORT_PROJECT ? (value as ReportFetchType) : 'normal';
+}
+
+/**
+ * レポート系API共通: from/to クエリのパース・検証
+ * - 必須チェック、ISO日付検証、toDate を 23:59:59.999 まで含むよう調整
+ */
+function parseReportDateRange(
+  from: string | undefined,
+  to: string | undefined
+): { fromDate: Date; toDate: Date } | { error: string; status: 400 } {
+  if (!from || !to) {
+    return { error: 'Missing required parameters: from, to', status: 400 };
+  }
+  const fromDate = new Date(from);
+  const toDate = new Date(to);
+  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+    return { error: 'Invalid date format', status: 400 };
+  }
+  toDate.setHours(23, 59, 59, 999);
+  return { fromDate, toDate };
+}
+
+/**
+ * セッションの実稼働秒数を返す（未完了は null）
+ * - durationSec > 0 ならそれを採用
+ * - 0 以下なら endedAt - startedAt で再計算（過去データの互換）
+ */
+function computeSessionDurationSec(session: {
+  startedAt: Date;
+  endedAt: Date | null;
+  durationSec: number;
+}): number | null {
+  if (!session.endedAt) return null;
+  const duration =
+    session.durationSec > 0
+      ? session.durationSec
+      : Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000);
+  return duration > 0 ? duration : null;
+}
+
+/**
+ * セッションの実稼働秒数のうち、指定期間と重なる分だけを返す
+ * - 期間と完全に重ならない: 0
+ * - 期間内に完全に収まる: 全durationSec
+ * - 部分的に重なる: overlap時間 / セッション全体時間 で按分
+ */
+function computeSessionDurationInRangeSec(
+  session: { startedAt: Date; endedAt: Date | null; durationSec: number },
+  fromDate: Date,
+  toDate: Date
+): number {
+  if (!session.endedAt) return 0;
+  if (session.endedAt < fromDate || session.startedAt > toDate) return 0;
+
+  const total = computeSessionDurationSec(session);
+  if (total === null) return 0;
+
+  // 完全に範囲内ならそのまま
+  if (session.startedAt >= fromDate && session.endedAt <= toDate) return total;
+
+  // 期間と重なる秒数 / セッション全体の秒数 で按分
+  const overlapStart = session.startedAt > fromDate ? session.startedAt : fromDate;
+  const overlapEnd = session.endedAt < toDate ? session.endedAt : toDate;
+  const overlapSec = Math.max(
+    0,
+    Math.floor((overlapEnd.getTime() - overlapStart.getTime()) / 1000)
+  );
+  const sessionRealSec = Math.max(
+    1,
+    Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000)
+  );
+
+  return Math.floor(total * (overlapSec / sessionRealSec));
 }
 
 /** 「運用」区分ラベルのIDを取得（無ければ null） */
@@ -106,11 +175,16 @@ async function fetchReportData(
       .from(tasks)
       .where(eq(tasks.projectType, STANDALONE_REPORT_PROJECT[type]));
   } else {
-    const allTasks = await db
+    // 運用区分 かつ 独立集計タイプ(BRGREG/FAQ_IMP)以外 を SQL レベルで絞る
+    targetTasks = await db
       .select(taskSelect)
       .from(tasks)
-      .where(eq(tasks.kubunLabelId, unyoLabelId));
-    targetTasks = allTasks.filter((t) => !isStandaloneReportProject(t.projectType));
+      .where(
+        and(
+          eq(tasks.kubunLabelId, unyoLabelId),
+          notInArray(tasks.projectType, STANDALONE_PROJECT_TYPES_ARRAY)
+        )
+      );
   }
 
   if (targetTasks.length === 0) {
@@ -120,15 +194,15 @@ async function fetchReportData(
   const taskMap = new Map(targetTasks.map((t) => [t.id, t]));
   const taskIds = targetTasks.map((t) => t.id);
 
-  // 4. 対象タスクの日付範囲内セッションを取得
+  // 4. 対象タスクの「期間と重なる」セッションを取得（月またぎは按分処理）
   const sessions = await db
     .select()
     .from(taskSessions)
     .where(
       and(
         inArray(taskSessions.taskId, taskIds),
-        gte(taskSessions.startedAt, fromDate),
-        lte(taskSessions.startedAt, toDate)
+        lte(taskSessions.startedAt, toDate),
+        gte(taskSessions.endedAt, fromDate)
       )
     );
 
@@ -136,22 +210,16 @@ async function fetchReportData(
   const durationByTaskId = new Map<string, number>();
   const recordedUsersByTaskId = new Map<string, Set<string>>();
   for (const session of sessions) {
-    if (!session.endedAt) continue;
+    const duration = computeSessionDurationInRangeSec(session, fromDate, toDate);
+    if (duration <= 0) continue;
 
-    const duration =
-      session.durationSec > 0
-        ? session.durationSec
-        : Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000);
-
-    if (duration > 0) {
-      durationByTaskId.set(session.taskId, (durationByTaskId.get(session.taskId) ?? 0) + duration);
-      let userSet = recordedUsersByTaskId.get(session.taskId);
-      if (!userSet) {
-        userSet = new Set();
-        recordedUsersByTaskId.set(session.taskId, userSet);
-      }
-      userSet.add(session.userId);
+    durationByTaskId.set(session.taskId, (durationByTaskId.get(session.taskId) ?? 0) + duration);
+    let userSet = recordedUsersByTaskId.get(session.taskId);
+    if (!userSet) {
+      userSet = new Set();
+      recordedUsersByTaskId.set(session.taskId, userSet);
     }
+    userSet.add(session.userId);
   }
 
   // 6. 結果を構築
@@ -178,36 +246,188 @@ async function fetchReportData(
   return { items, totalDurationSec };
 }
 
+interface PartnerTaskItem {
+  taskId: string;
+  title: string;
+  projectType: string;
+  durationSec: number;
+}
+
+interface PartnerReportItem {
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  avatarColor: string | null;
+  totalDurationSec: number;
+  tasks: PartnerTaskItem[];
+}
+
+/** 削除済みタスクのタイトル */
+const DELETED_TASK_TITLE = '[削除済みタスク]';
+
+/**
+ * パートナー稼働時間レポートを集計
+ * - users.role = 'partner' のユーザーごと（isAllowed問わず：過去の稼働実績も精算対象）
+ *   に期間内（または重なる）の task_sessions を集計
+ * - 月またぎセッションは期間内の重なり比率で按分
+ * - 「運用」ラベル等の条件は付けない（全タスクが対象）
+ * - 稼働ゼロのpartnerはレスポンスから除外
+ * - avatarUrl は R2 署名付きURLに解決して返す
+ */
+async function fetchPartnerReportData(
+  db: Database,
+  fromDate: Date,
+  toDate: Date,
+  signEnv: SignEnv
+): Promise<{ partners: PartnerReportItem[]; grandTotalDurationSec: number }> {
+  const partnerUsers = await db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      avatarColor: users.avatarColor,
+    })
+    .from(users)
+    .where(eq(users.role, 'partner'));
+
+  if (partnerUsers.length === 0) {
+    return { partners: [], grandTotalDurationSec: 0 };
+  }
+
+  const partnerIds = partnerUsers.map((u) => u.id);
+
+  // 期間と重なるセッションを取得（endedAt is null = 未完了は SQL レベルで除外）
+  const sessions = await db
+    .select({
+      userId: taskSessions.userId,
+      taskId: taskSessions.taskId,
+      startedAt: taskSessions.startedAt,
+      endedAt: taskSessions.endedAt,
+      durationSec: taskSessions.durationSec,
+    })
+    .from(taskSessions)
+    .where(
+      and(
+        inArray(taskSessions.userId, partnerIds),
+        lte(taskSessions.startedAt, toDate),
+        gte(taskSessions.endedAt, fromDate)
+      )
+    );
+
+  // userId → taskId → durationSec の二重マップで集計（月またぎは按分）
+  const durationByUserTask = new Map<string, Map<string, number>>();
+  for (const session of sessions) {
+    const duration = computeSessionDurationInRangeSec(session, fromDate, toDate);
+    if (duration <= 0) continue;
+
+    let taskMap = durationByUserTask.get(session.userId);
+    if (!taskMap) {
+      taskMap = new Map();
+      durationByUserTask.set(session.userId, taskMap);
+    }
+    taskMap.set(session.taskId, (taskMap.get(session.taskId) ?? 0) + duration);
+  }
+
+  // 集計対象タスクの情報を一括取得
+  const allTaskIds = new Set<string>();
+  for (const taskMap of durationByUserTask.values()) {
+    for (const taskId of taskMap.keys()) allTaskIds.add(taskId);
+  }
+
+  const taskInfoMap = new Map<string, { title: string; projectType: string }>();
+  if (allTaskIds.size > 0) {
+    const taskRows = await db
+      .select({
+        id: tasks.id,
+        title: tasks.title,
+        projectType: tasks.projectType,
+      })
+      .from(tasks)
+      .where(inArray(tasks.id, Array.from(allTaskIds)));
+    for (const t of taskRows) {
+      taskInfoMap.set(t.id, { title: t.title, projectType: t.projectType });
+    }
+  }
+
+  // 稼働ありの partner だけ抽出（ゼロ時間はノイズなので除外）
+  const partnersRaw = partnerUsers.flatMap((user) => {
+    const taskMap = durationByUserTask.get(user.id);
+    if (!taskMap || taskMap.size === 0) return [];
+
+    const taskItems: PartnerTaskItem[] = [];
+    let totalDurationSec = 0;
+
+    for (const [taskId, durationSec] of taskMap) {
+      // 削除済みタスクは「[削除済みタスク]」として保持（無音で落とすと精算とズレる）
+      const info = taskInfoMap.get(taskId) ?? { title: DELETED_TASK_TITLE, projectType: '' };
+      taskItems.push({
+        taskId,
+        title: info.title,
+        projectType: info.projectType,
+        durationSec,
+      });
+      totalDurationSec += durationSec;
+    }
+
+    if (totalDurationSec === 0) return [];
+
+    taskItems.sort((a, b) => b.durationSec - a.durationSec);
+
+    return [
+      {
+        userId: user.id,
+        displayName: user.displayName,
+        avatarUrl: user.avatarUrl,
+        avatarColor: user.avatarColor,
+        totalDurationSec,
+        tasks: taskItems,
+      },
+    ];
+  });
+
+  // avatarUrl を R2 署名付きURLに変換
+  const partners: PartnerReportItem[] = await Promise.all(
+    partnersRaw.map((p) => resolveAvatarUrl(p, signEnv))
+  );
+
+  // 合計時間の降順
+  partners.sort((a, b) => b.totalDurationSec - a.totalDurationSec);
+
+  const grandTotalDurationSec = partners.reduce((sum, p) => sum + p.totalDurationSec, 0);
+
+  return { partners, grandTotalDurationSec };
+}
+
+/**
+ * GET /time/partners
+ * パートナー稼働時間レポート取得
+ */
+app.get('/time/partners', async (c) => {
+  const db = c.get('db');
+  const range = parseReportDateRange(c.req.query('from'), c.req.query('to'));
+  if ('error' in range) return c.json({ error: range.error }, range.status);
+
+  const env = c.env as ReportEnv['Bindings'];
+  const result = await fetchPartnerReportData(db, range.fromDate, range.toDate, env);
+  return c.json(result);
+});
+
 /**
  * GET /time
  * 時間レポート取得
  */
 app.get('/time', async (c) => {
   const db = c.get('db');
-  const from = c.req.query('from');
-  const to = c.req.query('to');
   const type = normalizeReportType(c.req.query('type'));
-
-  if (!from || !to) {
-    return c.json({ error: 'Missing required parameters: from, to' }, 400);
-  }
-
-  const fromDate = new Date(from);
-  const toDate = new Date(to);
-
-  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
-    return c.json({ error: 'Invalid date format' }, 400);
-  }
-
-  // toDateをその日の終了時刻まで含める
-  toDate.setHours(23, 59, 59, 999);
+  const range = parseReportDateRange(c.req.query('from'), c.req.query('to'));
+  if ('error' in range) return c.json({ error: range.error }, range.status);
 
   const userId = c.get('userId');
   const unyoLabelId = await getUnyoLabelId(db);
   const { items, totalDurationSec } = await fetchReportData(
     db,
-    fromDate,
-    toDate,
+    range.fromDate,
+    range.toDate,
     type,
     unyoLabelId,
     userId
@@ -225,22 +445,11 @@ app.get('/time/csv', async (c) => {
   const from = c.req.query('from');
   const to = c.req.query('to');
   const type = normalizeReportType(c.req.query('type'));
-
-  if (!from || !to) {
-    return c.json({ error: 'Missing required parameters: from, to' }, 400);
-  }
-
-  const fromDate = new Date(from);
-  const toDate = new Date(to);
-
-  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
-    return c.json({ error: 'Invalid date format' }, 400);
-  }
-
-  toDate.setHours(23, 59, 59, 999);
+  const range = parseReportDateRange(from, to);
+  if ('error' in range) return c.json({ error: range.error }, range.status);
 
   const unyoLabelId = await getUnyoLabelId(db);
-  const { items } = await fetchReportData(db, fromDate, toDate, type, unyoLabelId);
+  const { items } = await fetchReportData(db, range.fromDate, range.toDate, type, unyoLabelId);
 
   // CSV生成（UTF-8+BOM/CRLF）
   const BOM = '\uFEFF';

--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -164,6 +164,27 @@ describe('Users API', () => {
       expect(body.user.role).toBe('admin');
     });
 
+    it('adminは他ユーザーのroleをpartnerに変更できる', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user-2',
+        email: 'admin2@example.com',
+        displayName: 'Admin2',
+        role: 'admin',
+        isAllowed: true,
+      });
+
+      const adminApp = createTestApp('admin-user-2');
+      const res = await adminApp.request('/api/users/test-user', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: 'partner' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.user.role).toBe('partner');
+    });
+
     it('非adminが他ユーザーを更新しようとすると403', async () => {
       await db.insert(schema.users).values({
         id: 'other-user',
@@ -245,7 +266,8 @@ describe('Users API', () => {
         .from(schema.users)
         .where(eq(schema.users.id, 'disabled-user'));
       expect(restored.isAllowed).toBe(true);
-      expect(restored.role).toBe('admin');
+      // 再有効化では role は保持する（変更したい場合は PUT /:id で）
+      expect(restored.role).toBe('member');
     });
 
     it('APP_ORIGIN 未設定なら 500 で明示メッセージを返す', async () => {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -18,7 +18,7 @@ import { importHmacKey, generateSignedFileUrl } from '../lib/crypto';
 import type { Env } from '../index';
 import type { Database } from '../db';
 
-type SignEnv = Pick<Env['Bindings'], 'APP_ORIGIN' | 'INTERNAL_API_KEY'>;
+export type SignEnv = Pick<Env['Bindings'], 'APP_ORIGIN' | 'INTERNAL_API_KEY'>;
 
 type UserEnv = Env & { Variables: { db: Database; userId: string } };
 
@@ -41,7 +41,7 @@ const safeUserColumns = {
 };
 
 /** avatarUrl（R2キー）を署名付きURLに変換する */
-async function resolveAvatarUrl<T extends { avatarUrl: string | null }>(
+export async function resolveAvatarUrl<T extends { avatarUrl: string | null }>(
   user: T,
   env: SignEnv,
   cryptoKey?: CryptoKey
@@ -273,11 +273,11 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
     .where(eq(users.email, email));
 
   if (existing) {
-    // 無効化されたユーザーなら再有効化
+    // 無効化されたユーザーなら再有効化（既存roleは保持。role変更が必要なら別途 PUT /:id で）
     if (!existing.isAllowed) {
       await db
         .update(users)
-        .set({ isAllowed: true, role, updatedAt: new Date() })
+        .set({ isAllowed: true, updatedAt: new Date() })
         .where(eq(users.id, existing.id));
       return c.json({ success: true, restored: true });
     }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useAuth } from '../../hooks/useAuth';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { usePreviewMode } from '../../hooks/usePreviewMode';
+import { ROLE_LABELS_JA } from '../../lib/roleLabels';
 
 const NAV_ITEMS = [
   { path: '/dashboard', label: 'ダッシュボード', icon: <LayoutDashboard size={20} /> },
@@ -25,11 +26,6 @@ const NAV_ITEMS = [
   { path: '/report', label: 'レポート', icon: <BarChart3 size={20} /> },
   { path: '/contact', label: 'お問い合わせ', icon: <MessageSquare size={20} /> },
 ];
-
-const ROLE_LABELS: Record<string, string> = {
-  admin: '管理者',
-  member: 'メンバー',
-};
 
 export function Sidebar() {
   const { theme, toggleTheme } = useTheme();
@@ -40,7 +36,7 @@ export function Sidebar() {
   const displayName =
     currentUser?.displayName ?? clerkUser?.fullName ?? (isPreview ? 'プレビューユーザー' : '');
   const displayRole = currentUser?.role
-    ? (ROLE_LABELS[currentUser.role] ?? currentUser.role)
+    ? (ROLE_LABELS_JA[currentUser.role] ?? currentUser.role)
     : isPreview
       ? 'プレビュー'
       : '';

--- a/frontend/src/components/shared/UserSectionHeader.tsx
+++ b/frontend/src/components/shared/UserSectionHeader.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import { Avatar } from '../ui/Avatar';
+
+interface UserSectionHeaderProps {
+  /** ユーザー名 */
+  displayName: string;
+  /** ロール等の補助ラベル（例: 'リーダー' / 'パートナー'） */
+  roleLabel: string;
+  /** アバター画像URL（未指定なら colorName ベースの初期表示） */
+  avatarUrl?: string | null;
+  avatarColor?: string | null;
+  /** 件数バッジに表示する値（数値）。未指定なら非表示 */
+  count?: number;
+  /** 件数バッジの単位（例: '件' / '人'） */
+  countUnit?: string;
+  /** 右端に追加表示するノード（合計時間など） */
+  rightSlot?: ReactNode;
+}
+
+/**
+ * メンバー / パートナー一覧で共通利用するセクションヘッダー
+ * Avatar + 名前 + ロールラベル + 件数バッジ + 右端スロット
+ */
+export function UserSectionHeader({
+  displayName,
+  roleLabel,
+  avatarUrl,
+  avatarColor,
+  count,
+  countUnit = '件',
+  rightSlot,
+}: UserSectionHeaderProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <Avatar name={displayName} imageUrl={avatarUrl ?? undefined} colorName={avatarColor} />
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-bold text-text-primary">{displayName}</span>
+        <span className="text-xs text-text-tertiary">{roleLabel}</span>
+      </div>
+      <div className="flex-1" />
+      {count !== undefined && (
+        <span className="inline-flex items-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
+          {count}
+          {countUnit}
+        </span>
+      )}
+      {rightSlot}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useInviteUser.ts
+++ b/frontend/src/hooks/useInviteUser.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../lib/api';
 import { queryKeys } from '../lib/queryKeys';
+import type { UserRole } from '../types';
 import { useAuth } from './useAuth';
 
 /**
@@ -12,7 +13,7 @@ export function useInviteUser() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ email, role }: { email: string; role: 'admin' | 'member' }) =>
+    mutationFn: ({ email, role }: { email: string; role: UserRole }) =>
       apiClient<{ success: boolean; restored?: boolean }>('/api/users/invite', {
         method: 'POST',
         body: { email, role },

--- a/frontend/src/hooks/usePartnerReport.ts
+++ b/frontend/src/hooks/usePartnerReport.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+
+export interface PartnerReportTask {
+  taskId: string;
+  title: string;
+  projectType: string;
+  durationSec: number;
+}
+
+export interface PartnerReportItem {
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  avatarColor: string | null;
+  totalDurationSec: number;
+  tasks: PartnerReportTask[];
+}
+
+interface PartnerReportResponse {
+  partners: PartnerReportItem[];
+  grandTotalDurationSec: number;
+}
+
+/**
+ * パートナー稼働時間レポートを取得
+ * GET /api/reports/time/partners?from=YYYY-MM-DD&to=YYYY-MM-DD
+ */
+export function usePartnerReport(fromDate: string, toDate: string, enabled = true) {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.partnerReport(fromDate, toDate),
+    queryFn: () =>
+      apiClient<PartnerReportResponse>(`/api/reports/time/partners?from=${fromDate}&to=${toDate}`, {
+        getToken,
+      }),
+    enabled: enabled && isSignedIn && !!fromDate && !!toDate,
+  });
+}

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -24,7 +24,7 @@ export type { ReportItem };
  * レポートデータを取得
  * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg|faq_imp
  */
-export function useReportData(type: ReportType, fromDate: string, toDate: string) {
+export function useReportData(type: ReportType, fromDate: string, toDate: string, enabled = true) {
   const { getToken, isSignedIn } = useAuth();
 
   return useQuery({
@@ -33,7 +33,7 @@ export function useReportData(type: ReportType, fromDate: string, toDate: string
       apiClient<ReportResponse>(`/api/reports/time?from=${fromDate}&to=${toDate}&type=${type}`, {
         getToken,
       }),
-    enabled: isSignedIn && !!fromDate && !!toDate,
+    enabled: enabled && isSignedIn && !!fromDate && !!toDate,
   });
 }
 

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -35,6 +35,7 @@ export const queryKeys = {
 
   // Reports
   reports: (type: string, from: string, to: string) => ['reports', type, from, to] as const,
+  partnerReport: (from: string, to: string) => ['reports', 'partners', from, to] as const,
 
   // Contacts
   contacts: (status?: string) =>

--- a/frontend/src/lib/roleLabels.ts
+++ b/frontend/src/lib/roleLabels.ts
@@ -1,0 +1,27 @@
+import type { UserRole } from '../types';
+
+/** ロール表示ラベル（日本語・一般用途／設定・サイドバー等） */
+export const ROLE_LABELS_JA: Record<UserRole, string> = {
+  admin: '管理者',
+  member: 'メンバー',
+  partner: 'パートナー',
+};
+
+/** ロール表示ラベル（日本語・タスク一覧 / レポート列見出し用）
+ *  admin を「リーダー」と表記する慣習に合わせる
+ */
+export const ROLE_LABELS_TASK_JA: Record<UserRole, string> = {
+  admin: 'リーダー',
+  member: 'メンバー',
+  partner: 'パートナー',
+};
+
+/** ロール表示ラベル（英語・設定画面のドロップダウン用） */
+export const ROLE_LABELS_EN: Record<UserRole, string> = {
+  admin: 'Admin',
+  member: 'Member',
+  partner: 'Partner',
+};
+
+/** UserRole の全候補（フォーム選択肢など） */
+export const USER_ROLES: readonly UserRole[] = ['admin', 'member', 'partner'];

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -174,9 +174,10 @@ export function ReportPage() {
     setActiveTab(key as ReportTabId);
   };
 
-  const handlePartnerTaskClick = (taskId: string) => {
-    // partnerデータから該当タスクを引いてReportEntry形式に変換し、ReportDetailTabで詳細を出す
-    const task = partnerData?.partners.flatMap((p) => p.tasks).find((t) => t.taskId === taskId);
+  const handlePartnerTaskClick = (partnerId: string, taskId: string) => {
+    // 同一 taskId が複数 partner に存在しうるため、partnerId で対象を限定してから引く
+    const partner = partnerData?.partners.find((p) => p.userId === partnerId);
+    const task = partner?.tasks.find((t) => t.taskId === taskId);
     if (!task) return;
 
     setSelectedTask({

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -11,17 +11,22 @@ import { ReportToolbar } from './components/ReportToolbar';
 import { DateRangeRow } from './components/DateRangeRow';
 import { SummaryRow } from './components/SummaryRow';
 import { ReportTable } from './components/ReportTable';
+import { PartnerReportList } from './components/PartnerReportList';
 import { SessionEditModalContent } from './components/SessionEditModalContent';
 import { useReportData } from '../../hooks/useReportData';
+import { usePartnerReport } from '../../hooks/usePartnerReport';
 import { useExportToSheets } from '../../hooks/useExportToSheets';
 import { useToast } from '../../hooks/useToast';
 import { HttpError } from '../../lib/api';
 import type { ReportEntry, ReportType, TaskSession } from '../../types';
 
-const REPORT_TABS: { id: ReportType | 'all'; label: string }[] = [
+type ReportTabId = ReportType | 'all' | 'partner';
+
+const REPORT_TABS: { id: ReportTabId; label: string }[] = [
   { id: 'all', label: '通常' },
   { id: 'brg', label: 'BRG' },
   { id: 'faq_imp', label: 'FAQ_IMP' },
+  { id: 'partner', label: 'パートナー' },
 ];
 
 function getLastDayOfMonth(year: number, month: number): number {
@@ -47,7 +52,8 @@ export function ReportPage() {
   const [month, setMonth] = useState(now.getMonth() + 1);
 
   // タブ状態
-  const [activeTab, setActiveTab] = useState<ReportType | 'all'>('all');
+  const [activeTab, setActiveTab] = useState<ReportTabId>('all');
+  const isPartnerTab = activeTab === 'partner';
 
   // 上書き確認モーダル
   const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
@@ -62,18 +68,40 @@ export function ReportPage() {
     session: TaskSession;
   } | null>(null);
 
-  // ドロワー状態
-  const [selectedEntry, setSelectedEntry] = useState<ReportEntry | null>(null);
+  // ドロワー状態（kind は今後の編集権限制御等の拡張用に保持）
+  const [selectedTask, setSelectedTask] = useState<{
+    kind: 'report' | 'partner';
+    entry: ReportEntry;
+  } | null>(null);
+
+  const selectedEntry = selectedTask?.entry ?? null;
+  const selectedTaskId = selectedEntry?.taskId ?? null;
 
   // API用の日付
   const fromDate = formatDateISO(year, month, 1);
   const toDate = formatDateISO(year, month, getLastDayOfMonth(year, month));
 
-  // レポートデータ取得
-  const reportType = activeTab === 'all' ? 'normal' : activeTab;
-  const { data, isLoading, error } = useReportData(reportType, fromDate, toDate);
+  // レポートデータ取得（パートナータブ以外）
+  const reportType: ReportType =
+    activeTab === 'partner' || activeTab === 'all' ? 'normal' : activeTab;
+  const {
+    data,
+    isLoading: isTaskReportLoading,
+    error: taskReportError,
+  } = useReportData(reportType, fromDate, toDate, !isPartnerTab);
 
-  const totalDurationSec = data?.totalDurationSec ?? 0;
+  // パートナー稼働時間レポート取得
+  const {
+    data: partnerData,
+    isLoading: isPartnerLoading,
+    error: partnerError,
+  } = usePartnerReport(fromDate, toDate, isPartnerTab);
+
+  const isLoading = isPartnerTab ? isPartnerLoading : isTaskReportLoading;
+  const error = isPartnerTab ? partnerError : taskReportError;
+  const totalDurationSec = isPartnerTab
+    ? (partnerData?.grandTotalDurationSec ?? 0)
+    : (data?.totalDurationSec ?? 0);
 
   // API ReportItem → フロント ReportEntry にマッピング（メモ化）
   const entries = useMemo<ReportEntry[]>(
@@ -135,7 +163,7 @@ export function ReportPage() {
   }, []);
 
   const handleRowClick = (entry: ReportEntry) => {
-    setSelectedEntry(entry);
+    setSelectedTask({ kind: 'report', entry });
   };
 
   const handleEditSession = (entry: ReportEntry, session: TaskSession) => {
@@ -143,7 +171,28 @@ export function ReportPage() {
   };
 
   const handleTabChange = (key: React.Key) => {
-    setActiveTab(key as ReportType | 'all');
+    setActiveTab(key as ReportTabId);
+  };
+
+  const handlePartnerTaskClick = (taskId: string) => {
+    // partnerデータから該当タスクを引いてReportEntry形式に変換し、ReportDetailTabで詳細を出す
+    const task = partnerData?.partners.flatMap((p) => p.tasks).find((t) => t.taskId === taskId);
+    if (!task) return;
+
+    setSelectedTask({
+      kind: 'partner',
+      entry: {
+        id: taskId,
+        taskId,
+        title: task.title,
+        type: 'normal',
+        projectType: task.projectType,
+        totalDurationSec: task.durationSec,
+        sessions: [],
+        date: new Date(year, month - 1, 1),
+        currentUserUnrecorded: false,
+      },
+    });
   };
 
   const handleExportError = useCallback(
@@ -213,6 +262,7 @@ export function ReportPage() {
           isExporting={isProcessing}
           showDateRange={showDateRange}
           onToggleDateRange={() => setShowDateRange((v) => !v)}
+          isExportDisabled={isPartnerTab}
         />
 
         {showDateRange && (
@@ -234,9 +284,13 @@ export function ReportPage() {
           </TabList>
 
           <div className="mt-6 space-y-6">
-            <SummaryRow totalDurationSec={totalDurationSec} entryCount={entries.length} />
+            <SummaryRow
+              totalDurationSec={totalDurationSec}
+              entryCount={isPartnerTab ? (partnerData?.partners.length ?? 0) : entries.length}
+              countUnit={isPartnerTab ? '人' : '件'}
+            />
 
-            {entries.some((e) => e.currentUserUnrecorded) && (
+            {!isPartnerTab && entries.some((e) => e.currentUserUnrecorded) && (
               <div className="flex items-center gap-3">
                 <span className="inline-flex items-center rounded-full bg-error-bg px-3 py-1 text-xs font-medium text-error-text">
                   セッション未記録
@@ -255,7 +309,14 @@ export function ReportPage() {
             ) : (
               REPORT_TABS.map((t) => (
                 <TabPanel key={t.id} id={t.id}>
-                  <ReportTable entries={entries} onRowClick={handleRowClick} />
+                  {t.id === 'partner' ? (
+                    <PartnerReportList
+                      partners={partnerData?.partners ?? []}
+                      onTaskClick={handlePartnerTaskClick}
+                    />
+                  ) : (
+                    <ReportTable entries={entries} onRowClick={handleRowClick} />
+                  )}
                 </TabPanel>
               ))
             )}
@@ -264,14 +325,14 @@ export function ReportPage() {
       </div>
 
       <TaskDrawer
-        taskId={selectedEntry?.taskId ?? null}
-        onClose={() => setSelectedEntry(null)}
+        taskId={selectedTaskId}
+        onClose={() => setSelectedTask(null)}
         detailTabLabel="レポート詳細"
         detailPadding={false}
         detailContent={
           selectedEntry ? (
             <ReportDetailTab entry={selectedEntry} onEditSession={handleEditSession} />
-          ) : null
+          ) : undefined
         }
       />
 

--- a/frontend/src/pages/reports/components/PartnerReportList.tsx
+++ b/frontend/src/pages/reports/components/PartnerReportList.tsx
@@ -1,0 +1,79 @@
+import { UserSectionHeader } from '../../../components/shared/UserSectionHeader';
+import { formatDuration } from '../../../lib/taskUtils';
+import { ROLE_LABELS_JA } from '../../../lib/roleLabels';
+import type { PartnerReportItem } from '../../../hooks/usePartnerReport';
+
+interface PartnerReportListProps {
+  partners: PartnerReportItem[];
+  onTaskClick: (taskId: string) => void;
+}
+
+export function PartnerReportList({ partners, onTaskClick }: PartnerReportListProps) {
+  if (partners.length === 0) {
+    return (
+      <div className="rounded-xl border border-border-default bg-bg-primary px-4 py-8 text-center text-sm text-text-tertiary">
+        パートナーの稼働データがありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {partners.map((partner) => (
+        <PartnerSection key={partner.userId} partner={partner} onTaskClick={onTaskClick} />
+      ))}
+    </div>
+  );
+}
+
+interface PartnerSectionProps {
+  partner: PartnerReportItem;
+  onTaskClick: (taskId: string) => void;
+}
+
+function PartnerSection({ partner, onTaskClick }: PartnerSectionProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border-default bg-bg-primary">
+      <div className="border-b border-border-default">
+        <UserSectionHeader
+          displayName={partner.displayName}
+          roleLabel={ROLE_LABELS_JA.partner}
+          avatarUrl={partner.avatarUrl}
+          avatarColor={partner.avatarColor}
+          count={partner.tasks.length}
+          rightSlot={
+            <span className="text-sm font-bold text-text-primary">
+              {formatDuration(partner.totalDurationSec)}
+            </span>
+          }
+        />
+      </div>
+
+      {/* タスクテーブル */}
+      <div className="flex items-center gap-2 border-b border-border-default px-4 py-2">
+        <span className="flex-1 text-xs font-medium text-primary-default">タイトル</span>
+        <span className="w-[120px] text-xs font-medium text-primary-default">区分</span>
+        <span className="w-[120px] text-center text-xs font-medium text-primary-default">時間</span>
+      </div>
+
+      {partner.tasks.map((task, i) => (
+        <div key={task.taskId}>
+          {i > 0 && <div className="h-px bg-border-default" />}
+          <button
+            type="button"
+            onClick={() => onTaskClick(task.taskId)}
+            className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-bg-secondary"
+          >
+            <span className="flex-1 truncate text-sm text-text-primary">{task.title}</span>
+            <span className="w-[120px] truncate text-xs text-text-secondary">
+              {task.projectType}
+            </span>
+            <span className="w-[120px] text-center text-sm text-text-secondary">
+              {formatDuration(task.durationSec)}
+            </span>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/reports/components/PartnerReportList.tsx
+++ b/frontend/src/pages/reports/components/PartnerReportList.tsx
@@ -5,7 +5,8 @@ import type { PartnerReportItem } from '../../../hooks/usePartnerReport';
 
 interface PartnerReportListProps {
   partners: PartnerReportItem[];
-  onTaskClick: (taskId: string) => void;
+  /** クリックされたパートナーIDとタスクIDを返す（同一taskIdが複数partnerに存在しうるため両方必要） */
+  onTaskClick: (partnerId: string, taskId: string) => void;
 }
 
 export function PartnerReportList({ partners, onTaskClick }: PartnerReportListProps) {
@@ -28,7 +29,7 @@ export function PartnerReportList({ partners, onTaskClick }: PartnerReportListPr
 
 interface PartnerSectionProps {
   partner: PartnerReportItem;
-  onTaskClick: (taskId: string) => void;
+  onTaskClick: (partnerId: string, taskId: string) => void;
 }
 
 function PartnerSection({ partner, onTaskClick }: PartnerSectionProps) {
@@ -61,7 +62,7 @@ function PartnerSection({ partner, onTaskClick }: PartnerSectionProps) {
           {i > 0 && <div className="h-px bg-border-default" />}
           <button
             type="button"
-            onClick={() => onTaskClick(task.taskId)}
+            onClick={() => onTaskClick(partner.userId, task.taskId)}
             className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-bg-secondary"
           >
             <span className="flex-1 truncate text-sm text-text-primary">{task.title}</span>

--- a/frontend/src/pages/reports/components/ReportToolbar.tsx
+++ b/frontend/src/pages/reports/components/ReportToolbar.tsx
@@ -16,6 +16,8 @@ interface ReportToolbarProps {
   isExporting?: boolean;
   showDateRange?: boolean;
   onToggleDateRange?: () => void;
+  /** 出力ボタンを無効化する（パートナータブはスプレッドシート未対応） */
+  isExportDisabled?: boolean;
 }
 
 export function ReportToolbar({
@@ -27,6 +29,7 @@ export function ReportToolbar({
   isExporting = false,
   showDateRange = false,
   onToggleDateRange,
+  isExportDisabled = false,
 }: ReportToolbarProps) {
   const { isPreview } = usePreviewMode();
   const { addToast } = useToast();
@@ -89,7 +92,7 @@ export function ReportToolbar({
           variant="primary"
           size="sm"
           onPress={isPreview ? handlePreviewBlock : onExport}
-          isDisabled={isExporting}
+          isDisabled={isExporting || isExportDisabled}
         >
           {isExporting ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
           {isExporting ? '出力中...' : 'スプレッドシートに出力'}

--- a/frontend/src/pages/reports/components/SummaryRow.tsx
+++ b/frontend/src/pages/reports/components/SummaryRow.tsx
@@ -3,9 +3,11 @@ import { formatDuration } from '../../../lib/taskUtils';
 interface SummaryRowProps {
   totalDurationSec: number;
   entryCount: number;
+  /** カウントの単位（デフォルト: '件'）。パートナータブでは '人' を渡す */
+  countUnit?: string;
 }
 
-export function SummaryRow({ totalDurationSec, entryCount }: SummaryRowProps) {
+export function SummaryRow({ totalDurationSec, entryCount, countUnit = '件' }: SummaryRowProps) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-base font-medium text-text-secondary">合計:</span>
@@ -13,7 +15,8 @@ export function SummaryRow({ totalDurationSec, entryCount }: SummaryRowProps) {
         {formatDuration(totalDurationSec)}
       </span>
       <span className="inline-flex rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
-        {entryCount}件
+        {entryCount}
+        {countUnit}
       </span>
     </div>
   );

--- a/frontend/src/pages/settings/components/AddMemberModal.tsx
+++ b/frontend/src/pages/settings/components/AddMemberModal.tsx
@@ -2,16 +2,18 @@ import { useState } from 'react';
 import { Plus, ChevronDown } from 'lucide-react';
 import { Modal } from '../../../components/ui/Modal';
 import { Button } from '../../../components/ui/Button';
+import { ROLE_LABELS_EN, USER_ROLES } from '../../../lib/roleLabels';
+import type { UserRole } from '../../../types';
 
 interface AddMemberModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAdd: (email: string, role: 'Admin' | 'Member') => void;
+  onAdd: (email: string, role: UserRole) => void;
 }
 
 export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) {
   const [email, setEmail] = useState('');
-  const [role, setRole] = useState<'Admin' | 'Member'>('Member');
+  const [role, setRole] = useState<UserRole>('member');
   const [roleOpen, setRoleOpen] = useState(false);
 
   const handleAdd = () => {
@@ -20,12 +22,12 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) return;
     onAdd(trimmedEmail, role);
     setEmail('');
-    setRole('Member');
+    setRole('member');
   };
 
   const handleClose = () => {
     setEmail('');
-    setRole('Member');
+    setRole('member');
     setRoleOpen(false);
     onClose();
   };
@@ -77,7 +79,7 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
               aria-labelledby="member-role-label"
               className="flex h-10 w-full items-center justify-between rounded-md border border-border-default px-3 text-sm text-text-primary transition-colors hover:bg-bg-secondary"
             >
-              <span>{role}</span>
+              <span>{ROLE_LABELS_EN[role]}</span>
               <ChevronDown size={16} className="text-text-secondary" />
             </button>
             {roleOpen && (
@@ -88,7 +90,7 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
                   aria-labelledby="member-role-label"
                   className="absolute left-0 top-full z-20 mt-1 w-full overflow-hidden rounded-md border border-border-default bg-bg-primary shadow-lg"
                 >
-                  {(['Admin', 'Member'] as const).map((r) => (
+                  {USER_ROLES.map((r) => (
                     <button
                       key={r}
                       type="button"
@@ -100,7 +102,7 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
                       }}
                       className="flex h-10 w-full items-center px-3 text-sm text-text-primary transition-colors hover:bg-bg-secondary"
                     >
-                      {r}
+                      {ROLE_LABELS_EN[r]}
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/settings/components/AdminTab.tsx
+++ b/frontend/src/pages/settings/components/AdminTab.tsx
@@ -11,7 +11,8 @@ import { useUpdateUser } from '../../../hooks/useUpdateUser';
 import { useInviteUser } from '../../../hooks/useInviteUser';
 import { usePreviewMode } from '../../../hooks/usePreviewMode';
 import { useToast } from '../../../hooks/useToast';
-import type { User } from '../../../types';
+import { ROLE_LABELS_EN, USER_ROLES } from '../../../lib/roleLabels';
+import type { User, UserRole } from '../../../types';
 
 const TABLE_COLUMNS = [
   { label: 'メンバー', width: 'w-[230px]' },
@@ -22,14 +23,14 @@ const TABLE_COLUMNS = [
 ];
 
 interface RoleDropdownProps {
-  value: 'admin' | 'member';
-  onChange: (role: 'admin' | 'member') => void;
+  value: UserRole;
+  onChange: (role: UserRole) => void;
   disabled?: boolean;
 }
 
 function RoleDropdown({ value, onChange, disabled }: RoleDropdownProps) {
   const [open, setOpen] = useState(false);
-  const displayValue = value === 'admin' ? 'Admin' : 'Member';
+  const displayValue = ROLE_LABELS_EN[value];
 
   return (
     <div className="relative">
@@ -50,8 +51,8 @@ function RoleDropdown({ value, onChange, disabled }: RoleDropdownProps) {
         <>
           <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
           <div className="absolute right-0 top-full z-20 mt-1 w-[120px] overflow-hidden rounded-md border border-border-default bg-bg-primary shadow-lg">
-            {(['admin', 'member'] as const).map((role) => {
-              const label = role === 'admin' ? 'Admin' : 'Member';
+            {USER_ROLES.map((role) => {
+              const label = ROLE_LABELS_EN[role];
               return (
                 <button
                   key={role}
@@ -93,14 +94,14 @@ export function AdminTab() {
     text: string;
   } | null>(null);
 
-  const handleRoleChange = (userId: string, role: 'admin' | 'member') => {
+  const handleRoleChange = (userId: string, role: UserRole) => {
     if (userId === currentUser?.id) return;
     updateUser.mutate({ userId, data: { role } });
   };
 
-  const handleAddMember = (email: string, role: 'Admin' | 'Member') => {
+  const handleAddMember = (email: string, role: UserRole) => {
     inviteUser.mutate(
-      { email, role: role.toLowerCase() as 'admin' | 'member' },
+      { email, role },
       {
         onSuccess: (data) => {
           setAddModalOpen(false);

--- a/frontend/src/pages/tasks/components/MemberCardSection.tsx
+++ b/frontend/src/pages/tasks/components/MemberCardSection.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
-import { Avatar } from '../../../components/ui/Avatar';
+import { UserSectionHeader } from '../../../components/shared/UserSectionHeader';
 import { CardSectionHeader } from './CardSectionHeader';
 import { TaskCard } from './TaskCard';
 import { FLOW_STATUS_ORDER, FLOW_STATUS_LABELS } from '../../../lib/constants';
+import { ROLE_LABELS_TASK_JA } from '../../../lib/roleLabels';
 import type { Task, User, FlowStatus } from '../../../types';
 
 interface MemberCardSectionProps {
@@ -12,8 +13,6 @@ interface MemberCardSectionProps {
 }
 
 export function MemberCardSection({ member, tasks, onTaskClick }: MemberCardSectionProps) {
-  const roleLabel = member.role === 'admin' ? 'リーダー' : 'メンバー';
-
   const columns = useMemo(() => {
     const grouped = new Map<FlowStatus, Task[]>();
     for (const status of FLOW_STATUS_ORDER) {
@@ -30,22 +29,13 @@ export function MemberCardSection({ member, tasks, onTaskClick }: MemberCardSect
 
   return (
     <div className="overflow-hidden rounded-lg border border-border-default bg-bg-primary">
-      {/* メンバーヘッダー */}
-      <div className="flex items-center gap-3 px-4 py-3">
-        <Avatar
-          name={member.displayName}
-          imageUrl={member.avatarUrl ?? undefined}
-          colorName={member.avatarColor}
-        />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-bold text-text-primary">{member.displayName}</span>
-          <span className="text-xs text-text-tertiary">{roleLabel}</span>
-        </div>
-        <div className="flex-1" />
-        <span className="inline-flex items-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
-          {tasks.length}件
-        </span>
-      </div>
+      <UserSectionHeader
+        displayName={member.displayName}
+        roleLabel={ROLE_LABELS_TASK_JA[member.role]}
+        avatarUrl={member.avatarUrl}
+        avatarColor={member.avatarColor}
+        count={tasks.length}
+      />
 
       {/* カンバンカラム */}
       <div className="flex gap-3 px-4 pb-4 pt-3">

--- a/frontend/src/pages/tasks/components/MemberSection.tsx
+++ b/frontend/src/pages/tasks/components/MemberSection.tsx
@@ -1,6 +1,7 @@
-import { Avatar } from '../../../components/ui/Avatar';
+import { UserSectionHeader } from '../../../components/shared/UserSectionHeader';
 import { TaskTableHeader } from './TaskTableHeader';
 import { TaskTableRow } from './TaskTableRow';
+import { ROLE_LABELS_TASK_JA } from '../../../lib/roleLabels';
 import type { Task, User } from '../../../types';
 
 interface MemberSectionProps {
@@ -10,26 +11,15 @@ interface MemberSectionProps {
 }
 
 export function MemberSection({ member, tasks, onTaskClick }: MemberSectionProps) {
-  const roleLabel = member.role === 'admin' ? 'リーダー' : 'メンバー';
-
   return (
     <div className="overflow-hidden rounded-lg border border-border-default bg-bg-primary">
-      {/* メンバーヘッダー */}
-      <div className="flex items-center gap-3 px-4 py-3">
-        <Avatar
-          name={member.displayName}
-          imageUrl={member.avatarUrl ?? undefined}
-          colorName={member.avatarColor}
-        />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-bold text-text-primary">{member.displayName}</span>
-          <span className="text-xs text-text-tertiary">{roleLabel}</span>
-        </div>
-        <div className="flex-1" />
-        <span className="inline-flex items-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
-          {tasks.length}件
-        </span>
-      </div>
+      <UserSectionHeader
+        displayName={member.displayName}
+        roleLabel={ROLE_LABELS_TASK_JA[member.role]}
+        avatarUrl={member.avatarUrl}
+        avatarColor={member.avatarColor}
+        count={tasks.length}
+      />
 
       {/* テーブル */}
       <TaskTableHeader />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,7 +16,7 @@ export const PROJECT_TYPES = [
 
 export type ProjectType = (typeof PROJECT_TYPES)[number];
 
-export type UserRole = 'admin' | 'member';
+export type UserRole = 'admin' | 'member' | 'partner';
 
 export type FlowStatus =
   | '未着手'


### PR DESCRIPTION
## Summary
- メンバーに **partner** ロールを追加（権限は member と同等。admin 判定だけ通らない＝業務委託向け）
- レポート画面に新タブ「**パートナー**」を追加。partner 個人ごとに稼働タスク一覧＋合計稼働時間を表示
- 既存のメンバー別タスク一覧と同じ UX（Avatar＋名前＋件数バッジ＋合計時間）

## 主な変更
### バックエンド
- `user_role` enum に `'partner'` を追加（マイグレーション 0008）
- `GET /api/reports/time/partners` 新設（partner 別の稼働集計）
- `computeSessionDurationInRangeSec` で **月またぎセッションを按分**集計（既存 `/time` 系にも適用）
- `parseReportDateRange` で 3 エンドポイント分のクエリパースを共通化
- normal 集計の STANDALONE 除外を `notInArray` で SQL push down
- invite 再有効化時に `role` を上書きせず保持（権限事故を防ぐ）

### フロントエンド
- `UserRole` に `'partner'` を追加。`lib/roleLabels.ts` に表示ラベルを集約
- 設定画面のメンバー追加 / ロール変更で Partner を選択可能に
- レポート画面に「パートナー」タブを追加（`PartnerReportList` / `usePartnerReport`）
- 共通 `UserSectionHeader` を切り出し、MemberSection / MemberCardSection / PartnerReportList で共有
- パートナータブではスプレッドシート出力ボタンを無効化（CSV/Sheets 未対応のため）
- `SummaryRow` は countUnit で「件」/「人」を切替

### コードレビュー対応
xhigh の workflow レビューで挙がった以下の指摘を反映しています:
- avatarUrl を `resolveAvatarUrl` 経由で R2 署名付きURL に解決
- 月またぎセッション按分（startedAt 単独フィルタの誤差を解消）
- is_allowed=false の partner も精算対象に含める
- 稼働ゼロ partner はレスポンスから除外
- 削除済みタスクのセッションは `[削除済みタスク]` として保持

## ⚠️ デプロイ前にやること
**マイグレーション適用**: `0008_lush_moira_mactaggert.sql` は `ALTER TYPE user_role ADD VALUE 'partner'` を実行します。Neon コンソールから手動適用してください（CLI からは sslmode 等の事情で適用未確認）。

## Test plan
- [x] `bun run type-check` 通過
- [x] `bun run lint` 通過（0 warnings / 0 errors）
- [x] `bun run test` 通過（144 tests passed）
- [x] `bun run build` 通過
- [ ] DB マイグレーション適用後、設定画面で Partner ロール作成 → レポート画面のパートナータブで稼働が見えることを動作確認
- [ ] 月またぎセッション（5/31 23:00→6/1 02:00 など）で 6 月のレポートに按分加算されることを確認
- [ ] パートナーが居ない / 全員稼働ゼロでも UI が崩れないことを確認
- [ ] 設定画面の invite で `member` を無効化→再招待した時に role が member のまま維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018crvCtkzijkWgSY5bGVyuQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **新機能**
  - ユーザーロールに「パートナー」を追加しました
  - パートナー別の稼働時間レポートを新規追加しました

* **改善**
  - レポートの期間指定を統一し、期間にまたがる一部重複も按分して正確に集計するよう改善しました
  - 役割表示ラベルを統一管理し、一覧・タスク画面の表示を共通化しました
  - パートナー表示ではスプレッドシート出力を無効化しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->