### PR TITLE
🐛 fix(backlog): 課題更新Webhookで日付が反映されない問題を修正

### DIFF
--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -4,8 +4,11 @@ import {
   generateBacklogUrl,
   parseDateString,
   getCustomFieldValue,
+  getChangedCustomFieldValue,
+  resolveCustomDateField,
   extractIssueFromPayload,
   getCustomFieldConfig,
+  IT_UP_DATE_FIELD_NAMES,
 } from './backlog';
 
 describe('Backlog ユーティリティ', () => {
@@ -99,6 +102,107 @@ describe('Backlog ユーティリティ', () => {
 
     it('undefined配列 → null', () => {
       expect(getCustomFieldValue(undefined, 1)).toBeNull();
+    });
+  });
+
+  describe('getChangedCustomFieldValue', () => {
+    it('カスタム属性名でマッチする（全角ＩＴ予定日）', () => {
+      const changes = [
+        { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
+        { field: 'ＩＴ予定日', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('customField_<ID> 形式でマッチする', () => {
+      const changes = [
+        { field: 'customField_1073783169', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('ID文字列でマッチする', () => {
+      const changes = [
+        { field: '1073783169', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('対象フィールドの変更が無い → undefined', () => {
+      const changes = [{ field: 'status', new_value: '処理中', old_value: '', type: 'standard' }];
+      expect(
+        getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('クリアされた変更（new_value空文字）→ 空文字を返す', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe('');
+    });
+
+    it('changesがundefined → undefined', () => {
+      expect(
+        getChangedCustomFieldValue(undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('resolveCustomDateField', () => {
+    it('customFieldsに対象フィールドがあればそこから解決する', () => {
+      const customFields = [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }];
+      const date = resolveCustomDateField(
+        customFields,
+        undefined,
+        1073783169,
+        IT_UP_DATE_FIELD_NAMES
+      );
+      expect(date).toBeInstanceOf(Date);
+      expect(date!.getFullYear()).toBe(2026);
+    });
+
+    it('customFieldsに無ければchangesから解決する', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      const date = resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES);
+      expect(date).toBeInstanceOf(Date);
+    });
+
+    it('changesでクリアされた場合はnull', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+      ];
+      expect(
+        resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeNull();
+    });
+
+    it('どちらにも情報が無い場合はundefined（既存値を維持）', () => {
+      const changes = [{ field: 'status', new_value: '処理中', old_value: '', type: 'standard' }];
+      expect(
+        resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('customFieldsで値がnull（未設定）ならnull', () => {
+      const customFields = [{ id: 1073783169, value: null, fieldTypeId: 4 }];
+      expect(
+        resolveCustomDateField(customFields, undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeNull();
+    });
+
+    it('fieldIdが未設定のプロジェクトはundefined', () => {
+      expect(
+        resolveCustomDateField([], undefined, undefined, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
     });
   });
 

--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -3,7 +3,6 @@ import {
   extractProjectTypeFromIssueKey,
   generateBacklogUrl,
   parseDateString,
-  getCustomFieldValue,
   getChangedCustomFieldValue,
   resolveCustomDateField,
   extractIssueFromPayload,
@@ -79,32 +78,6 @@ describe('Backlog ユーティリティ', () => {
     });
   });
 
-  describe('getCustomFieldValue', () => {
-    it('文字列値を取得', () => {
-      expect(getCustomFieldValue([{ id: 1, value: '2025/07/15', fieldTypeId: 4 }], 1)).toBe(
-        '2025/07/15'
-      );
-    });
-
-    it('オブジェクト値（name）を取得', () => {
-      expect(
-        getCustomFieldValue([{ id: 1, value: { name: '2025/08/01' }, fieldTypeId: 4 }], 1)
-      ).toBe('2025/08/01');
-    });
-
-    it('存在しないフィールド → null', () => {
-      expect(getCustomFieldValue([{ id: 1, value: 'test', fieldTypeId: 4 }], 99)).toBeNull();
-    });
-
-    it('null値 → null', () => {
-      expect(getCustomFieldValue([{ id: 1, value: null, fieldTypeId: 4 }], 1)).toBeNull();
-    });
-
-    it('undefined配列 → null', () => {
-      expect(getCustomFieldValue(undefined, 1)).toBeNull();
-    });
-  });
-
   describe('getChangedCustomFieldValue', () => {
     it('カスタム属性名でマッチする（全角ＩＴ予定日）', () => {
       const changes = [
@@ -151,6 +124,29 @@ describe('Backlog ユーティリティ', () => {
     it('changesがundefined → undefined', () => {
       expect(
         getChangedCustomFieldValue(undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('fieldが数値でもマッチする（外部JSONの型ゆらぎ対策）', () => {
+      const changes = [
+        { field: 1073783169 as unknown as string, new_value: '2026/07/15', old_value: '' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('new_valueがnull → 空文字（クリア扱い）', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: null, old_value: '2026/07/15', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe('');
+    });
+
+    it('new_valueキー欠落 → undefined（情報なし扱い）', () => {
+      const changes = [{ field: 'ＩＴ予定日', old_value: '2026/07/15', type: 'custom' }];
+      expect(
+        getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
       ).toBeUndefined();
     });
   });
@@ -202,6 +198,27 @@ describe('Backlog ユーティリティ', () => {
     it('fieldIdが未設定のプロジェクトはundefined', () => {
       expect(
         resolveCustomDateField([], undefined, undefined, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('changesの値がパース不能ならundefined（既存値を消さない）', () => {
+      const changes = [
+        {
+          field: 'ＩＴ予定日',
+          new_value: '2026-07-15T00:00:00Z',
+          old_value: '',
+          type: 'custom',
+        },
+      ];
+      expect(
+        resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('customFieldsの値がパース不能ならundefined（既存値を消さない）', () => {
+      const customFields = [{ id: 1073783169, value: '2026年7月15日', fieldTypeId: 4 }];
+      expect(
+        resolveCustomDateField(customFields, undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
       ).toBeUndefined();
     });
   });

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -33,6 +33,14 @@ export function getCustomFieldConfig(projectType: string): BacklogCustomFieldCon
   return BACKLOG_CUSTOM_FIELDS[projectType as ProjectType] ?? {};
 }
 
+/**
+ * 課題更新 Webhook の changes 配列でカスタムフィールドを特定するための属性名。
+ * Backlog の changes は field をカスタム属性名で表す場合と
+ * `customField_<ID>` / ID 文字列で表す場合があるため、名前候補も併せて照合する。
+ */
+export const IT_UP_DATE_FIELD_NAMES = ['ＩＴ予定日', 'IT予定日'] as const;
+export const RELEASE_DATE_FIELD_NAMES = ['本番リリース予定日', 'リリース予定日'] as const;
+
 // --- Webhook ペイロード型 ---
 
 export interface BacklogCustomField {
@@ -40,6 +48,14 @@ export interface BacklogCustomField {
   field?: string;
   value: string | { name?: string; value?: string } | null;
   fieldTypeId: number;
+}
+
+/** 課題更新 Webhook の content.changes の1エントリ */
+export interface BacklogChange {
+  field?: string;
+  new_value?: string | null;
+  old_value?: string | null;
+  type?: string;
 }
 
 export interface BacklogWebhookPayload {
@@ -52,6 +68,7 @@ export interface BacklogWebhookPayload {
     title?: string;
     description?: string;
     customFields?: BacklogCustomField[];
+    changes?: BacklogChange[];
   };
   project?: {
     projectKey?: string;
@@ -153,6 +170,52 @@ export function getCustomFieldValue(
 }
 
 /**
+ * 課題更新 Webhook の changes 配列からカスタムフィールドの変更後の値を取得する
+ *
+ * @returns 対象フィールドの変更エントリが無い場合は undefined（＝情報なし）、
+ *          変更がある場合は new_value（クリア時は空文字 or null）
+ */
+export function getChangedCustomFieldValue(
+  changes: BacklogChange[] | undefined,
+  fieldId: number,
+  fieldNames: readonly string[]
+): string | null | undefined {
+  if (!changes || !Array.isArray(changes)) return undefined;
+
+  const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
+  const change = changes.find((c) => typeof c.field === 'string' && candidates.has(c.field.trim()));
+  if (!change) return undefined;
+
+  return typeof change.new_value === 'string' ? change.new_value : null;
+}
+
+/**
+ * Webhook ペイロードから日付カスタムフィールドの更新値を解決する
+ *
+ * 課題追加イベントは customFields に全フィールドが入るが、
+ * 課題更新イベントは changes に変更差分しか入らない。
+ *
+ * @returns undefined = ペイロードに情報なし（既存値を維持すべき）、
+ *          null = クリアされた、Date = 設定された
+ */
+export function resolveCustomDateField(
+  customFields: BacklogCustomField[] | undefined,
+  changes: BacklogChange[] | undefined,
+  fieldId: number | undefined,
+  fieldNames: readonly string[]
+): Date | null | undefined {
+  if (!fieldId) return undefined;
+
+  if (Array.isArray(customFields) && customFields.some((f) => f.id === fieldId)) {
+    return parseDateString(getCustomFieldValue(customFields, fieldId));
+  }
+
+  const changedValue = getChangedCustomFieldValue(changes, fieldId, fieldNames);
+  if (changedValue === undefined) return undefined;
+  return parseDateString(changedValue);
+}
+
+/**
  * Webhook ペイロードから課題情報を抽出する
  */
 export function extractIssueFromPayload(body: BacklogWebhookPayload): {
@@ -161,6 +224,7 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
   title: string | null;
   description: string | undefined;
   customFields: BacklogCustomField[] | undefined;
+  changes: BacklogChange[] | undefined;
 } {
   if (body.content) {
     let issueKey: string | null = null;
@@ -175,6 +239,7 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
       title: body.content.summary || body.content.title || null,
       description: body.content.description || undefined,
       customFields: body.content.customFields,
+      changes: body.content.changes,
     };
   }
 
@@ -185,6 +250,7 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
       title: body.issue.summary || body.issue.title || null,
       description: body.issue.description || undefined,
       customFields: body.issue.customFields,
+      changes: undefined,
     };
   }
 
@@ -194,5 +260,6 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
     title: body.summary || body.title || null,
     description: body.description || undefined,
     customFields: undefined,
+    changes: undefined,
   };
 }

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -144,18 +144,8 @@ export function parseDateString(dateString: string | null | undefined): Date | n
   return date;
 }
 
-/**
- * カスタムフィールドから値を取得
- */
-export function getCustomFieldValue(
-  customFields: BacklogCustomField[] | undefined,
-  fieldId: number
-): string | null {
-  if (!customFields || !Array.isArray(customFields)) return null;
-
-  const field = customFields.find((f) => f.id === fieldId);
-  if (!field) return null;
-
+/** カスタムフィールド1件から値を取り出す */
+function extractCustomFieldValue(field: BacklogCustomField): string | null {
   const value = field.value;
   if (value == null) return null;
   if (typeof value === 'string') return value;
@@ -170,6 +160,19 @@ export function getCustomFieldValue(
 }
 
 /**
+ * カスタムフィールドから値を取得
+ */
+export function getCustomFieldValue(
+  customFields: BacklogCustomField[] | undefined,
+  fieldId: number
+): string | null {
+  if (!Array.isArray(customFields)) return null;
+
+  const field = customFields.find((f) => f.id === fieldId);
+  return field ? extractCustomFieldValue(field) : null;
+}
+
+/**
  * 課題更新 Webhook の changes 配列からカスタムフィールドの変更後の値を取得する
  *
  * @returns 対象フィールドの変更エントリが無い場合は undefined（＝情報なし）、
@@ -180,8 +183,9 @@ export function getChangedCustomFieldValue(
   fieldId: number,
   fieldNames: readonly string[]
 ): string | null | undefined {
-  if (!changes || !Array.isArray(changes)) return undefined;
+  if (!Array.isArray(changes)) return undefined;
 
+  // TODO: 実ペイロードで field の表記が確定したら候補を絞る（route側の unmatched ログで確認可能）
   const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
   const change = changes.find((c) => typeof c.field === 'string' && candidates.has(c.field.trim()));
   if (!change) return undefined;
@@ -206,8 +210,9 @@ export function resolveCustomDateField(
 ): Date | null | undefined {
   if (!fieldId) return undefined;
 
-  if (Array.isArray(customFields) && customFields.some((f) => f.id === fieldId)) {
-    return parseDateString(getCustomFieldValue(customFields, fieldId));
+  if (Array.isArray(customFields)) {
+    const field = customFields.find((f) => f.id === fieldId);
+    if (field) return parseDateString(extractCustomFieldValue(field));
   }
 
   const changedValue = getChangedCustomFieldValue(changes, fieldId, fieldNames);

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -144,6 +144,18 @@ export function parseDateString(dateString: string | null | undefined): Date | n
   return date;
 }
 
+/**
+ * Webhook から取れた日付文字列を3値に解決する
+ *
+ * 空値（null / 空文字）はクリア（null）を意味する。
+ * パース不能な非空文字列は形式不明の情報として信用せず undefined（既存値維持）にする
+ * （更新イベントで想定外の日付形式が来た場合に既存日付を消さないため）
+ */
+function parseDateValue(value: string | null): Date | null | undefined {
+  if (value == null || value === '') return null;
+  return parseDateString(value) ?? undefined;
+}
+
 /** カスタムフィールド1件から値を取り出す */
 function extractCustomFieldValue(field: BacklogCustomField): string | null {
   const value = field.value;
@@ -160,23 +172,10 @@ function extractCustomFieldValue(field: BacklogCustomField): string | null {
 }
 
 /**
- * カスタムフィールドから値を取得
- */
-export function getCustomFieldValue(
-  customFields: BacklogCustomField[] | undefined,
-  fieldId: number
-): string | null {
-  if (!Array.isArray(customFields)) return null;
-
-  const field = customFields.find((f) => f.id === fieldId);
-  return field ? extractCustomFieldValue(field) : null;
-}
-
-/**
  * 課題更新 Webhook の changes 配列からカスタムフィールドの変更後の値を取得する
  *
- * @returns 対象フィールドの変更エントリが無い場合は undefined（＝情報なし）、
- *          変更がある場合は new_value（クリア時は空文字 or null）
+ * @returns 対象フィールドの変更エントリが無い（または new_value が欠落している）場合は
+ *          undefined（＝情報なし）、変更がある場合は new_value（クリア時は空文字）
  */
 export function getChangedCustomFieldValue(
   changes: BacklogChange[] | undefined,
@@ -187,10 +186,12 @@ export function getChangedCustomFieldValue(
 
   // TODO: 実ペイロードで field の表記が確定したら候補を絞る（route側の unmatched ログで確認可能）
   const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
-  const change = changes.find((c) => typeof c.field === 'string' && candidates.has(c.field.trim()));
+  const change = changes.find((c) => c.field != null && candidates.has(String(c.field).trim()));
   if (!change) return undefined;
 
-  return typeof change.new_value === 'string' ? change.new_value : null;
+  if (typeof change.new_value === 'string') return change.new_value;
+  // new_value: null は明示的なクリア、キー自体の欠落は情報なし扱い
+  return change.new_value === null ? '' : undefined;
 }
 
 /**
@@ -199,7 +200,7 @@ export function getChangedCustomFieldValue(
  * 課題追加イベントは customFields に全フィールドが入るが、
  * 課題更新イベントは changes に変更差分しか入らない。
  *
- * @returns undefined = ペイロードに情報なし（既存値を維持すべき）、
+ * @returns undefined = ペイロードに情報なし or パース不能（既存値を維持すべき）、
  *          null = クリアされた、Date = 設定された
  */
 export function resolveCustomDateField(
@@ -212,12 +213,12 @@ export function resolveCustomDateField(
 
   if (Array.isArray(customFields)) {
     const field = customFields.find((f) => f.id === fieldId);
-    if (field) return parseDateString(extractCustomFieldValue(field));
+    if (field) return parseDateValue(extractCustomFieldValue(field));
   }
 
   const changedValue = getChangedCustomFieldValue(changes, fieldId, fieldNames);
   if (changedValue === undefined) return undefined;
-  return parseDateString(changedValue);
+  return parseDateValue(changedValue);
 }
 
 /**

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -183,6 +183,191 @@ describe('Backlog API', () => {
       expect(task.itUpDate).not.toBeNull();
       expect(task.releaseDate).not.toBeNull();
     });
+
+    it('更新イベント（customFieldsなし）でも既存の日付を消さない', async () => {
+      // 作成: 日付あり
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 300,
+            key_id: 300,
+            summary: '日付保持テスト',
+            customFields: [
+              { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
+              { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
+            ],
+          },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      // 更新イベント: customFieldsなし・日付以外の変更のみ
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 300,
+            key_id: 300,
+            summary: '日付保持テスト（更新後）',
+            changes: [
+              { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.title).toBe('REG2017-300 日付保持テスト（更新後）');
+      expect(task.itUpDate).not.toBeNull();
+      expect(task.releaseDate).not.toBeNull();
+    });
+
+    it('更新イベントのchangesから日付を反映できる', async () => {
+      // 作成: 日付なし
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: { id: 301, key_id: 301, summary: '日付追加テスト' },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      // 更新イベント: changesでＩＴ予定日・本番リリース予定日を設定
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 301,
+            key_id: 301,
+            summary: '日付追加テスト',
+            changes: [
+              { field: 'ＩＴ予定日', new_value: '2026/07/22', old_value: '', type: 'custom' },
+              {
+                field: '本番リリース予定日',
+                new_value: '2026/07/30',
+                old_value: '',
+                type: 'custom',
+              },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.itUpDate).not.toBeNull();
+      expect(task.releaseDate).not.toBeNull();
+    });
+
+    it('更新イベントのchanges（customField_<ID>形式）でも日付を反映できる', async () => {
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'BRGREG' },
+          content: { id: 302, key_id: 302, summary: 'ID形式テスト' },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'BRGREG' },
+          content: {
+            id: 302,
+            key_id: 302,
+            summary: 'ID形式テスト',
+            changes: [
+              {
+                field: 'customField_1073754985',
+                new_value: '2026/07/22',
+                old_value: '',
+                type: 'custom',
+              },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.itUpDate).not.toBeNull();
+      // 変更が無かった releaseDate は触らない
+      expect(task.releaseDate).toBeNull();
+    });
+
+    it('更新イベントで日付がクリアされたらnullにする', async () => {
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 303,
+            key_id: 303,
+            summary: '日付クリアテスト',
+            customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
+          },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 303,
+            key_id: 303,
+            summary: '日付クリアテスト',
+            changes: [
+              { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.itUpDate).toBeNull();
+    });
   });
 
   describe('POST /api/backlog/sync', () => {

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -27,21 +27,14 @@ afterAll(async () => {
 describe('Backlog API', () => {
   describe('POST /api/backlog/webhook', () => {
     it('新規タスクを作成できる（content形式）', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res = await postWebhook({
+        project: { projectKey: 'BRGREG' },
+        content: {
+          id: 2905,
+          key_id: 2905,
+          summary: 'テストタスク',
+          description: '説明文',
         },
-        body: JSON.stringify({
-          project: { projectKey: 'BRGREG' },
-          content: {
-            id: 2905,
-            key_id: 2905,
-            summary: 'テストタスク',
-            description: '説明文',
-          },
-        }),
       });
 
       expect(res.status).toBe(200);
@@ -67,31 +60,17 @@ describe('Backlog API', () => {
 
     it('既存タスクを更新できる（idempotent upsert）', async () => {
       // 1回目: 作成
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: { id: 100, key_id: 100, summary: '初回タイトル' },
-        }),
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 100, key_id: 100, summary: '初回タイトル' },
       });
       expect(res1.status).toBe(200);
       const body1 = (await res1.json()) as any;
 
       // 2回目: 更新
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: { id: 100, key_id: 100, summary: '更新タイトル' },
-        }),
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 100, key_id: 100, summary: '更新タイトル' },
       });
       expect(res2.status).toBe(200);
       const body2 = (await res2.json()) as any;
@@ -104,61 +83,33 @@ describe('Backlog API', () => {
     });
 
     it('issueKeyがないと400', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({ content: { summary: 'テスト' } }),
-      });
+      const res = await postWebhook({ content: { summary: 'テスト' } });
       expect(res.status).toBe(400);
     });
 
     it('不明なプロジェクトタイプだと400', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'UNKNOWN' },
-          content: { id: 1, key_id: 1, summary: 'テスト' },
-        }),
+      const res = await postWebhook({
+        project: { projectKey: 'UNKNOWN' },
+        content: { id: 1, key_id: 1, summary: 'テスト' },
       });
       expect(res.status).toBe(400);
     });
 
     it('titleがないと400', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'MONO' },
-          content: { id: 1, key_id: 1 },
-        }),
+      const res = await postWebhook({
+        project: { projectKey: 'MONO' },
+        content: { id: 1, key_id: 1 },
       });
       expect(res.status).toBe(400);
     });
 
     it('issue形式のペイロードでも処理できる', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res = await postWebhook({
+        issue: {
+          id: 500,
+          issueKey: 'MONO-500',
+          summary: 'issue形式タスク',
         },
-        body: JSON.stringify({
-          issue: {
-            id: 500,
-            issueKey: 'MONO-500',
-            summary: 'issue形式タスク',
-          },
-        }),
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
@@ -166,24 +117,17 @@ describe('Backlog API', () => {
     });
 
     it('カスタムフィールドから日付を抽出できる', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 200,
+          key_id: 200,
+          summary: '日付テスト',
+          customFields: [
+            { id: 1073783169, value: '2025/07/15', fieldTypeId: 4 },
+            { id: 1073783170, value: { name: '2025/08/01' }, fieldTypeId: 4 },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 200,
-            key_id: 200,
-            summary: '日付テスト',
-            customFields: [
-              { id: 1073783169, value: '2025/07/15', fieldTypeId: 4 },
-              { id: 1073783170, value: { name: '2025/08/01' }, fieldTypeId: 4 },
-            ],
-          },
-        }),
       });
 
       expect(res.status).toBe(200);

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -6,6 +6,16 @@ import * as schema from '../db/schema';
 
 const app = createTestApp();
 
+const postWebhook = (payload: unknown) =>
+  app.request('/api/backlog/webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+    },
+    body: JSON.stringify(payload),
+  });
+
 afterEach(async () => {
   await cleanDatabase(db);
 });
@@ -186,45 +196,31 @@ describe('Backlog API', () => {
 
     it('更新イベント（customFieldsなし）でも既存の日付を消さない', async () => {
       // 作成: 日付あり
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 300,
+          key_id: 300,
+          summary: '日付保持テスト',
+          customFields: [
+            { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
+            { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 300,
-            key_id: 300,
-            summary: '日付保持テスト',
-            customFields: [
-              { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
-              { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
-            ],
-          },
-        }),
       });
       const body1 = (await res1.json()) as any;
 
       // 更新イベント: customFieldsなし・日付以外の変更のみ
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 300,
+          key_id: 300,
+          summary: '日付保持テスト（更新後）',
+          changes: [
+            { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 300,
-            key_id: 300,
-            summary: '日付保持テスト（更新後）',
-            changes: [
-              { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 
@@ -236,43 +232,29 @@ describe('Backlog API', () => {
 
     it('更新イベントのchangesから日付を反映できる', async () => {
       // 作成: 日付なし
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: { id: 301, key_id: 301, summary: '日付追加テスト' },
-        }),
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 301, key_id: 301, summary: '日付追加テスト' },
       });
       const body1 = (await res1.json()) as any;
 
       // 更新イベント: changesでＩＴ予定日・本番リリース予定日を設定
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 301,
+          key_id: 301,
+          summary: '日付追加テスト',
+          changes: [
+            { field: 'ＩＴ予定日', new_value: '2026/07/22', old_value: '', type: 'custom' },
+            {
+              field: '本番リリース予定日',
+              new_value: '2026/07/30',
+              old_value: '',
+              type: 'custom',
+            },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 301,
-            key_id: 301,
-            summary: '日付追加テスト',
-            changes: [
-              { field: 'ＩＴ予定日', new_value: '2026/07/22', old_value: '', type: 'custom' },
-              {
-                field: '本番リリース予定日',
-                new_value: '2026/07/30',
-                old_value: '',
-                type: 'custom',
-              },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 
@@ -282,41 +264,27 @@ describe('Backlog API', () => {
     });
 
     it('更新イベントのchanges（customField_<ID>形式）でも日付を反映できる', async () => {
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'BRGREG' },
-          content: { id: 302, key_id: 302, summary: 'ID形式テスト' },
-        }),
+      const res1 = await postWebhook({
+        project: { projectKey: 'BRGREG' },
+        content: { id: 302, key_id: 302, summary: 'ID形式テスト' },
       });
       const body1 = (await res1.json()) as any;
 
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'BRGREG' },
+        content: {
+          id: 302,
+          key_id: 302,
+          summary: 'ID形式テスト',
+          changes: [
+            {
+              field: 'customField_1073754985',
+              new_value: '2026/07/22',
+              old_value: '',
+              type: 'custom',
+            },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'BRGREG' },
-          content: {
-            id: 302,
-            key_id: 302,
-            summary: 'ID形式テスト',
-            changes: [
-              {
-                field: 'customField_1073754985',
-                new_value: '2026/07/22',
-                old_value: '',
-                type: 'custom',
-              },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 
@@ -327,41 +295,27 @@ describe('Backlog API', () => {
     });
 
     it('更新イベントで日付がクリアされたらnullにする', async () => {
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 303,
+          key_id: 303,
+          summary: '日付クリアテスト',
+          customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 303,
-            key_id: 303,
-            summary: '日付クリアテスト',
-            customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
-          },
-        }),
       });
       const body1 = (await res1.json()) as any;
 
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 303,
+          key_id: 303,
+          summary: '日付クリアテスト',
+          changes: [
+            { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 303,
-            key_id: 303,
-            summary: '日付クリアテスト',
-            changes: [
-              { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -91,7 +91,14 @@ app.post('/webhook', async (c) => {
   );
 
   // changes の field 表記が想定と違う場合の調査用ログ
-  if ((changes?.length ?? 0) > 0 && itUpDate === undefined && releaseDate === undefined) {
+  // （日付フィールド未設定のプロジェクトや日付以外の変更で埋もれないよう対象を限定）
+  const hasDateFieldConfig = Boolean(fieldConfig.itUpDate || fieldConfig.releaseDate);
+  if (
+    hasDateFieldConfig &&
+    (changes?.length ?? 0) > 0 &&
+    itUpDate === undefined &&
+    releaseDate === undefined
+  ) {
     console.info('[backlog/webhook] no date fields matched in changes', {
       issueKey,
       changeFields: changes?.map((ch) => ch.field),

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -9,8 +9,9 @@ import {
   extractProjectTypeFromIssueKey,
   generateBacklogUrl,
   getCustomFieldConfig,
-  getCustomFieldValue,
-  parseDateString,
+  resolveCustomDateField,
+  IT_UP_DATE_FIELD_NAMES,
+  RELEASE_DATE_FIELD_NAMES,
 } from '../lib/backlog';
 import type { BacklogWebhookPayload } from '../lib/backlog';
 import type { Env } from '../index';
@@ -42,13 +43,15 @@ app.post('/webhook', async (c) => {
   const body = (await c.req.json()) as BacklogWebhookPayload;
 
   // ペイロードから課題情報を抽出
-  const { issueKey, issueId, title, description, customFields } = extractIssueFromPayload(body);
+  const { issueKey, issueId, title, description, customFields, changes } =
+    extractIssueFromPayload(body);
   console.info('[backlog/webhook] parsed', {
     issueKey,
     issueId,
     hasTitle: Boolean(title),
     hasDescription: description !== undefined,
     customFieldsCount: customFields?.length ?? 0,
+    changesCount: changes?.length ?? 0,
   });
 
   if (!issueKey) {
@@ -71,16 +74,29 @@ app.post('/webhook', async (c) => {
   const url = generateBacklogUrl(issueKey);
   const finalIssueId = issueId || issueKey;
 
-  // カスタムフィールドから日付を抽出
+  // カスタムフィールド（追加イベント）または changes（更新イベント）から日付を解決
+  // undefined = ペイロードに情報なし（更新時は既存値を維持する）
   const fieldConfig = getCustomFieldConfig(projectType);
-  const itUpDateValue = fieldConfig.itUpDate
-    ? getCustomFieldValue(customFields, fieldConfig.itUpDate)
-    : null;
-  const releaseDateValue = fieldConfig.releaseDate
-    ? getCustomFieldValue(customFields, fieldConfig.releaseDate)
-    : null;
-  const itUpDate = parseDateString(itUpDateValue);
-  const releaseDate = parseDateString(releaseDateValue);
+  const itUpDate = resolveCustomDateField(
+    customFields,
+    changes,
+    fieldConfig.itUpDate,
+    IT_UP_DATE_FIELD_NAMES
+  );
+  const releaseDate = resolveCustomDateField(
+    customFields,
+    changes,
+    fieldConfig.releaseDate,
+    RELEASE_DATE_FIELD_NAMES
+  );
+
+  // changes の field 表記が想定と違う場合の調査用ログ
+  if ((changes?.length ?? 0) > 0 && itUpDate === undefined && releaseDate === undefined) {
+    console.info('[backlog/webhook] no date fields matched in changes', {
+      issueKey,
+      changeFields: changes?.map((ch) => ch.field),
+    });
+  }
 
   // タイトルに課題番号を接頭辞として追加
   const formattedTitle = `${issueKey} ${title}`;
@@ -101,8 +117,8 @@ app.post('/webhook', async (c) => {
         title: formattedTitle,
         ...(description !== undefined && { description }),
         projectType: projectType as (typeof tasks.projectType.enumValues)[number],
-        itUpDate,
-        releaseDate,
+        ...(itUpDate !== undefined && { itUpDate }),
+        ...(releaseDate !== undefined && { releaseDate }),
         updatedAt: now,
       })
       .where(eq(tasks.id, existingExternal.taskId));
@@ -143,8 +159,8 @@ app.post('/webhook', async (c) => {
     ...(description !== undefined && { description }),
     flowStatus: '未着手',
     assigneeIds: [],
-    itUpDate,
-    releaseDate,
+    itUpDate: itUpDate ?? null,
+    releaseDate: releaseDate ?? null,
     kubunLabelId: '',
     backlogUrl: url,
     order: Date.now(),


### PR DESCRIPTION
## 概要

BacklogチケットのＩＴ予定日・本番リリース予定日がChumoに反映されない問題の修正。

## 原因（本番ログ + DBで裏取り済み）

1. **主因**: Backlogの「課題の更新」Webhookは `customFields` を含まず `content.changes`（変更差分）のみを送る仕様だが、現行コードは `customFields` しか参照していない。チケット作成後に日付を設定・変更するフローでは反映されない
   - Workers Logs 直近3日の全9リクエストが「課題の追加」のみで、更新イベントは0件。**Backlog側のWebhook通知設定で「課題の更新」が対象外になっている疑いも濃厚**（要設定確認）
   - 作成時点で日付が入っていたチケット（REG2017-2369〜2372等、customFields 6〜7個）は現在も正常に同期されている
2. **副因（時限爆弾）**: 更新処理が `itUpDate` / `releaseDate` を無条件上書きしており、customFieldsの無い更新イベントが届くと既存の日付が null で消える

## 修正内容

- `content.changes` からＩＴ予定日・本番リリース予定日を解決する処理を追加（`resolveCustomDateField` / `getChangedCustomFieldValue`）
- changes の `field` 表記が未確定のため、属性名（「ＩＴ予定日」全角含む）/ `customField_<ID>` / ID文字列の3パターンにマッチ。未マッチ時は調査用ログを出力（形式確定後に絞る TODO 付き）
- 日付情報がペイロードに無い更新は既存値を維持（undefined / null / Date の3値で表現）。日付クリアは null を反映
- ユニットテスト13件・統合テスト4件を追加、simplifyレビューの指摘反映（二重スキャン解消・テストヘルパー集約）

## テスト

- [x] `bun run test` 164件全パス
- [x] `bun run lint` / `bun run type-check` クリーン

## マージ後の運用手順（順番重要）

1. 本番デプロイ（このPRの修正 + 未デプロイのFAQ_IMP対応が乗る ※現本番はFAQ_IMPチケットを unknown projectType で拒否中）
2. **デプロイ後に** Backlog管理画面のWebhook通知イベントへ「課題の更新」を追加
3. 動作確認: Backlogでチケットの日付を変更 → Chumo反映と Workers Logs の `changesCount` / `no date fields matched` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ff1qnrQ3nrBtz3JPUXEe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhookで、更新内容に含まれるカスタム日付フィールドの変更を反映できるようになりました。
  * 既存の日付情報を維持しつつ、変更・クリアの状態も正しく扱えるようになりました。

* **Bug Fixes**
  * カスタム日付が変更されていない場合に、不要な上書きを防ぐよう改善しました。
  * 日付のクリアや未設定のケースが、期待どおり `null` / 未更新として扱われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->