### PR TITLE
🚀 release: Backlog日付同期修正・partnerロール・FAQ_IMP対応

### DIFF
--- a/backend/src/db/migrations/0007_chemical_fixer.sql
+++ b/backend/src/db/migrations/0007_chemical_fixer.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."project_type" ADD VALUE 'FAQ_IMP';

--- a/backend/src/db/migrations/0008_lush_moira_mactaggert.sql
+++ b/backend/src/db/migrations/0008_lush_moira_mactaggert.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."user_role" ADD VALUE 'partner';

--- a/backend/src/db/migrations/meta/0007_snapshot.json
+++ b/backend/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1311 @@
+{
+  "id": "c44e4ee7-10e5-404b-9de2-eb62bbe72aba",
+  "prevId": "b39fd73e-0e90-4de3-91a7-da3b6660b1ac",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "contact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_report_details": {
+          "name": "error_report_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_idx": {
+          "name": "notifications_recipient_id_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_task_id_tasks_id_fk": {
+          "name": "notifications_task_id_tasks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "backlog_project_key": {
+          "name": "backlog_project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_parent_id": {
+          "name": "drive_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_activities": {
+      "name": "task_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_activities_task_id_idx": {
+          "name": "task_activities_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_activities_task_id_tasks_id_fk": {
+          "name": "task_activities_task_id_tasks_id_fk",
+          "tableFrom": "task_activities",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_ids": {
+          "name": "mentioned_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "read_by": {
+          "name": "read_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_comments_task_id_idx": {
+          "name": "task_comments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_comments_author_id_idx": {
+          "name": "task_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_comments_task_id_tasks_id_fk": {
+          "name": "task_comments_task_id_tasks_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_externals": {
+      "name": "task_externals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "external_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_externals_task_id_tasks_id_fk": {
+          "name": "task_externals_task_id_tasks_id_fk",
+          "tableFrom": "task_externals",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_externals_task_id_unique": {
+          "name": "task_externals_task_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pins": {
+      "name": "task_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pins_user_task_idx": {
+          "name": "task_pins_user_task_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_user_id_idx": {
+          "name": "task_pins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pins_task_id_tasks_id_fk": {
+          "name": "task_pins_task_id_tasks_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_sessions": {
+      "name": "task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_sessions_task_id_idx": {
+          "name": "task_sessions_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_id_idx": {
+          "name": "task_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_ended_at_idx": {
+          "name": "task_sessions_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_active_idx": {
+          "name": "task_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_sessions_task_id_tasks_id_fk": {
+          "name": "task_sessions_task_id_tasks_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flow_status": {
+          "name": "flow_status",
+          "type": "flow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'未着手'"
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_ids": {
+          "name": "assignee_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "it_up_date": {
+          "name": "it_up_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kubun_label_id": {
+          "name": "kubun_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_drive_url": {
+          "name": "google_drive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fire_issue_url": {
+          "name": "fire_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_chat_thread_url": {
+          "name": "google_chat_thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlog_url": {
+          "name": "backlog_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_issue_url": {
+          "name": "pet_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "over3_reason": {
+          "name": "over3_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_reminders": {
+          "name": "session_reminders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_project_type_idx": {
+          "name": "tasks_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_flow_status_idx": {
+          "name": "tasks_flow_status_idx",
+          "columns": [
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_assignee_ids_idx": {
+          "name": "tasks_assignee_ids_idx",
+          "columns": [
+            {
+              "expression": "assignee_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "tasks_order_idx": {
+          "name": "tasks_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_project_type_flow_status_idx": {
+          "name": "tasks_project_type_flow_status_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_allowed": {
+          "name": "is_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_color": {
+          "name": "avatar_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_oauth_updated_at": {
+          "name": "google_oauth_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcm_tokens": {
+          "name": "fcm_tokens",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": ["sync", "timerStart", "timerStop", "update", "driveCreate", "fireCreate"]
+    },
+    "public.contact_status": {
+      "name": "contact_status",
+      "schema": "public",
+      "values": ["pending", "resolved"]
+    },
+    "public.contact_type": {
+      "name": "contact_type",
+      "schema": "public",
+      "values": ["error", "feature", "other"]
+    },
+    "public.external_source": {
+      "name": "external_source",
+      "schema": "public",
+      "values": ["backlog"]
+    },
+    "public.flow_status": {
+      "name": "flow_status",
+      "schema": "public",
+      "values": ["未着手", "ディレクション", "コーディング", "デザイン", "待ち", "対応中", "完了"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["mention", "session_reminder"]
+    },
+    "public.priority": {
+      "name": "priority",
+      "schema": "public",
+      "values": ["low", "medium", "high", "urgent"]
+    },
+    "public.progress_status": {
+      "name": "progress_status",
+      "schema": "public",
+      "values": [
+        "未着手",
+        "仕様確認",
+        "待ち",
+        "調査",
+        "見積",
+        "CO",
+        "ロック解除待ち",
+        "デザイン",
+        "コーディング",
+        "品管チェック",
+        "FAQ公開申請",
+        "IT連絡済み",
+        "ST連絡済み",
+        "SENJU登録",
+        "親課題"
+      ]
+    },
+    "public.project_type": {
+      "name": "project_type",
+      "schema": "public",
+      "values": [
+        "REG2017",
+        "BRGREG",
+        "MONO",
+        "MONO_ADMIN",
+        "DES_FIRE",
+        "DesignSystem",
+        "DMREG2",
+        "monosus",
+        "PRREG",
+        "FAQ_IMP"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["ok", "failed"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/0008_snapshot.json
+++ b/backend/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1311 @@
+{
+  "id": "9fb05396-5730-4520-9dbc-c4d807e624ab",
+  "prevId": "c44e4ee7-10e5-404b-9de2-eb62bbe72aba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "contact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_report_details": {
+          "name": "error_report_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_idx": {
+          "name": "notifications_recipient_id_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_task_id_tasks_id_fk": {
+          "name": "notifications_task_id_tasks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "backlog_project_key": {
+          "name": "backlog_project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_parent_id": {
+          "name": "drive_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_activities": {
+      "name": "task_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_activities_task_id_idx": {
+          "name": "task_activities_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_activities_task_id_tasks_id_fk": {
+          "name": "task_activities_task_id_tasks_id_fk",
+          "tableFrom": "task_activities",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_ids": {
+          "name": "mentioned_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "read_by": {
+          "name": "read_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_comments_task_id_idx": {
+          "name": "task_comments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_comments_author_id_idx": {
+          "name": "task_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_comments_task_id_tasks_id_fk": {
+          "name": "task_comments_task_id_tasks_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_externals": {
+      "name": "task_externals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "external_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_key": {
+          "name": "issue_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_externals_task_id_tasks_id_fk": {
+          "name": "task_externals_task_id_tasks_id_fk",
+          "tableFrom": "task_externals",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_externals_task_id_unique": {
+          "name": "task_externals_task_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pins": {
+      "name": "task_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_pins_user_task_idx": {
+          "name": "task_pins_user_task_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_pins_user_id_idx": {
+          "name": "task_pins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pins_task_id_tasks_id_fk": {
+          "name": "task_pins_task_id_tasks_id_fk",
+          "tableFrom": "task_pins",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_sessions": {
+      "name": "task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_sessions_task_id_idx": {
+          "name": "task_sessions_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_id_idx": {
+          "name": "task_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_ended_at_idx": {
+          "name": "task_sessions_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_user_active_idx": {
+          "name": "task_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_sessions_task_id_tasks_id_fk": {
+          "name": "task_sessions_task_id_tasks_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flow_status": {
+          "name": "flow_status",
+          "type": "flow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'未着手'"
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_ids": {
+          "name": "assignee_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "it_up_date": {
+          "name": "it_up_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kubun_label_id": {
+          "name": "kubun_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_drive_url": {
+          "name": "google_drive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fire_issue_url": {
+          "name": "fire_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_chat_thread_url": {
+          "name": "google_chat_thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlog_url": {
+          "name": "backlog_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pet_issue_url": {
+          "name": "pet_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "over3_reason": {
+          "name": "over3_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_reminders": {
+          "name": "session_reminders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_project_type_idx": {
+          "name": "tasks_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_flow_status_idx": {
+          "name": "tasks_flow_status_idx",
+          "columns": [
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_assignee_ids_idx": {
+          "name": "tasks_assignee_ids_idx",
+          "columns": [
+            {
+              "expression": "assignee_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "tasks_order_idx": {
+          "name": "tasks_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_project_type_flow_status_idx": {
+          "name": "tasks_project_type_flow_status_idx",
+          "columns": [
+            {
+              "expression": "project_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flow_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_allowed": {
+          "name": "is_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_color": {
+          "name": "avatar_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_oauth_updated_at": {
+          "name": "google_oauth_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcm_tokens": {
+          "name": "fcm_tokens",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": ["sync", "timerStart", "timerStop", "update", "driveCreate", "fireCreate"]
+    },
+    "public.contact_status": {
+      "name": "contact_status",
+      "schema": "public",
+      "values": ["pending", "resolved"]
+    },
+    "public.contact_type": {
+      "name": "contact_type",
+      "schema": "public",
+      "values": ["error", "feature", "other"]
+    },
+    "public.external_source": {
+      "name": "external_source",
+      "schema": "public",
+      "values": ["backlog"]
+    },
+    "public.flow_status": {
+      "name": "flow_status",
+      "schema": "public",
+      "values": ["未着手", "ディレクション", "コーディング", "デザイン", "待ち", "対応中", "完了"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["mention", "session_reminder"]
+    },
+    "public.priority": {
+      "name": "priority",
+      "schema": "public",
+      "values": ["low", "medium", "high", "urgent"]
+    },
+    "public.progress_status": {
+      "name": "progress_status",
+      "schema": "public",
+      "values": [
+        "未着手",
+        "仕様確認",
+        "待ち",
+        "調査",
+        "見積",
+        "CO",
+        "ロック解除待ち",
+        "デザイン",
+        "コーディング",
+        "品管チェック",
+        "FAQ公開申請",
+        "IT連絡済み",
+        "ST連絡済み",
+        "SENJU登録",
+        "親課題"
+      ]
+    },
+    "public.project_type": {
+      "name": "project_type",
+      "schema": "public",
+      "values": [
+        "REG2017",
+        "BRGREG",
+        "MONO",
+        "MONO_ADMIN",
+        "DES_FIRE",
+        "DesignSystem",
+        "DMREG2",
+        "monosus",
+        "PRREG",
+        "FAQ_IMP"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["ok", "failed"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "member", "partner"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775894757939,
       "tag": "0006_dazzling_frog_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1780367091692,
+      "tag": "0007_chemical_fixer",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1780367091692,
       "tag": "0007_chemical_fixer",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782201791257,
+      "tag": "0008_lush_moira_mactaggert",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.test.ts
+++ b/backend/src/db/schema.test.ts
@@ -60,6 +60,20 @@ describe('schema: users', () => {
     expect(user.createdAt).toBeInstanceOf(Date);
   });
 
+  it('partner ロールを保存できる', async () => {
+    await db.insert(schema.users).values({
+      id: 'user-partner',
+      email: 'partner@example.com',
+      displayName: 'パートナーユーザー',
+      role: 'partner',
+      isAllowed: true,
+    });
+
+    const [user] = await db.select().from(schema.users).where(eq(schema.users.id, 'user-partner'));
+
+    expect(user.role).toBe('partner');
+  });
+
   it('fcmTokens 配列を保存できる', async () => {
     await db.insert(schema.users).values({
       id: 'user-2',

--- a/backend/src/db/schema.test.ts
+++ b/backend/src/db/schema.test.ts
@@ -1,9 +1,36 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { eq } from 'drizzle-orm';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { createTestDb, cleanDatabase } from './test-helpers';
 import * as schema from './schema';
+import { projectTypeEnum } from './schema';
 
 const { db, client } = createTestDb();
+
+/**
+ * ドリフト検知: frontend の PROJECT_TYPES は手動メンテのため、
+ * DB enum (project_type) と値がズレていないかをここで保証する。
+ * frontend↔backend は別パッケージで定数を共有できないため、ソースを読んで突き合わせる。
+ */
+describe('schema: project_type enum とフロントの同期', () => {
+  it('frontend の PROJECT_TYPES が project_type enum と一致する', () => {
+    const frontendTypesPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../../frontend/src/types/index.ts'
+    );
+    const src = readFileSync(frontendTypesPath, 'utf-8');
+
+    const block = src.match(/export const PROJECT_TYPES = \[([\s\S]*?)\] as const;/);
+    expect(block, 'frontend に PROJECT_TYPES 定義が見つからない').not.toBeNull();
+
+    const frontendValues = [...block![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+
+    // 値の集合が一致すること（表示順の差異は許容するため sort で比較）
+    expect([...frontendValues].sort()).toEqual([...projectTypeEnum.enumValues].sort());
+  });
+});
 
 afterEach(async () => {
   await cleanDatabase(db);

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -14,7 +14,7 @@ import { sql } from 'drizzle-orm';
 
 // --- Enums ---
 
-export const userRoleEnum = pgEnum('user_role', ['admin', 'member']);
+export const userRoleEnum = pgEnum('user_role', ['admin', 'member', 'partner']);
 
 export const flowStatusEnum = pgEnum('flow_status', [
   '未着手',

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -56,6 +56,7 @@ export const projectTypeEnum = pgEnum('project_type', [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ]);
 
 export const contactTypeEnum = pgEnum('contact_type', ['error', 'feature', 'other']);

--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -4,8 +4,11 @@ import {
   generateBacklogUrl,
   parseDateString,
   getCustomFieldValue,
+  getChangedCustomFieldValue,
+  resolveCustomDateField,
   extractIssueFromPayload,
   getCustomFieldConfig,
+  IT_UP_DATE_FIELD_NAMES,
 } from './backlog';
 
 describe('Backlog ユーティリティ', () => {
@@ -99,6 +102,107 @@ describe('Backlog ユーティリティ', () => {
 
     it('undefined配列 → null', () => {
       expect(getCustomFieldValue(undefined, 1)).toBeNull();
+    });
+  });
+
+  describe('getChangedCustomFieldValue', () => {
+    it('カスタム属性名でマッチする（全角ＩＴ予定日）', () => {
+      const changes = [
+        { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
+        { field: 'ＩＴ予定日', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('customField_<ID> 形式でマッチする', () => {
+      const changes = [
+        { field: 'customField_1073783169', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('ID文字列でマッチする', () => {
+      const changes = [
+        { field: '1073783169', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('対象フィールドの変更が無い → undefined', () => {
+      const changes = [{ field: 'status', new_value: '処理中', old_value: '', type: 'standard' }];
+      expect(
+        getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('クリアされた変更（new_value空文字）→ 空文字を返す', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe('');
+    });
+
+    it('changesがundefined → undefined', () => {
+      expect(
+        getChangedCustomFieldValue(undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('resolveCustomDateField', () => {
+    it('customFieldsに対象フィールドがあればそこから解決する', () => {
+      const customFields = [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }];
+      const date = resolveCustomDateField(
+        customFields,
+        undefined,
+        1073783169,
+        IT_UP_DATE_FIELD_NAMES
+      );
+      expect(date).toBeInstanceOf(Date);
+      expect(date!.getFullYear()).toBe(2026);
+    });
+
+    it('customFieldsに無ければchangesから解決する', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: '2026/07/15', old_value: '', type: 'custom' },
+      ];
+      const date = resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES);
+      expect(date).toBeInstanceOf(Date);
+    });
+
+    it('changesでクリアされた場合はnull', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+      ];
+      expect(
+        resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeNull();
+    });
+
+    it('どちらにも情報が無い場合はundefined（既存値を維持）', () => {
+      const changes = [{ field: 'status', new_value: '処理中', old_value: '', type: 'standard' }];
+      expect(
+        resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('customFieldsで値がnull（未設定）ならnull', () => {
+      const customFields = [{ id: 1073783169, value: null, fieldTypeId: 4 }];
+      expect(
+        resolveCustomDateField(customFields, undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeNull();
+    });
+
+    it('fieldIdが未設定のプロジェクトはundefined', () => {
+      expect(
+        resolveCustomDateField([], undefined, undefined, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
     });
   });
 

--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -22,6 +22,10 @@ describe('Backlog ユーティリティ', () => {
       expect(extractProjectTypeFromIssueKey('MONO-100')).toBe('MONO');
     });
 
+    it('FAQ_IMP-10 → FAQ_IMP（アンダースコア入りキー）', () => {
+      expect(extractProjectTypeFromIssueKey('FAQ_IMP-10')).toBe('FAQ_IMP');
+    });
+
     it('不明なプロジェクトキー → null', () => {
       expect(extractProjectTypeFromIssueKey('UNKNOWN-100')).toBeNull();
     });
@@ -108,6 +112,11 @@ describe('Backlog ユーティリティ', () => {
     it('MONOは空オブジェクトを返す', () => {
       const config = getCustomFieldConfig('MONO');
       expect(config.itUpDate).toBeUndefined();
+    });
+
+    it('FAQ_IMPは空オブジェクトを返す', () => {
+      const config = getCustomFieldConfig('FAQ_IMP');
+      expect(config).toEqual({});
     });
 
     it('不明なプロジェクトは空オブジェクトを返す', () => {

--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -3,7 +3,6 @@ import {
   extractProjectTypeFromIssueKey,
   generateBacklogUrl,
   parseDateString,
-  getCustomFieldValue,
   getChangedCustomFieldValue,
   resolveCustomDateField,
   extractIssueFromPayload,
@@ -79,32 +78,6 @@ describe('Backlog ユーティリティ', () => {
     });
   });
 
-  describe('getCustomFieldValue', () => {
-    it('文字列値を取得', () => {
-      expect(getCustomFieldValue([{ id: 1, value: '2025/07/15', fieldTypeId: 4 }], 1)).toBe(
-        '2025/07/15'
-      );
-    });
-
-    it('オブジェクト値（name）を取得', () => {
-      expect(
-        getCustomFieldValue([{ id: 1, value: { name: '2025/08/01' }, fieldTypeId: 4 }], 1)
-      ).toBe('2025/08/01');
-    });
-
-    it('存在しないフィールド → null', () => {
-      expect(getCustomFieldValue([{ id: 1, value: 'test', fieldTypeId: 4 }], 99)).toBeNull();
-    });
-
-    it('null値 → null', () => {
-      expect(getCustomFieldValue([{ id: 1, value: null, fieldTypeId: 4 }], 1)).toBeNull();
-    });
-
-    it('undefined配列 → null', () => {
-      expect(getCustomFieldValue(undefined, 1)).toBeNull();
-    });
-  });
-
   describe('getChangedCustomFieldValue', () => {
     it('カスタム属性名でマッチする（全角ＩＴ予定日）', () => {
       const changes = [
@@ -151,6 +124,29 @@ describe('Backlog ユーティリティ', () => {
     it('changesがundefined → undefined', () => {
       expect(
         getChangedCustomFieldValue(undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('fieldが数値でもマッチする（外部JSONの型ゆらぎ対策）', () => {
+      const changes = [
+        { field: 1073783169 as unknown as string, new_value: '2026/07/15', old_value: '' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
+        '2026/07/15'
+      );
+    });
+
+    it('new_valueがnull → 空文字（クリア扱い）', () => {
+      const changes = [
+        { field: 'ＩＴ予定日', new_value: null, old_value: '2026/07/15', type: 'custom' },
+      ];
+      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe('');
+    });
+
+    it('new_valueキー欠落 → undefined（情報なし扱い）', () => {
+      const changes = [{ field: 'ＩＴ予定日', old_value: '2026/07/15', type: 'custom' }];
+      expect(
+        getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
       ).toBeUndefined();
     });
   });
@@ -202,6 +198,27 @@ describe('Backlog ユーティリティ', () => {
     it('fieldIdが未設定のプロジェクトはundefined', () => {
       expect(
         resolveCustomDateField([], undefined, undefined, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('changesの値がパース不能ならundefined（既存値を消さない）', () => {
+      const changes = [
+        {
+          field: 'ＩＴ予定日',
+          new_value: '2026-07-15T00:00:00Z',
+          old_value: '',
+          type: 'custom',
+        },
+      ];
+      expect(
+        resolveCustomDateField(undefined, changes, 1073783169, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
+
+    it('customFieldsの値がパース不能ならundefined（既存値を消さない）', () => {
+      const customFields = [{ id: 1073783169, value: '2026年7月15日', fieldTypeId: 4 }];
+      expect(
+        resolveCustomDateField(customFields, undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
       ).toBeUndefined();
     });
   });

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -33,6 +33,14 @@ export function getCustomFieldConfig(projectType: string): BacklogCustomFieldCon
   return BACKLOG_CUSTOM_FIELDS[projectType as ProjectType] ?? {};
 }
 
+/**
+ * 課題更新 Webhook の changes 配列でカスタムフィールドを特定するための属性名。
+ * Backlog の changes は field をカスタム属性名で表す場合と
+ * `customField_<ID>` / ID 文字列で表す場合があるため、名前候補も併せて照合する。
+ */
+export const IT_UP_DATE_FIELD_NAMES = ['ＩＴ予定日', 'IT予定日'] as const;
+export const RELEASE_DATE_FIELD_NAMES = ['本番リリース予定日', 'リリース予定日'] as const;
+
 // --- Webhook ペイロード型 ---
 
 export interface BacklogCustomField {
@@ -40,6 +48,14 @@ export interface BacklogCustomField {
   field?: string;
   value: string | { name?: string; value?: string } | null;
   fieldTypeId: number;
+}
+
+/** 課題更新 Webhook の content.changes の1エントリ */
+export interface BacklogChange {
+  field?: string;
+  new_value?: string | null;
+  old_value?: string | null;
+  type?: string;
 }
 
 export interface BacklogWebhookPayload {
@@ -52,6 +68,7 @@ export interface BacklogWebhookPayload {
     title?: string;
     description?: string;
     customFields?: BacklogCustomField[];
+    changes?: BacklogChange[];
   };
   project?: {
     projectKey?: string;
@@ -153,6 +170,52 @@ export function getCustomFieldValue(
 }
 
 /**
+ * 課題更新 Webhook の changes 配列からカスタムフィールドの変更後の値を取得する
+ *
+ * @returns 対象フィールドの変更エントリが無い場合は undefined（＝情報なし）、
+ *          変更がある場合は new_value（クリア時は空文字 or null）
+ */
+export function getChangedCustomFieldValue(
+  changes: BacklogChange[] | undefined,
+  fieldId: number,
+  fieldNames: readonly string[]
+): string | null | undefined {
+  if (!changes || !Array.isArray(changes)) return undefined;
+
+  const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
+  const change = changes.find((c) => typeof c.field === 'string' && candidates.has(c.field.trim()));
+  if (!change) return undefined;
+
+  return typeof change.new_value === 'string' ? change.new_value : null;
+}
+
+/**
+ * Webhook ペイロードから日付カスタムフィールドの更新値を解決する
+ *
+ * 課題追加イベントは customFields に全フィールドが入るが、
+ * 課題更新イベントは changes に変更差分しか入らない。
+ *
+ * @returns undefined = ペイロードに情報なし（既存値を維持すべき）、
+ *          null = クリアされた、Date = 設定された
+ */
+export function resolveCustomDateField(
+  customFields: BacklogCustomField[] | undefined,
+  changes: BacklogChange[] | undefined,
+  fieldId: number | undefined,
+  fieldNames: readonly string[]
+): Date | null | undefined {
+  if (!fieldId) return undefined;
+
+  if (Array.isArray(customFields) && customFields.some((f) => f.id === fieldId)) {
+    return parseDateString(getCustomFieldValue(customFields, fieldId));
+  }
+
+  const changedValue = getChangedCustomFieldValue(changes, fieldId, fieldNames);
+  if (changedValue === undefined) return undefined;
+  return parseDateString(changedValue);
+}
+
+/**
  * Webhook ペイロードから課題情報を抽出する
  */
 export function extractIssueFromPayload(body: BacklogWebhookPayload): {
@@ -161,6 +224,7 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
   title: string | null;
   description: string | undefined;
   customFields: BacklogCustomField[] | undefined;
+  changes: BacklogChange[] | undefined;
 } {
   if (body.content) {
     let issueKey: string | null = null;
@@ -175,6 +239,7 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
       title: body.content.summary || body.content.title || null,
       description: body.content.description || undefined,
       customFields: body.content.customFields,
+      changes: body.content.changes,
     };
   }
 
@@ -185,6 +250,7 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
       title: body.issue.summary || body.issue.title || null,
       description: body.issue.description || undefined,
       customFields: body.issue.customFields,
+      changes: undefined,
     };
   }
 
@@ -194,5 +260,6 @@ export function extractIssueFromPayload(body: BacklogWebhookPayload): {
     title: body.summary || body.title || null,
     description: body.description || undefined,
     customFields: undefined,
+    changes: undefined,
   };
 }

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -12,6 +12,7 @@ const PROJECT_TYPES = [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ] as const;
 
 type ProjectType = (typeof PROJECT_TYPES)[number];
@@ -33,6 +34,7 @@ const BACKLOG_CUSTOM_FIELDS: Record<ProjectType, BacklogCustomFieldConfig> = {
   DesignSystem: {},
   DMREG2: { itUpDate: 1073767877, releaseDate: 1073767878 },
   monosus: {},
+  FAQ_IMP: {},
 };
 
 export function getCustomFieldConfig(projectType: string): BacklogCustomFieldConfig {

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -2,20 +2,12 @@
  * Backlog連携ユーティリティ
  */
 
-const PROJECT_TYPES = [
-  'REG2017',
-  'BRGREG',
-  'MONO',
-  'MONO_ADMIN',
-  'DES_FIRE',
-  'DesignSystem',
-  'DMREG2',
-  'monosus',
-  'PRREG',
-  'FAQ_IMP',
-] as const;
+import { projectTypeEnum } from '../db/schema';
 
-type ProjectType = (typeof PROJECT_TYPES)[number];
+/** project_type enum を唯一のソースとして参照（重複定義しない） */
+const PROJECT_TYPES = projectTypeEnum.enumValues;
+
+type ProjectType = (typeof projectTypeEnum.enumValues)[number];
 
 // --- カスタムフィールド設定 ---
 

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -144,18 +144,8 @@ export function parseDateString(dateString: string | null | undefined): Date | n
   return date;
 }
 
-/**
- * カスタムフィールドから値を取得
- */
-export function getCustomFieldValue(
-  customFields: BacklogCustomField[] | undefined,
-  fieldId: number
-): string | null {
-  if (!customFields || !Array.isArray(customFields)) return null;
-
-  const field = customFields.find((f) => f.id === fieldId);
-  if (!field) return null;
-
+/** カスタムフィールド1件から値を取り出す */
+function extractCustomFieldValue(field: BacklogCustomField): string | null {
   const value = field.value;
   if (value == null) return null;
   if (typeof value === 'string') return value;
@@ -170,6 +160,19 @@ export function getCustomFieldValue(
 }
 
 /**
+ * カスタムフィールドから値を取得
+ */
+export function getCustomFieldValue(
+  customFields: BacklogCustomField[] | undefined,
+  fieldId: number
+): string | null {
+  if (!Array.isArray(customFields)) return null;
+
+  const field = customFields.find((f) => f.id === fieldId);
+  return field ? extractCustomFieldValue(field) : null;
+}
+
+/**
  * 課題更新 Webhook の changes 配列からカスタムフィールドの変更後の値を取得する
  *
  * @returns 対象フィールドの変更エントリが無い場合は undefined（＝情報なし）、
@@ -180,8 +183,9 @@ export function getChangedCustomFieldValue(
   fieldId: number,
   fieldNames: readonly string[]
 ): string | null | undefined {
-  if (!changes || !Array.isArray(changes)) return undefined;
+  if (!Array.isArray(changes)) return undefined;
 
+  // TODO: 実ペイロードで field の表記が確定したら候補を絞る（route側の unmatched ログで確認可能）
   const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
   const change = changes.find((c) => typeof c.field === 'string' && candidates.has(c.field.trim()));
   if (!change) return undefined;
@@ -206,8 +210,9 @@ export function resolveCustomDateField(
 ): Date | null | undefined {
   if (!fieldId) return undefined;
 
-  if (Array.isArray(customFields) && customFields.some((f) => f.id === fieldId)) {
-    return parseDateString(getCustomFieldValue(customFields, fieldId));
+  if (Array.isArray(customFields)) {
+    const field = customFields.find((f) => f.id === fieldId);
+    if (field) return parseDateString(extractCustomFieldValue(field));
   }
 
   const changedValue = getChangedCustomFieldValue(changes, fieldId, fieldNames);

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -144,6 +144,18 @@ export function parseDateString(dateString: string | null | undefined): Date | n
   return date;
 }
 
+/**
+ * Webhook から取れた日付文字列を3値に解決する
+ *
+ * 空値（null / 空文字）はクリア（null）を意味する。
+ * パース不能な非空文字列は形式不明の情報として信用せず undefined（既存値維持）にする
+ * （更新イベントで想定外の日付形式が来た場合に既存日付を消さないため）
+ */
+function parseDateValue(value: string | null): Date | null | undefined {
+  if (value == null || value === '') return null;
+  return parseDateString(value) ?? undefined;
+}
+
 /** カスタムフィールド1件から値を取り出す */
 function extractCustomFieldValue(field: BacklogCustomField): string | null {
   const value = field.value;
@@ -160,23 +172,10 @@ function extractCustomFieldValue(field: BacklogCustomField): string | null {
 }
 
 /**
- * カスタムフィールドから値を取得
- */
-export function getCustomFieldValue(
-  customFields: BacklogCustomField[] | undefined,
-  fieldId: number
-): string | null {
-  if (!Array.isArray(customFields)) return null;
-
-  const field = customFields.find((f) => f.id === fieldId);
-  return field ? extractCustomFieldValue(field) : null;
-}
-
-/**
  * 課題更新 Webhook の changes 配列からカスタムフィールドの変更後の値を取得する
  *
- * @returns 対象フィールドの変更エントリが無い場合は undefined（＝情報なし）、
- *          変更がある場合は new_value（クリア時は空文字 or null）
+ * @returns 対象フィールドの変更エントリが無い（または new_value が欠落している）場合は
+ *          undefined（＝情報なし）、変更がある場合は new_value（クリア時は空文字）
  */
 export function getChangedCustomFieldValue(
   changes: BacklogChange[] | undefined,
@@ -187,10 +186,12 @@ export function getChangedCustomFieldValue(
 
   // TODO: 実ペイロードで field の表記が確定したら候補を絞る（route側の unmatched ログで確認可能）
   const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
-  const change = changes.find((c) => typeof c.field === 'string' && candidates.has(c.field.trim()));
+  const change = changes.find((c) => c.field != null && candidates.has(String(c.field).trim()));
   if (!change) return undefined;
 
-  return typeof change.new_value === 'string' ? change.new_value : null;
+  if (typeof change.new_value === 'string') return change.new_value;
+  // new_value: null は明示的なクリア、キー自体の欠落は情報なし扱い
+  return change.new_value === null ? '' : undefined;
 }
 
 /**
@@ -199,7 +200,7 @@ export function getChangedCustomFieldValue(
  * 課題追加イベントは customFields に全フィールドが入るが、
  * 課題更新イベントは changes に変更差分しか入らない。
  *
- * @returns undefined = ペイロードに情報なし（既存値を維持すべき）、
+ * @returns undefined = ペイロードに情報なし or パース不能（既存値を維持すべき）、
  *          null = クリアされた、Date = 設定された
  */
 export function resolveCustomDateField(
@@ -212,12 +213,12 @@ export function resolveCustomDateField(
 
   if (Array.isArray(customFields)) {
     const field = customFields.find((f) => f.id === fieldId);
-    if (field) return parseDateString(extractCustomFieldValue(field));
+    if (field) return parseDateValue(extractCustomFieldValue(field));
   }
 
   const changedValue = getChangedCustomFieldValue(changes, fieldId, fieldNames);
   if (changedValue === undefined) return undefined;
-  return parseDateString(changedValue);
+  return parseDateValue(changedValue);
 }
 
 /**

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -183,6 +183,191 @@ describe('Backlog API', () => {
       expect(task.itUpDate).not.toBeNull();
       expect(task.releaseDate).not.toBeNull();
     });
+
+    it('更新イベント（customFieldsなし）でも既存の日付を消さない', async () => {
+      // 作成: 日付あり
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 300,
+            key_id: 300,
+            summary: '日付保持テスト',
+            customFields: [
+              { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
+              { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
+            ],
+          },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      // 更新イベント: customFieldsなし・日付以外の変更のみ
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 300,
+            key_id: 300,
+            summary: '日付保持テスト（更新後）',
+            changes: [
+              { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.title).toBe('REG2017-300 日付保持テスト（更新後）');
+      expect(task.itUpDate).not.toBeNull();
+      expect(task.releaseDate).not.toBeNull();
+    });
+
+    it('更新イベントのchangesから日付を反映できる', async () => {
+      // 作成: 日付なし
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: { id: 301, key_id: 301, summary: '日付追加テスト' },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      // 更新イベント: changesでＩＴ予定日・本番リリース予定日を設定
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 301,
+            key_id: 301,
+            summary: '日付追加テスト',
+            changes: [
+              { field: 'ＩＴ予定日', new_value: '2026/07/22', old_value: '', type: 'custom' },
+              {
+                field: '本番リリース予定日',
+                new_value: '2026/07/30',
+                old_value: '',
+                type: 'custom',
+              },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.itUpDate).not.toBeNull();
+      expect(task.releaseDate).not.toBeNull();
+    });
+
+    it('更新イベントのchanges（customField_<ID>形式）でも日付を反映できる', async () => {
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'BRGREG' },
+          content: { id: 302, key_id: 302, summary: 'ID形式テスト' },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'BRGREG' },
+          content: {
+            id: 302,
+            key_id: 302,
+            summary: 'ID形式テスト',
+            changes: [
+              {
+                field: 'customField_1073754985',
+                new_value: '2026/07/22',
+                old_value: '',
+                type: 'custom',
+              },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.itUpDate).not.toBeNull();
+      // 変更が無かった releaseDate は触らない
+      expect(task.releaseDate).toBeNull();
+    });
+
+    it('更新イベントで日付がクリアされたらnullにする', async () => {
+      const res1 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 303,
+            key_id: 303,
+            summary: '日付クリアテスト',
+            customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
+          },
+        }),
+      });
+      const body1 = (await res1.json()) as any;
+
+      const res2 = await app.request('/api/backlog/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+        },
+        body: JSON.stringify({
+          project: { projectKey: 'REG2017' },
+          content: {
+            id: 303,
+            key_id: 303,
+            summary: '日付クリアテスト',
+            changes: [
+              { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+            ],
+          },
+        }),
+      });
+      expect(res2.status).toBe(200);
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body1.taskId));
+      expect(task.itUpDate).toBeNull();
+    });
   });
 
   describe('POST /api/backlog/sync', () => {

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -27,21 +27,14 @@ afterAll(async () => {
 describe('Backlog API', () => {
   describe('POST /api/backlog/webhook', () => {
     it('新規タスクを作成できる（content形式）', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res = await postWebhook({
+        project: { projectKey: 'BRGREG' },
+        content: {
+          id: 2905,
+          key_id: 2905,
+          summary: 'テストタスク',
+          description: '説明文',
         },
-        body: JSON.stringify({
-          project: { projectKey: 'BRGREG' },
-          content: {
-            id: 2905,
-            key_id: 2905,
-            summary: 'テストタスク',
-            description: '説明文',
-          },
-        }),
       });
 
       expect(res.status).toBe(200);
@@ -67,31 +60,17 @@ describe('Backlog API', () => {
 
     it('既存タスクを更新できる（idempotent upsert）', async () => {
       // 1回目: 作成
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: { id: 100, key_id: 100, summary: '初回タイトル' },
-        }),
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 100, key_id: 100, summary: '初回タイトル' },
       });
       expect(res1.status).toBe(200);
       const body1 = (await res1.json()) as any;
 
       // 2回目: 更新
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: { id: 100, key_id: 100, summary: '更新タイトル' },
-        }),
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 100, key_id: 100, summary: '更新タイトル' },
       });
       expect(res2.status).toBe(200);
       const body2 = (await res2.json()) as any;
@@ -104,61 +83,33 @@ describe('Backlog API', () => {
     });
 
     it('issueKeyがないと400', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({ content: { summary: 'テスト' } }),
-      });
+      const res = await postWebhook({ content: { summary: 'テスト' } });
       expect(res.status).toBe(400);
     });
 
     it('不明なプロジェクトタイプだと400', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'UNKNOWN' },
-          content: { id: 1, key_id: 1, summary: 'テスト' },
-        }),
+      const res = await postWebhook({
+        project: { projectKey: 'UNKNOWN' },
+        content: { id: 1, key_id: 1, summary: 'テスト' },
       });
       expect(res.status).toBe(400);
     });
 
     it('titleがないと400', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'MONO' },
-          content: { id: 1, key_id: 1 },
-        }),
+      const res = await postWebhook({
+        project: { projectKey: 'MONO' },
+        content: { id: 1, key_id: 1 },
       });
       expect(res.status).toBe(400);
     });
 
     it('issue形式のペイロードでも処理できる', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res = await postWebhook({
+        issue: {
+          id: 500,
+          issueKey: 'MONO-500',
+          summary: 'issue形式タスク',
         },
-        body: JSON.stringify({
-          issue: {
-            id: 500,
-            issueKey: 'MONO-500',
-            summary: 'issue形式タスク',
-          },
-        }),
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
@@ -166,24 +117,17 @@ describe('Backlog API', () => {
     });
 
     it('カスタムフィールドから日付を抽出できる', async () => {
-      const res = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 200,
+          key_id: 200,
+          summary: '日付テスト',
+          customFields: [
+            { id: 1073783169, value: '2025/07/15', fieldTypeId: 4 },
+            { id: 1073783170, value: { name: '2025/08/01' }, fieldTypeId: 4 },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 200,
-            key_id: 200,
-            summary: '日付テスト',
-            customFields: [
-              { id: 1073783169, value: '2025/07/15', fieldTypeId: 4 },
-              { id: 1073783170, value: { name: '2025/08/01' }, fieldTypeId: 4 },
-            ],
-          },
-        }),
       });
 
       expect(res.status).toBe(200);

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -6,6 +6,16 @@ import * as schema from '../db/schema';
 
 const app = createTestApp();
 
+const postWebhook = (payload: unknown) =>
+  app.request('/api/backlog/webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+    },
+    body: JSON.stringify(payload),
+  });
+
 afterEach(async () => {
   await cleanDatabase(db);
 });
@@ -186,45 +196,31 @@ describe('Backlog API', () => {
 
     it('更新イベント（customFieldsなし）でも既存の日付を消さない', async () => {
       // 作成: 日付あり
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 300,
+          key_id: 300,
+          summary: '日付保持テスト',
+          customFields: [
+            { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
+            { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 300,
-            key_id: 300,
-            summary: '日付保持テスト',
-            customFields: [
-              { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
-              { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
-            ],
-          },
-        }),
       });
       const body1 = (await res1.json()) as any;
 
       // 更新イベント: customFieldsなし・日付以外の変更のみ
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 300,
+          key_id: 300,
+          summary: '日付保持テスト（更新後）',
+          changes: [
+            { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 300,
-            key_id: 300,
-            summary: '日付保持テスト（更新後）',
-            changes: [
-              { field: 'status', new_value: '処理中', old_value: '未対応', type: 'standard' },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 
@@ -236,43 +232,29 @@ describe('Backlog API', () => {
 
     it('更新イベントのchangesから日付を反映できる', async () => {
       // 作成: 日付なし
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: { id: 301, key_id: 301, summary: '日付追加テスト' },
-        }),
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 301, key_id: 301, summary: '日付追加テスト' },
       });
       const body1 = (await res1.json()) as any;
 
       // 更新イベント: changesでＩＴ予定日・本番リリース予定日を設定
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 301,
+          key_id: 301,
+          summary: '日付追加テスト',
+          changes: [
+            { field: 'ＩＴ予定日', new_value: '2026/07/22', old_value: '', type: 'custom' },
+            {
+              field: '本番リリース予定日',
+              new_value: '2026/07/30',
+              old_value: '',
+              type: 'custom',
+            },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 301,
-            key_id: 301,
-            summary: '日付追加テスト',
-            changes: [
-              { field: 'ＩＴ予定日', new_value: '2026/07/22', old_value: '', type: 'custom' },
-              {
-                field: '本番リリース予定日',
-                new_value: '2026/07/30',
-                old_value: '',
-                type: 'custom',
-              },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 
@@ -282,41 +264,27 @@ describe('Backlog API', () => {
     });
 
     it('更新イベントのchanges（customField_<ID>形式）でも日付を反映できる', async () => {
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
-        },
-        body: JSON.stringify({
-          project: { projectKey: 'BRGREG' },
-          content: { id: 302, key_id: 302, summary: 'ID形式テスト' },
-        }),
+      const res1 = await postWebhook({
+        project: { projectKey: 'BRGREG' },
+        content: { id: 302, key_id: 302, summary: 'ID形式テスト' },
       });
       const body1 = (await res1.json()) as any;
 
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'BRGREG' },
+        content: {
+          id: 302,
+          key_id: 302,
+          summary: 'ID形式テスト',
+          changes: [
+            {
+              field: 'customField_1073754985',
+              new_value: '2026/07/22',
+              old_value: '',
+              type: 'custom',
+            },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'BRGREG' },
-          content: {
-            id: 302,
-            key_id: 302,
-            summary: 'ID形式テスト',
-            changes: [
-              {
-                field: 'customField_1073754985',
-                new_value: '2026/07/22',
-                old_value: '',
-                type: 'custom',
-              },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 
@@ -327,41 +295,27 @@ describe('Backlog API', () => {
     });
 
     it('更新イベントで日付がクリアされたらnullにする', async () => {
-      const res1 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res1 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 303,
+          key_id: 303,
+          summary: '日付クリアテスト',
+          customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 303,
-            key_id: 303,
-            summary: '日付クリアテスト',
-            customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
-          },
-        }),
       });
       const body1 = (await res1.json()) as any;
 
-      const res2 = await app.request('/api/backlog/webhook', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Backlog-Webhook-Secret': TEST_ENV.BACKLOG_WEBHOOK_SECRET,
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 303,
+          key_id: 303,
+          summary: '日付クリアテスト',
+          changes: [
+            { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
+          ],
         },
-        body: JSON.stringify({
-          project: { projectKey: 'REG2017' },
-          content: {
-            id: 303,
-            key_id: 303,
-            summary: '日付クリアテスト',
-            changes: [
-              { field: 'ＩＴ予定日', new_value: '', old_value: '2026/07/15', type: 'custom' },
-            ],
-          },
-        }),
       });
       expect(res2.status).toBe(200);
 

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -91,7 +91,14 @@ app.post('/webhook', async (c) => {
   );
 
   // changes の field 表記が想定と違う場合の調査用ログ
-  if ((changes?.length ?? 0) > 0 && itUpDate === undefined && releaseDate === undefined) {
+  // （日付フィールド未設定のプロジェクトや日付以外の変更で埋もれないよう対象を限定）
+  const hasDateFieldConfig = Boolean(fieldConfig.itUpDate || fieldConfig.releaseDate);
+  if (
+    hasDateFieldConfig &&
+    (changes?.length ?? 0) > 0 &&
+    itUpDate === undefined &&
+    releaseDate === undefined
+  ) {
     console.info('[backlog/webhook] no date fields matched in changes', {
       issueKey,
       changeFields: changes?.map((ch) => ch.field),

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -9,8 +9,9 @@ import {
   extractProjectTypeFromIssueKey,
   generateBacklogUrl,
   getCustomFieldConfig,
-  getCustomFieldValue,
-  parseDateString,
+  resolveCustomDateField,
+  IT_UP_DATE_FIELD_NAMES,
+  RELEASE_DATE_FIELD_NAMES,
 } from '../lib/backlog';
 import type { BacklogWebhookPayload } from '../lib/backlog';
 import type { Env } from '../index';
@@ -42,13 +43,15 @@ app.post('/webhook', async (c) => {
   const body = (await c.req.json()) as BacklogWebhookPayload;
 
   // ペイロードから課題情報を抽出
-  const { issueKey, issueId, title, description, customFields } = extractIssueFromPayload(body);
+  const { issueKey, issueId, title, description, customFields, changes } =
+    extractIssueFromPayload(body);
   console.info('[backlog/webhook] parsed', {
     issueKey,
     issueId,
     hasTitle: Boolean(title),
     hasDescription: description !== undefined,
     customFieldsCount: customFields?.length ?? 0,
+    changesCount: changes?.length ?? 0,
   });
 
   if (!issueKey) {
@@ -71,16 +74,29 @@ app.post('/webhook', async (c) => {
   const url = generateBacklogUrl(issueKey);
   const finalIssueId = issueId || issueKey;
 
-  // カスタムフィールドから日付を抽出
+  // カスタムフィールド（追加イベント）または changes（更新イベント）から日付を解決
+  // undefined = ペイロードに情報なし（更新時は既存値を維持する）
   const fieldConfig = getCustomFieldConfig(projectType);
-  const itUpDateValue = fieldConfig.itUpDate
-    ? getCustomFieldValue(customFields, fieldConfig.itUpDate)
-    : null;
-  const releaseDateValue = fieldConfig.releaseDate
-    ? getCustomFieldValue(customFields, fieldConfig.releaseDate)
-    : null;
-  const itUpDate = parseDateString(itUpDateValue);
-  const releaseDate = parseDateString(releaseDateValue);
+  const itUpDate = resolveCustomDateField(
+    customFields,
+    changes,
+    fieldConfig.itUpDate,
+    IT_UP_DATE_FIELD_NAMES
+  );
+  const releaseDate = resolveCustomDateField(
+    customFields,
+    changes,
+    fieldConfig.releaseDate,
+    RELEASE_DATE_FIELD_NAMES
+  );
+
+  // changes の field 表記が想定と違う場合の調査用ログ
+  if ((changes?.length ?? 0) > 0 && itUpDate === undefined && releaseDate === undefined) {
+    console.info('[backlog/webhook] no date fields matched in changes', {
+      issueKey,
+      changeFields: changes?.map((ch) => ch.field),
+    });
+  }
 
   // タイトルに課題番号を接頭辞として追加
   const formattedTitle = `${issueKey} ${title}`;
@@ -101,8 +117,8 @@ app.post('/webhook', async (c) => {
         title: formattedTitle,
         ...(description !== undefined && { description }),
         projectType: projectType as (typeof tasks.projectType.enumValues)[number],
-        itUpDate,
-        releaseDate,
+        ...(itUpDate !== undefined && { itUpDate }),
+        ...(releaseDate !== undefined && { releaseDate }),
         updatedAt: now,
       })
       .where(eq(tasks.id, existingExternal.taskId));
@@ -143,8 +159,8 @@ app.post('/webhook', async (c) => {
     ...(description !== undefined && { description }),
     flowStatus: '未着手',
     assigneeIds: [],
-    itUpDate,
-    releaseDate,
+    itUpDate: itUpDate ?? null,
+    releaseDate: releaseDate ?? null,
     kubunLabelId: '',
     backlogUrl: url,
     order: Date.now(),

--- a/backend/src/routes/reports.test.ts
+++ b/backend/src/routes/reports.test.ts
@@ -56,6 +56,26 @@ async function seedReportData() {
     createdBy: 'test-user',
   });
 
+  // タスク: FAQ_IMP + 運用（レポート対象 faq_imp、normalからは除外される）
+  await db.insert(schema.tasks).values({
+    id: 'task-faq-unyo',
+    projectType: 'FAQ_IMP',
+    title: 'FAQ_IMP運用タスク',
+    kubunLabelId: 'kubun-unyo',
+    order: 1,
+    createdBy: 'test-user',
+  });
+
+  // タスク: FAQ_IMP + 開発（区分不問で faq_imp に含まれることの検証用）
+  await db.insert(schema.tasks).values({
+    id: 'task-faq-dev',
+    projectType: 'FAQ_IMP',
+    title: 'FAQ_IMP開発タスク',
+    kubunLabelId: 'kubun-kaihatsu',
+    order: 2,
+    createdBy: 'test-user',
+  });
+
   // タスク: MONO + 開発（レポート対象外）
   await db.insert(schema.tasks).values({
     id: 'task-mono-dev',
@@ -134,6 +154,28 @@ async function seedReportData() {
     durationSec: 14400,
   });
 
+  // セッション: task-faq-unyo に 30分（1800秒）
+  await db.insert(schema.taskSessions).values({
+    id: 'session-faq-1',
+    taskId: 'task-faq-unyo',
+    projectType: 'FAQ_IMP',
+    userId: 'test-user',
+    startedAt: new Date(baseDate.getTime()),
+    endedAt: new Date(baseDate.getTime() + 1800 * 1000),
+    durationSec: 1800,
+  });
+
+  // セッション: task-faq-dev に 15分（900秒、区分=開発でも faq_imp に含まれる）
+  await db.insert(schema.taskSessions).values({
+    id: 'session-faq-2',
+    taskId: 'task-faq-dev',
+    projectType: 'FAQ_IMP',
+    userId: 'test-user',
+    startedAt: new Date(baseDate.getTime()),
+    endedAt: new Date(baseDate.getTime() + 900 * 1000),
+    durationSec: 900,
+  });
+
   // セッション: 対象期間外（レポートに含まれない）
   await db.insert(schema.taskSessions).values({
     id: 'session-out-of-range',
@@ -194,6 +236,31 @@ describe('Reports API', () => {
       expect(body.items).toHaveLength(1);
       expect(body.totalDurationSec).toBe(7200);
       expect(body.items[0].taskId).toBe('task-brg-1');
+    });
+
+    it('faq_impタイプは区分不問でFAQ_IMPの全タスクを集計する', async () => {
+      await seedReportData();
+
+      const res = await app.request('/api/reports/time?from=2025-06-01&to=2025-06-30&type=faq_imp');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      // faq_imp = FAQ_IMP全タスク（区分不問）→ task-faq-unyo(1800) + task-faq-dev(900)
+      expect(body.items).toHaveLength(2);
+      expect(body.totalDurationSec).toBe(1800 + 900);
+
+      const taskIds = body.items.map((i: { taskId: string }) => i.taskId).sort();
+      expect(taskIds).toEqual(['task-faq-dev', 'task-faq-unyo']);
+    });
+
+    it('normalタイプはFAQ_IMP（運用区分）を含まない', async () => {
+      await seedReportData();
+
+      const res = await app.request('/api/reports/time?from=2025-06-01&to=2025-06-30&type=normal');
+      const body = (await res.json()) as any;
+
+      const faqTask = body.items.find((i: { taskId: string }) => i.taskId === 'task-faq-unyo');
+      expect(faqTask).toBeUndefined();
     });
 
     it('開発区分のタスクはレポートに含まれない', async () => {

--- a/backend/src/routes/reports.test.ts
+++ b/backend/src/routes/reports.test.ts
@@ -616,5 +616,105 @@ describe('Reports API', () => {
       const res = await app.request('/api/reports/time/partners?from=invalid&to=2025-06-30');
       expect(res.status).toBe(400);
     });
+
+    it('存在しない日付（2025-02-30 等）は400を返す', async () => {
+      const res = await app.request('/api/reports/time/partners?from=2025-02-30&to=2025-06-30');
+      expect(res.status).toBe(400);
+    });
+
+    it('from > to は400を返す', async () => {
+      const res = await app.request('/api/reports/time/partners?from=2025-06-30&to=2025-06-01');
+      expect(res.status).toBe(400);
+    });
+
+    it('月またぎセッションは期間内の重なり時間で按分される', async () => {
+      // セットアップ: partner + task
+      await db.insert(schema.users).values({
+        id: 'partner-cross',
+        email: 'partner-cross@example.com',
+        displayName: '月またぎパートナー',
+        role: 'partner',
+        isAllowed: true,
+      });
+      await db.insert(schema.labels).values({
+        id: 'kubun-cross',
+        name: 'cross-kubun',
+        color: '#888888',
+        projectId: null,
+        ownerId: 'partner-cross',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'cross-task',
+        projectType: 'MONO',
+        title: '月またぎタスク',
+        kubunLabelId: 'kubun-cross',
+        order: 1,
+        createdBy: 'partner-cross',
+      });
+      // 5/31 23:00 → 6/1 02:00（3時間 = 10800秒）
+      await db.insert(schema.taskSessions).values({
+        id: 'cross-session',
+        taskId: 'cross-task',
+        projectType: 'MONO',
+        userId: 'partner-cross',
+        startedAt: new Date('2025-05-31T23:00:00Z'),
+        endedAt: new Date('2025-06-01T02:00:00Z'),
+        durationSec: 10800,
+      });
+
+      // 6月レポートを取得（期間と重なるのは 6/1 00:00 ～ 6/1 02:00 = 7200秒）
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      const partner = body.partners.find((p: { userId: string }) => p.userId === 'partner-cross');
+      expect(partner).toBeDefined();
+      expect(partner.totalDurationSec).toBe(7200);
+      expect(partner.tasks[0].durationSec).toBe(7200);
+
+      // 5月レポートを取得（期間と重なるのは 5/31 23:00 ～ 5/31 24:00 = 3600秒）
+      const res5 = await app.request('/api/reports/time/partners?from=2025-05-01&to=2025-05-31');
+      const body5 = (await res5.json()) as any;
+      const partner5 = body5.partners.find((p: { userId: string }) => p.userId === 'partner-cross');
+      expect(partner5).toBeDefined();
+      expect(partner5.totalDurationSec).toBe(3600);
+    });
+  });
+
+  describe('GET /api/reports/time (月またぎ按分)', () => {
+    it('月またぎセッションは normal レポートでも期間内の重なり時間で按分される', async () => {
+      await db.insert(schema.labels).values({
+        id: 'kubun-unyo',
+        name: '運用',
+        color: '#00897B',
+        projectId: null,
+        ownerId: 'test-user',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'task-cross',
+        projectType: 'MONO',
+        title: 'normal月またぎタスク',
+        kubunLabelId: 'kubun-unyo',
+        order: 1,
+        createdBy: 'test-user',
+      });
+      // 5/31 22:00 → 6/1 02:00（4時間 = 14400秒）。6月の重なりは2時間 = 7200秒
+      await db.insert(schema.taskSessions).values({
+        id: 'cross-normal',
+        taskId: 'task-cross',
+        projectType: 'MONO',
+        userId: 'test-user',
+        startedAt: new Date('2025-05-31T22:00:00Z'),
+        endedAt: new Date('2025-06-01T02:00:00Z'),
+        durationSec: 14400,
+      });
+
+      const res = await app.request('/api/reports/time?from=2025-06-01&to=2025-06-30&type=normal');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      const task = body.items.find((i: { taskId: string }) => i.taskId === 'task-cross');
+      expect(task).toBeDefined();
+      expect(task.durationSec).toBe(7200);
+    });
   });
 });

--- a/backend/src/routes/reports.test.ts
+++ b/backend/src/routes/reports.test.ts
@@ -368,4 +368,253 @@ describe('Reports API', () => {
       expect(res.status).toBe(400);
     });
   });
+
+  describe('GET /api/reports/time/partners', () => {
+    /**
+     * パートナー稼働時間レポート用のシード
+     * - partner1: 2タスクで合計1時間30分
+     * - partner2: 1タスクで2時間
+     * - admin: セッションあるがレポート対象外
+     * - 無効化partner: セッションあるが is_allowed=false
+     */
+    async function seedPartnerReportData() {
+      await db.insert(schema.users).values([
+        {
+          id: 'admin-user',
+          email: 'admin@example.com',
+          displayName: 'Admin User',
+          role: 'admin',
+          isAllowed: true,
+        },
+        {
+          id: 'partner-1',
+          email: 'partner1@example.com',
+          displayName: 'パートナー1',
+          role: 'partner',
+          isAllowed: true,
+          avatarColor: 'teal',
+        },
+        {
+          id: 'partner-2',
+          email: 'partner2@example.com',
+          displayName: 'パートナー2',
+          role: 'partner',
+          isAllowed: true,
+        },
+        {
+          id: 'partner-disabled',
+          email: 'disabled@example.com',
+          displayName: '無効化パートナー',
+          role: 'partner',
+          isAllowed: false,
+        },
+      ]);
+
+      await db.insert(schema.labels).values({
+        id: 'p-kubun',
+        name: 'テスト区分',
+        color: '#888888',
+        projectId: null,
+        ownerId: 'admin-user',
+      });
+
+      await db.insert(schema.tasks).values({
+        id: 'p-task-1',
+        projectType: 'MONO',
+        title: 'パートナータスク1',
+        kubunLabelId: 'p-kubun',
+        order: 1,
+        createdBy: 'admin-user',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'p-task-2',
+        projectType: 'BRGREG',
+        title: 'パートナータスク2',
+        kubunLabelId: 'p-kubun',
+        order: 2,
+        createdBy: 'admin-user',
+      });
+      await db.insert(schema.tasks).values({
+        id: 'p-task-3',
+        projectType: 'MONO',
+        title: 'パートナータスク3',
+        kubunLabelId: 'p-kubun',
+        order: 3,
+        createdBy: 'admin-user',
+      });
+
+      const baseDate = new Date('2025-06-15T10:00:00Z');
+
+      await db.insert(schema.taskSessions).values([
+        // partner-1: p-task-1 で 1時間
+        {
+          id: 'ps-1',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-1',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 3600 * 1000),
+          durationSec: 3600,
+        },
+        // partner-1: p-task-2 で 30分
+        {
+          id: 'ps-2',
+          taskId: 'p-task-2',
+          projectType: 'BRGREG',
+          userId: 'partner-1',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 1800 * 1000),
+          durationSec: 1800,
+        },
+        // partner-2: p-task-3 で 2時間
+        {
+          id: 'ps-3',
+          taskId: 'p-task-3',
+          projectType: 'MONO',
+          userId: 'partner-2',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 7200 * 1000),
+          durationSec: 7200,
+        },
+        // admin: p-task-1 で 1時間（partnerじゃないので集計外）
+        {
+          id: 'ps-admin',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'admin-user',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 3600 * 1000),
+          durationSec: 3600,
+        },
+        // partner-disabled: p-task-1 で 1時間（is_allowed=false でも過去稼働は集計対象）
+        {
+          id: 'ps-disabled',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-disabled',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: new Date(baseDate.getTime() + 3600 * 1000),
+          durationSec: 3600,
+        },
+        // partner-1: 期間外（集計外）
+        {
+          id: 'ps-out',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-1',
+          startedAt: new Date('2025-01-01T10:00:00Z'),
+          endedAt: new Date('2025-01-01T11:00:00Z'),
+          durationSec: 3600,
+        },
+        // partner-1: 未完了セッション（集計外）
+        {
+          id: 'ps-active',
+          taskId: 'p-task-1',
+          projectType: 'MONO',
+          userId: 'partner-1',
+          startedAt: new Date(baseDate.getTime()),
+          endedAt: null,
+          durationSec: 0,
+        },
+      ]);
+    }
+
+    it('パートナーごとの稼働時間とタスク一覧を返す', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      // partner-1 + partner-2 + partner-disabled = 3人（adminは除外、無効化は含む）
+      expect(body.partners).toHaveLength(3);
+
+      // 合計時間の降順 → partner-2(7200) が先頭
+      expect(body.partners[0].userId).toBe('partner-2');
+      expect(body.partners[0].displayName).toBe('パートナー2');
+      expect(body.partners[0].totalDurationSec).toBe(7200);
+      expect(body.partners[0].tasks).toHaveLength(1);
+      expect(body.partners[0].tasks[0]).toMatchObject({
+        taskId: 'p-task-3',
+        title: 'パートナータスク3',
+        projectType: 'MONO',
+        durationSec: 7200,
+      });
+
+      // partner-1: 3600 + 1800 = 5400秒、2タスク
+      expect(body.partners[1].userId).toBe('partner-1');
+      expect(body.partners[1].totalDurationSec).toBe(5400);
+      expect(body.partners[1].tasks).toHaveLength(2);
+      // タスクは durationSec 降順
+      expect(body.partners[1].tasks[0].taskId).toBe('p-task-1');
+      expect(body.partners[1].tasks[0].durationSec).toBe(3600);
+      expect(body.partners[1].tasks[1].taskId).toBe('p-task-2');
+      expect(body.partners[1].tasks[1].durationSec).toBe(1800);
+
+      // partner-disabled: 3600秒（無効化されても過去稼働は集計）
+      expect(body.partners[2].userId).toBe('partner-disabled');
+      expect(body.partners[2].totalDurationSec).toBe(3600);
+
+      // 全体合計
+      expect(body.grandTotalDurationSec).toBe(7200 + 5400 + 3600);
+    });
+
+    it('isAllowed=false のパートナーも集計に含まれる（過去の稼働実績は精算対象）', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      const body = (await res.json()) as any;
+
+      const disabled = body.partners.find(
+        (p: { userId: string }) => p.userId === 'partner-disabled'
+      );
+      expect(disabled).toBeDefined();
+      expect(disabled.totalDurationSec).toBe(3600);
+    });
+
+    it('admin/memberロールのセッションは含まれない', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      const body = (await res.json()) as any;
+
+      // admin-user は出てこない
+      const admin = body.partners.find((p: { userId: string }) => p.userId === 'admin-user');
+      expect(admin).toBeUndefined();
+
+      // partner-1 の totalDurationSec には admin の 1時間が含まれていない
+      const p1 = body.partners.find((p: { userId: string }) => p.userId === 'partner-1');
+      expect(p1.totalDurationSec).toBe(5400);
+    });
+
+    it('avatar情報を返す', async () => {
+      await seedPartnerReportData();
+
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      const body = (await res.json()) as any;
+
+      const p1 = body.partners.find((p: { userId: string }) => p.userId === 'partner-1');
+      expect(p1.avatarColor).toBe('teal');
+      expect(p1.avatarUrl).toBeNull();
+    });
+
+    it('パートナーが居ない場合は空配列を返す', async () => {
+      const res = await app.request('/api/reports/time/partners?from=2025-06-01&to=2025-06-30');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      expect(body.partners).toEqual([]);
+      expect(body.grandTotalDurationSec).toBe(0);
+    });
+
+    it('from/toが未指定だと400', async () => {
+      const res = await app.request('/api/reports/time/partners');
+      expect(res.status).toBe(400);
+    });
+
+    it('不正な日付だと400', async () => {
+      const res = await app.request('/api/reports/time/partners?from=invalid&to=2025-06-30');
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod/v4';
 import { zValidator } from '@hono/zod-validator';
 import { eq, and, gte, lte, isNull, inArray } from 'drizzle-orm';
-import { tasks, taskSessions, labels, users } from '../db/schema';
+import { tasks, taskSessions, labels, users, projectTypeEnum } from '../db/schema';
 import {
   getAccessToken,
   driveSearchFiles,
@@ -22,20 +22,30 @@ const app = new Hono<ReportEnv>();
 /** レポート集計の種別 */
 type ReportFetchType = 'normal' | 'brg' | 'faq_imp';
 
+type ProjectTypeValue = (typeof projectTypeEnum.enumValues)[number];
+
 /** 独立してレポート集計するプロジェクトタイプ（集計種別 → projectType） */
-const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, string> = {
+const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, ProjectTypeValue> = {
   brg: 'BRGREG',
   faq_imp: 'FAQ_IMP',
 };
 
+const STANDALONE_PROJECT_TYPES = new Set<string>(Object.values(STANDALONE_REPORT_PROJECT));
+
 /** 独立集計タイプ（通常集計からは除外する） */
 function isStandaloneReportProject(projectType: string): boolean {
-  return Object.values(STANDALONE_REPORT_PROJECT).includes(projectType);
+  return STANDALONE_PROJECT_TYPES.has(projectType);
 }
 
 /** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
 function normalizeReportType(value: string | undefined): ReportFetchType {
-  return value === 'brg' || value === 'faq_imp' ? value : 'normal';
+  return value && value in STANDALONE_REPORT_PROJECT ? (value as ReportFetchType) : 'normal';
+}
+
+/** 「運用」区分ラベルのIDを取得（無ければ null） */
+async function getUnyoLabelId(db: Database): Promise<string | null> {
+  const allLabels = await db.select().from(labels).where(isNull(labels.projectId));
+  return allLabels.find((l) => l.name === '運用')?.id ?? null;
 }
 
 /** CSVインジェクション防止: 先頭が数式トリガー文字の場合にシングルクォートをプレフィクス */
@@ -70,17 +80,15 @@ async function fetchReportData(
   fromDate: Date,
   toDate: Date,
   type: ReportFetchType,
+  unyoLabelId: string | null,
   userId?: string
 ): Promise<{ items: ReportItem[]; totalDurationSec: number }> {
-  // 1. 「運用」区分ラベルのIDを取得
-  const allLabels = await db.select().from(labels).where(isNull(labels.projectId));
-
-  const unyoLabel = allLabels.find((l) => l.name === '運用');
-  if (!unyoLabel) {
+  // 「運用」区分ラベルが無ければ集計対象なし
+  if (!unyoLabelId) {
     return { items: [], totalDurationSec: 0 };
   }
 
-  // 2. 対象タスクを取得
+  // 対象タスクを取得
   // 独立集計タイプ(BRG/FAQ_IMP): projectType一致の全タスク（kubunLabelId不問）
   // 通常タイプ: kubunLabelId=運用 のタスクのうち、独立集計タイプを除外
   const taskSelect = {
@@ -93,18 +101,15 @@ async function fetchReportData(
 
   let targetTasks: TaskRow[];
   if (type !== 'normal') {
-    const targetProjectType = STANDALONE_REPORT_PROJECT[type];
     targetTasks = await db
       .select(taskSelect)
       .from(tasks)
-      .where(
-        eq(tasks.projectType, targetProjectType as (typeof tasks.projectType.enumValues)[number])
-      );
+      .where(eq(tasks.projectType, STANDALONE_REPORT_PROJECT[type]));
   } else {
     const allTasks = await db
       .select(taskSelect)
       .from(tasks)
-      .where(eq(tasks.kubunLabelId, unyoLabel.id));
+      .where(eq(tasks.kubunLabelId, unyoLabelId));
     targetTasks = allTasks.filter((t) => !isStandaloneReportProject(t.projectType));
   }
 
@@ -198,7 +203,15 @@ app.get('/time', async (c) => {
   toDate.setHours(23, 59, 59, 999);
 
   const userId = c.get('userId');
-  const { items, totalDurationSec } = await fetchReportData(db, fromDate, toDate, type, userId);
+  const unyoLabelId = await getUnyoLabelId(db);
+  const { items, totalDurationSec } = await fetchReportData(
+    db,
+    fromDate,
+    toDate,
+    type,
+    unyoLabelId,
+    userId
+  );
 
   return c.json({ items, totalDurationSec });
 });
@@ -226,7 +239,8 @@ app.get('/time/csv', async (c) => {
 
   toDate.setHours(23, 59, 59, 999);
 
-  const { items } = await fetchReportData(db, fromDate, toDate, type);
+  const unyoLabelId = await getUnyoLabelId(db);
+  const { items } = await fetchReportData(db, fromDate, toDate, type, unyoLabelId);
 
   // CSV生成（UTF-8+BOM/CRLF）
   const BOM = '\uFEFF';
@@ -457,10 +471,11 @@ app.post('/time/export', zValidator('json', exportSchema), async (c) => {
   );
   toDate.setHours(23, 59, 59, 999);
 
+  const unyoLabelId = await getUnyoLabelId(db);
   const [normalData, brgData, faqImpData] = await Promise.all([
-    fetchReportData(db, fromDate, toDate, 'normal'),
-    fetchReportData(db, fromDate, toDate, 'brg'),
-    fetchReportData(db, fromDate, toDate, 'faq_imp'),
+    fetchReportData(db, fromDate, toDate, 'normal', unyoLabelId),
+    fetchReportData(db, fromDate, toDate, 'brg', unyoLabelId),
+    fetchReportData(db, fromDate, toDate, 'faq_imp', unyoLabelId),
   ]);
 
   // 「データ」シートにデータ書き込み

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -29,6 +29,7 @@ const PROJECT_TYPES = [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ] as const;
 
 function isBRGREGProject(projectType: string): boolean {

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -35,12 +35,35 @@ const STANDALONE_PROJECT_TYPES_ARRAY = Object.values(STANDALONE_REPORT_PROJECT);
 
 /** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
 function normalizeReportType(value: string | undefined): ReportFetchType {
-  return value && value in STANDALONE_REPORT_PROJECT ? (value as ReportFetchType) : 'normal';
+  if (!value) return 'normal';
+  // `in` だと toString / constructor 等プロトタイプ上のキーも true になるため、自身プロパティだけ判定
+  return Object.prototype.hasOwnProperty.call(STANDALONE_REPORT_PROJECT, value)
+    ? (value as Exclude<ReportFetchType, 'normal'>)
+    : 'normal';
+}
+
+/**
+ * YYYY-MM-DD 形式の日付文字列を厳格にパース
+ * - new Date() の寛容仕様（'2025-02-30' → '2025-03-02' に自動補正）を防ぐため、
+ *   regex で形式を縛った上で「パース結果が元の数値と一致するか」も検証する
+ */
+function parseStrictYmd(value: string): Date | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return null;
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== mo - 1 || dt.getUTCDate() !== d) {
+    return null;
+  }
+  return dt;
 }
 
 /**
  * レポート系API共通: from/to クエリのパース・検証
- * - 必須チェック、ISO日付検証、toDate を 23:59:59.999 まで含むよう調整
+ * - 必須チェック、YYYY-MM-DD 厳格検証、from <= to の順序検証、
+ *   toDate を 23:59:59.999 まで含むよう調整
  */
 function parseReportDateRange(
   from: string | undefined,
@@ -49,12 +72,16 @@ function parseReportDateRange(
   if (!from || !to) {
     return { error: 'Missing required parameters: from, to', status: 400 };
   }
-  const fromDate = new Date(from);
-  const toDate = new Date(to);
-  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+  const fromDate = parseStrictYmd(from);
+  const toDate = parseStrictYmd(to);
+  if (!fromDate || !toDate) {
     return { error: 'Invalid date format', status: 400 };
   }
-  toDate.setHours(23, 59, 59, 999);
+  if (fromDate > toDate) {
+    return { error: '`from` must be earlier than or equal to `to`', status: 400 };
+  }
+  // 実行環境のタイムゾーン依存を避けるため UTC で末尾時刻を設定
+  toDate.setUTCHours(23, 59, 59, 999);
   return { fromDate, toDate };
 }
 
@@ -97,11 +124,12 @@ function computeSessionDurationInRangeSec(
   if (session.startedAt >= fromDate && session.endedAt <= toDate) return total;
 
   // 期間と重なる秒数 / セッション全体の秒数 で按分
+  // toDate は 23:59:59.999 まで含むため round で 1ms 誤差を吸収
   const overlapStart = session.startedAt > fromDate ? session.startedAt : fromDate;
   const overlapEnd = session.endedAt < toDate ? session.endedAt : toDate;
   const overlapSec = Math.max(
     0,
-    Math.floor((overlapEnd.getTime() - overlapStart.getTime()) / 1000)
+    Math.round((overlapEnd.getTime() - overlapStart.getTime()) / 1000)
   );
   const sessionRealSec = Math.max(
     1,

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod/v4';
 import { zValidator } from '@hono/zod-validator';
-import { eq, and, gte, lte, isNull, inArray } from 'drizzle-orm';
+import { eq, and, gte, lte, isNull, inArray, notInArray } from 'drizzle-orm';
 import { tasks, taskSessions, labels, users, projectTypeEnum } from '../db/schema';
 import {
   getAccessToken,
@@ -12,6 +12,7 @@ import {
   sheetsUpdateValues,
   sheetsClearValues,
 } from '../lib/google-api';
+import { resolveAvatarUrl, type SignEnv } from './users';
 import type { Env } from '../index';
 import type { Database } from '../db';
 
@@ -30,16 +31,84 @@ const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, Proj
   faq_imp: 'FAQ_IMP',
 };
 
-const STANDALONE_PROJECT_TYPES = new Set<string>(Object.values(STANDALONE_REPORT_PROJECT));
-
-/** 独立集計タイプ（通常集計からは除外する） */
-function isStandaloneReportProject(projectType: string): boolean {
-  return STANDALONE_PROJECT_TYPES.has(projectType);
-}
+const STANDALONE_PROJECT_TYPES_ARRAY = Object.values(STANDALONE_REPORT_PROJECT);
 
 /** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
 function normalizeReportType(value: string | undefined): ReportFetchType {
   return value && value in STANDALONE_REPORT_PROJECT ? (value as ReportFetchType) : 'normal';
+}
+
+/**
+ * レポート系API共通: from/to クエリのパース・検証
+ * - 必須チェック、ISO日付検証、toDate を 23:59:59.999 まで含むよう調整
+ */
+function parseReportDateRange(
+  from: string | undefined,
+  to: string | undefined
+): { fromDate: Date; toDate: Date } | { error: string; status: 400 } {
+  if (!from || !to) {
+    return { error: 'Missing required parameters: from, to', status: 400 };
+  }
+  const fromDate = new Date(from);
+  const toDate = new Date(to);
+  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+    return { error: 'Invalid date format', status: 400 };
+  }
+  toDate.setHours(23, 59, 59, 999);
+  return { fromDate, toDate };
+}
+
+/**
+ * セッションの実稼働秒数を返す（未完了は null）
+ * - durationSec > 0 ならそれを採用
+ * - 0 以下なら endedAt - startedAt で再計算（過去データの互換）
+ */
+function computeSessionDurationSec(session: {
+  startedAt: Date;
+  endedAt: Date | null;
+  durationSec: number;
+}): number | null {
+  if (!session.endedAt) return null;
+  const duration =
+    session.durationSec > 0
+      ? session.durationSec
+      : Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000);
+  return duration > 0 ? duration : null;
+}
+
+/**
+ * セッションの実稼働秒数のうち、指定期間と重なる分だけを返す
+ * - 期間と完全に重ならない: 0
+ * - 期間内に完全に収まる: 全durationSec
+ * - 部分的に重なる: overlap時間 / セッション全体時間 で按分
+ */
+function computeSessionDurationInRangeSec(
+  session: { startedAt: Date; endedAt: Date | null; durationSec: number },
+  fromDate: Date,
+  toDate: Date
+): number {
+  if (!session.endedAt) return 0;
+  if (session.endedAt < fromDate || session.startedAt > toDate) return 0;
+
+  const total = computeSessionDurationSec(session);
+  if (total === null) return 0;
+
+  // 完全に範囲内ならそのまま
+  if (session.startedAt >= fromDate && session.endedAt <= toDate) return total;
+
+  // 期間と重なる秒数 / セッション全体の秒数 で按分
+  const overlapStart = session.startedAt > fromDate ? session.startedAt : fromDate;
+  const overlapEnd = session.endedAt < toDate ? session.endedAt : toDate;
+  const overlapSec = Math.max(
+    0,
+    Math.floor((overlapEnd.getTime() - overlapStart.getTime()) / 1000)
+  );
+  const sessionRealSec = Math.max(
+    1,
+    Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000)
+  );
+
+  return Math.floor(total * (overlapSec / sessionRealSec));
 }
 
 /** 「運用」区分ラベルのIDを取得（無ければ null） */
@@ -106,11 +175,16 @@ async function fetchReportData(
       .from(tasks)
       .where(eq(tasks.projectType, STANDALONE_REPORT_PROJECT[type]));
   } else {
-    const allTasks = await db
+    // 運用区分 かつ 独立集計タイプ(BRGREG/FAQ_IMP)以外 を SQL レベルで絞る
+    targetTasks = await db
       .select(taskSelect)
       .from(tasks)
-      .where(eq(tasks.kubunLabelId, unyoLabelId));
-    targetTasks = allTasks.filter((t) => !isStandaloneReportProject(t.projectType));
+      .where(
+        and(
+          eq(tasks.kubunLabelId, unyoLabelId),
+          notInArray(tasks.projectType, STANDALONE_PROJECT_TYPES_ARRAY)
+        )
+      );
   }
 
   if (targetTasks.length === 0) {
@@ -120,15 +194,15 @@ async function fetchReportData(
   const taskMap = new Map(targetTasks.map((t) => [t.id, t]));
   const taskIds = targetTasks.map((t) => t.id);
 
-  // 4. 対象タスクの日付範囲内セッションを取得
+  // 4. 対象タスクの「期間と重なる」セッションを取得（月またぎは按分処理）
   const sessions = await db
     .select()
     .from(taskSessions)
     .where(
       and(
         inArray(taskSessions.taskId, taskIds),
-        gte(taskSessions.startedAt, fromDate),
-        lte(taskSessions.startedAt, toDate)
+        lte(taskSessions.startedAt, toDate),
+        gte(taskSessions.endedAt, fromDate)
       )
     );
 
@@ -136,22 +210,16 @@ async function fetchReportData(
   const durationByTaskId = new Map<string, number>();
   const recordedUsersByTaskId = new Map<string, Set<string>>();
   for (const session of sessions) {
-    if (!session.endedAt) continue;
+    const duration = computeSessionDurationInRangeSec(session, fromDate, toDate);
+    if (duration <= 0) continue;
 
-    const duration =
-      session.durationSec > 0
-        ? session.durationSec
-        : Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000);
-
-    if (duration > 0) {
-      durationByTaskId.set(session.taskId, (durationByTaskId.get(session.taskId) ?? 0) + duration);
-      let userSet = recordedUsersByTaskId.get(session.taskId);
-      if (!userSet) {
-        userSet = new Set();
-        recordedUsersByTaskId.set(session.taskId, userSet);
-      }
-      userSet.add(session.userId);
+    durationByTaskId.set(session.taskId, (durationByTaskId.get(session.taskId) ?? 0) + duration);
+    let userSet = recordedUsersByTaskId.get(session.taskId);
+    if (!userSet) {
+      userSet = new Set();
+      recordedUsersByTaskId.set(session.taskId, userSet);
     }
+    userSet.add(session.userId);
   }
 
   // 6. 結果を構築
@@ -178,36 +246,188 @@ async function fetchReportData(
   return { items, totalDurationSec };
 }
 
+interface PartnerTaskItem {
+  taskId: string;
+  title: string;
+  projectType: string;
+  durationSec: number;
+}
+
+interface PartnerReportItem {
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  avatarColor: string | null;
+  totalDurationSec: number;
+  tasks: PartnerTaskItem[];
+}
+
+/** 削除済みタスクのタイトル */
+const DELETED_TASK_TITLE = '[削除済みタスク]';
+
+/**
+ * パートナー稼働時間レポートを集計
+ * - users.role = 'partner' のユーザーごと（isAllowed問わず：過去の稼働実績も精算対象）
+ *   に期間内（または重なる）の task_sessions を集計
+ * - 月またぎセッションは期間内の重なり比率で按分
+ * - 「運用」ラベル等の条件は付けない（全タスクが対象）
+ * - 稼働ゼロのpartnerはレスポンスから除外
+ * - avatarUrl は R2 署名付きURLに解決して返す
+ */
+async function fetchPartnerReportData(
+  db: Database,
+  fromDate: Date,
+  toDate: Date,
+  signEnv: SignEnv
+): Promise<{ partners: PartnerReportItem[]; grandTotalDurationSec: number }> {
+  const partnerUsers = await db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      avatarColor: users.avatarColor,
+    })
+    .from(users)
+    .where(eq(users.role, 'partner'));
+
+  if (partnerUsers.length === 0) {
+    return { partners: [], grandTotalDurationSec: 0 };
+  }
+
+  const partnerIds = partnerUsers.map((u) => u.id);
+
+  // 期間と重なるセッションを取得（endedAt is null = 未完了は SQL レベルで除外）
+  const sessions = await db
+    .select({
+      userId: taskSessions.userId,
+      taskId: taskSessions.taskId,
+      startedAt: taskSessions.startedAt,
+      endedAt: taskSessions.endedAt,
+      durationSec: taskSessions.durationSec,
+    })
+    .from(taskSessions)
+    .where(
+      and(
+        inArray(taskSessions.userId, partnerIds),
+        lte(taskSessions.startedAt, toDate),
+        gte(taskSessions.endedAt, fromDate)
+      )
+    );
+
+  // userId → taskId → durationSec の二重マップで集計（月またぎは按分）
+  const durationByUserTask = new Map<string, Map<string, number>>();
+  for (const session of sessions) {
+    const duration = computeSessionDurationInRangeSec(session, fromDate, toDate);
+    if (duration <= 0) continue;
+
+    let taskMap = durationByUserTask.get(session.userId);
+    if (!taskMap) {
+      taskMap = new Map();
+      durationByUserTask.set(session.userId, taskMap);
+    }
+    taskMap.set(session.taskId, (taskMap.get(session.taskId) ?? 0) + duration);
+  }
+
+  // 集計対象タスクの情報を一括取得
+  const allTaskIds = new Set<string>();
+  for (const taskMap of durationByUserTask.values()) {
+    for (const taskId of taskMap.keys()) allTaskIds.add(taskId);
+  }
+
+  const taskInfoMap = new Map<string, { title: string; projectType: string }>();
+  if (allTaskIds.size > 0) {
+    const taskRows = await db
+      .select({
+        id: tasks.id,
+        title: tasks.title,
+        projectType: tasks.projectType,
+      })
+      .from(tasks)
+      .where(inArray(tasks.id, Array.from(allTaskIds)));
+    for (const t of taskRows) {
+      taskInfoMap.set(t.id, { title: t.title, projectType: t.projectType });
+    }
+  }
+
+  // 稼働ありの partner だけ抽出（ゼロ時間はノイズなので除外）
+  const partnersRaw = partnerUsers.flatMap((user) => {
+    const taskMap = durationByUserTask.get(user.id);
+    if (!taskMap || taskMap.size === 0) return [];
+
+    const taskItems: PartnerTaskItem[] = [];
+    let totalDurationSec = 0;
+
+    for (const [taskId, durationSec] of taskMap) {
+      // 削除済みタスクは「[削除済みタスク]」として保持（無音で落とすと精算とズレる）
+      const info = taskInfoMap.get(taskId) ?? { title: DELETED_TASK_TITLE, projectType: '' };
+      taskItems.push({
+        taskId,
+        title: info.title,
+        projectType: info.projectType,
+        durationSec,
+      });
+      totalDurationSec += durationSec;
+    }
+
+    if (totalDurationSec === 0) return [];
+
+    taskItems.sort((a, b) => b.durationSec - a.durationSec);
+
+    return [
+      {
+        userId: user.id,
+        displayName: user.displayName,
+        avatarUrl: user.avatarUrl,
+        avatarColor: user.avatarColor,
+        totalDurationSec,
+        tasks: taskItems,
+      },
+    ];
+  });
+
+  // avatarUrl を R2 署名付きURLに変換
+  const partners: PartnerReportItem[] = await Promise.all(
+    partnersRaw.map((p) => resolveAvatarUrl(p, signEnv))
+  );
+
+  // 合計時間の降順
+  partners.sort((a, b) => b.totalDurationSec - a.totalDurationSec);
+
+  const grandTotalDurationSec = partners.reduce((sum, p) => sum + p.totalDurationSec, 0);
+
+  return { partners, grandTotalDurationSec };
+}
+
+/**
+ * GET /time/partners
+ * パートナー稼働時間レポート取得
+ */
+app.get('/time/partners', async (c) => {
+  const db = c.get('db');
+  const range = parseReportDateRange(c.req.query('from'), c.req.query('to'));
+  if ('error' in range) return c.json({ error: range.error }, range.status);
+
+  const env = c.env as ReportEnv['Bindings'];
+  const result = await fetchPartnerReportData(db, range.fromDate, range.toDate, env);
+  return c.json(result);
+});
+
 /**
  * GET /time
  * 時間レポート取得
  */
 app.get('/time', async (c) => {
   const db = c.get('db');
-  const from = c.req.query('from');
-  const to = c.req.query('to');
   const type = normalizeReportType(c.req.query('type'));
-
-  if (!from || !to) {
-    return c.json({ error: 'Missing required parameters: from, to' }, 400);
-  }
-
-  const fromDate = new Date(from);
-  const toDate = new Date(to);
-
-  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
-    return c.json({ error: 'Invalid date format' }, 400);
-  }
-
-  // toDateをその日の終了時刻まで含める
-  toDate.setHours(23, 59, 59, 999);
+  const range = parseReportDateRange(c.req.query('from'), c.req.query('to'));
+  if ('error' in range) return c.json({ error: range.error }, range.status);
 
   const userId = c.get('userId');
   const unyoLabelId = await getUnyoLabelId(db);
   const { items, totalDurationSec } = await fetchReportData(
     db,
-    fromDate,
-    toDate,
+    range.fromDate,
+    range.toDate,
     type,
     unyoLabelId,
     userId
@@ -225,22 +445,11 @@ app.get('/time/csv', async (c) => {
   const from = c.req.query('from');
   const to = c.req.query('to');
   const type = normalizeReportType(c.req.query('type'));
-
-  if (!from || !to) {
-    return c.json({ error: 'Missing required parameters: from, to' }, 400);
-  }
-
-  const fromDate = new Date(from);
-  const toDate = new Date(to);
-
-  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
-    return c.json({ error: 'Invalid date format' }, 400);
-  }
-
-  toDate.setHours(23, 59, 59, 999);
+  const range = parseReportDateRange(from, to);
+  if ('error' in range) return c.json({ error: range.error }, range.status);
 
   const unyoLabelId = await getUnyoLabelId(db);
-  const { items } = await fetchReportData(db, fromDate, toDate, type, unyoLabelId);
+  const { items } = await fetchReportData(db, range.fromDate, range.toDate, type, unyoLabelId);
 
   // CSV生成（UTF-8+BOM/CRLF）
   const BOM = '\uFEFF';

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -19,21 +19,23 @@ type ReportEnv = Env & { Variables: { db: Database; userId: string } };
 
 const app = new Hono<ReportEnv>();
 
-const PROJECT_TYPES = [
-  'REG2017',
-  'BRGREG',
-  'MONO',
-  'MONO_ADMIN',
-  'DES_FIRE',
-  'DesignSystem',
-  'DMREG2',
-  'monosus',
-  'PRREG',
-  'FAQ_IMP',
-] as const;
+/** レポート集計の種別 */
+type ReportFetchType = 'normal' | 'brg' | 'faq_imp';
 
-function isBRGREGProject(projectType: string): boolean {
-  return projectType === 'BRGREG';
+/** 独立してレポート集計するプロジェクトタイプ（集計種別 → projectType） */
+const STANDALONE_REPORT_PROJECT: Record<Exclude<ReportFetchType, 'normal'>, string> = {
+  brg: 'BRGREG',
+  faq_imp: 'FAQ_IMP',
+};
+
+/** 独立集計タイプ（通常集計からは除外する） */
+function isStandaloneReportProject(projectType: string): boolean {
+  return Object.values(STANDALONE_REPORT_PROJECT).includes(projectType);
+}
+
+/** クエリの type パラメータを正規化（不正値は normal にフォールバック） */
+function normalizeReportType(value: string | undefined): ReportFetchType {
+  return value === 'brg' || value === 'faq_imp' ? value : 'normal';
 }
 
 /** CSVインジェクション防止: 先頭が数式トリガー文字の場合にシングルクォートをプレフィクス */
@@ -67,7 +69,7 @@ async function fetchReportData(
   db: Database,
   fromDate: Date,
   toDate: Date,
-  type: 'normal' | 'brg',
+  type: ReportFetchType,
   userId?: string
 ): Promise<{ items: ReportItem[]; totalDurationSec: number }> {
   // 1. 「運用」区分ラベルのIDを取得
@@ -78,14 +80,9 @@ async function fetchReportData(
     return { items: [], totalDurationSec: 0 };
   }
 
-  // 2. 対象プロジェクトタイプをフィルタ
-  const targetTypes = PROJECT_TYPES.filter((pt) =>
-    type === 'brg' ? isBRGREGProject(pt) : !isBRGREGProject(pt)
-  );
-
-  // 3. 対象タスクを取得
-  // BRGタイプ: projectType=BRGREG の全タスク（kubunLabelId不問）
-  // 通常タイプ: kubunLabelId=運用 のタスクのみ
+  // 2. 対象タスクを取得
+  // 独立集計タイプ(BRG/FAQ_IMP): projectType一致の全タスク（kubunLabelId不問）
+  // 通常タイプ: kubunLabelId=運用 のタスクのうち、独立集計タイプを除外
   const taskSelect = {
     id: tasks.id,
     title: tasks.title,
@@ -95,16 +92,20 @@ async function fetchReportData(
   };
 
   let targetTasks: TaskRow[];
-  if (type === 'brg') {
-    targetTasks = await db.select(taskSelect).from(tasks).where(eq(tasks.projectType, 'BRGREG'));
+  if (type !== 'normal') {
+    const targetProjectType = STANDALONE_REPORT_PROJECT[type];
+    targetTasks = await db
+      .select(taskSelect)
+      .from(tasks)
+      .where(
+        eq(tasks.projectType, targetProjectType as (typeof tasks.projectType.enumValues)[number])
+      );
   } else {
     const allTasks = await db
       .select(taskSelect)
       .from(tasks)
       .where(eq(tasks.kubunLabelId, unyoLabel.id));
-    targetTasks = allTasks.filter((t) =>
-      targetTypes.includes(t.projectType as (typeof PROJECT_TYPES)[number])
-    );
+    targetTasks = allTasks.filter((t) => !isStandaloneReportProject(t.projectType));
   }
 
   if (targetTasks.length === 0) {
@@ -180,7 +181,7 @@ app.get('/time', async (c) => {
   const db = c.get('db');
   const from = c.req.query('from');
   const to = c.req.query('to');
-  const type = (c.req.query('type') ?? 'normal') as 'normal' | 'brg';
+  const type = normalizeReportType(c.req.query('type'));
 
   if (!from || !to) {
     return c.json({ error: 'Missing required parameters: from, to' }, 400);
@@ -210,7 +211,7 @@ app.get('/time/csv', async (c) => {
   const db = c.get('db');
   const from = c.req.query('from');
   const to = c.req.query('to');
-  const type = (c.req.query('type') ?? 'normal') as 'normal' | 'brg';
+  const type = normalizeReportType(c.req.query('type'));
 
   if (!from || !to) {
     return c.json({ error: 'Missing required parameters: from, to' }, 400);
@@ -264,25 +265,31 @@ function formatDuration(sec: number): string {
  */
 function buildDataSheetRows(
   normalItems: ReportItem[],
-  brgItems: ReportItem[]
+  brgItems: ReportItem[],
+  faqImpItems: ReportItem[]
 ): (string | number)[][] {
   const rows: (string | number)[][] = [];
 
+  const pushSection = (heading: string, items: ReportItem[]) => {
+    rows.push([heading, '', '']);
+    rows.push(['案件名', '実績時間', '3時間超内容']);
+    for (const item of items) {
+      rows.push([item.title, formatDuration(item.durationSec), item.over3hours || '']);
+    }
+  };
+
   // 通常セクション
-  rows.push(['■通常■', '', '']);
-  rows.push(['案件名', '実績時間', '3時間超内容']);
-  for (const item of normalItems) {
-    rows.push([item.title, formatDuration(item.durationSec), item.over3hours || '']);
-  }
+  pushSection('■通常■', normalItems);
 
   rows.push(['', '', '']); // 空行
 
   // BRGセクション
-  rows.push(['■BRG■', '', '']);
-  rows.push(['案件名', '実績時間', '3時間超内容']);
-  for (const item of brgItems) {
-    rows.push([item.title, formatDuration(item.durationSec), item.over3hours || '']);
-  }
+  pushSection('■BRG■', brgItems);
+
+  rows.push(['', '', '']); // 空行
+
+  // FAQ_IMPセクション
+  pushSection('■FAQ_IMP■', faqImpItems);
 
   return rows;
 }
@@ -450,13 +457,14 @@ app.post('/time/export', zValidator('json', exportSchema), async (c) => {
   );
   toDate.setHours(23, 59, 59, 999);
 
-  const [normalData, brgData] = await Promise.all([
+  const [normalData, brgData, faqImpData] = await Promise.all([
     fetchReportData(db, fromDate, toDate, 'normal'),
     fetchReportData(db, fromDate, toDate, 'brg'),
+    fetchReportData(db, fromDate, toDate, 'faq_imp'),
   ]);
 
   // 「データ」シートにデータ書き込み
-  const rows = buildDataSheetRows(normalData.items, brgData.items);
+  const rows = buildDataSheetRows(normalData.items, brgData.items, faqImpData.items);
   const range = `データ!A1:C${rows.length}`;
   const written = await sheetsUpdateValues(accessToken, spreadsheetId, range, rows);
   if (!written) {

--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -1,12 +1,39 @@
-import { describe, it, expect, afterAll, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, afterEach, beforeEach, vi } from 'vitest';
+import { createClerkClient } from '@clerk/backend';
 import { createTestApp, db, client } from './test-app';
 import { cleanDatabase } from '../db/test-helpers';
 import * as schema from '../db/schema';
 import { eq } from 'drizzle-orm';
 
+// Clerk SDK 全体をモック化。
+// /me の Clerk fallback は getUser が reject されれば 404 に落ちるだけなので既存テストに無害。
+// /invite 系は各テスト内で createInvitation の挙動を上書きする。
+vi.mock('@clerk/backend', () => ({
+  createClerkClient: vi.fn(),
+}));
+
+const mockedCreateClerkClient = vi.mocked(createClerkClient);
+
+function setClerkMock(overrides: {
+  createInvitation?: ReturnType<typeof vi.fn>;
+  getUser?: ReturnType<typeof vi.fn>;
+}) {
+  mockedCreateClerkClient.mockReturnValue({
+    invitations: {
+      createInvitation: overrides.createInvitation ?? vi.fn().mockResolvedValue({ id: 'inv_mock' }),
+    },
+    users: {
+      getUser: overrides.getUser ?? vi.fn().mockRejectedValue(new Error('clerk mock not set')),
+    },
+  } as unknown as ReturnType<typeof createClerkClient>);
+}
+
 const app = createTestApp();
 
 beforeEach(async () => {
+  // 各テストの先頭で Clerk モックをデフォルト状態にリセット
+  setClerkMock({});
+
   await db.insert(schema.users).values({
     id: 'test-user',
     email: 'test@example.com',
@@ -243,6 +270,117 @@ describe('Users API', () => {
       expect(String(body.error)).toContain('APP_ORIGIN');
 
       // 早期 return なので DB にプレースホルダーは作られない
+      const [shouldNotExist] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, 'new@example.com'));
+      expect(shouldNotExist).toBeUndefined();
+    });
+
+    it('APP_ORIGIN が URL 形式不正なら 500 を返す', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const res = await adminApp.request(
+        '/api/users/invite',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+        },
+        { APP_ORIGIN: 'localhost:3000' }
+      );
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as any;
+      expect(String(body.error)).toContain('APP_ORIGIN');
+    });
+
+    it('Clerk が 4xx を返したら 400 で詳細メッセージを返す', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const clerkErr = {
+        status: 422,
+        errors: [
+          {
+            long_message: 'redirect_url is not allowed for this instance',
+            code: 'redirect_url_not_allowed',
+          },
+        ],
+      };
+      setClerkMock({
+        createInvitation: vi.fn().mockRejectedValue(clerkErr),
+      });
+
+      const res = await adminApp.request(
+        '/api/users/invite',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+        },
+        { APP_ORIGIN: 'https://example.com' }
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as any;
+      expect(body.error).toContain('redirect_url is not allowed');
+
+      // DB プレースホルダーは補償削除されている
+      const [shouldNotExist] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, 'new@example.com'));
+      expect(shouldNotExist).toBeUndefined();
+    });
+
+    it('Clerk が 5xx / 例外なら 500 で汎用メッセージを返し内部エラーを露出しない', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      setClerkMock({
+        createInvitation: vi
+          .fn()
+          .mockRejectedValue(new Error('Internal Clerk error: secret_leak_xyz')),
+      });
+
+      const res = await adminApp.request(
+        '/api/users/invite',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+        },
+        { APP_ORIGIN: 'https://example.com' }
+      );
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as any;
+      // 内部メッセージは漏らさない
+      expect(body.error).not.toContain('secret_leak_xyz');
+      // 汎用メッセージは返す
+      expect(body.error).toContain('招待の送信に失敗');
+
+      // 補償削除されている
       const [shouldNotExist] = await db
         .select()
         .from(schema.users)

--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -156,6 +156,101 @@ describe('Users API', () => {
     });
   });
 
+  describe('POST /api/users/invite', () => {
+    it('管理者以外は403', async () => {
+      const res = await app.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('既存の有効なメールは409', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const res = await adminApp.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'test@example.com', role: 'member' }),
+      });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('無効化されたユーザーは再有効化される', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      await db.insert(schema.users).values({
+        id: 'disabled-user',
+        email: 'disabled@example.com',
+        displayName: 'Disabled',
+        role: 'member',
+        isAllowed: false,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      const res = await adminApp.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'disabled@example.com', role: 'admin' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.restored).toBe(true);
+
+      const [restored] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, 'disabled-user'));
+      expect(restored.isAllowed).toBe(true);
+      expect(restored.role).toBe('admin');
+    });
+
+    it('APP_ORIGIN 未設定なら 500 で明示メッセージを返す', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        displayName: 'Admin',
+        role: 'admin',
+        isAllowed: true,
+      });
+      const adminApp = createTestApp('admin-user');
+
+      // APP_ORIGIN が空のままリクエスト
+      const res = await adminApp.request('/api/users/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com', role: 'member' }),
+      });
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as any;
+      expect(String(body.error)).toContain('APP_ORIGIN');
+
+      // 早期 return なので DB にプレースホルダーは作られない
+      const [shouldNotExist] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.email, 'new@example.com'));
+      expect(shouldNotExist).toBeUndefined();
+    });
+  });
+
   describe('POST /api/users/me/fcm-tokens', () => {
     it('FCMトークンを追加できる', async () => {
       const res = await app.request('/api/users/me/fcm-tokens', {

--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -164,6 +164,27 @@ describe('Users API', () => {
       expect(body.user.role).toBe('admin');
     });
 
+    it('adminは他ユーザーのroleをpartnerに変更できる', async () => {
+      await db.insert(schema.users).values({
+        id: 'admin-user-2',
+        email: 'admin2@example.com',
+        displayName: 'Admin2',
+        role: 'admin',
+        isAllowed: true,
+      });
+
+      const adminApp = createTestApp('admin-user-2');
+      const res = await adminApp.request('/api/users/test-user', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: 'partner' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.user.role).toBe('partner');
+    });
+
     it('非adminが他ユーザーを更新しようとすると403', async () => {
       await db.insert(schema.users).values({
         id: 'other-user',
@@ -245,7 +266,8 @@ describe('Users API', () => {
         .from(schema.users)
         .where(eq(schema.users.id, 'disabled-user'));
       expect(restored.isAllowed).toBe(true);
-      expect(restored.role).toBe('admin');
+      // 再有効化では role は保持する（変更したい場合は PUT /:id で）
+      expect(restored.role).toBe('member');
     });
 
     it('APP_ORIGIN 未設定なら 500 で明示メッセージを返す', async () => {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -18,7 +18,7 @@ import { importHmacKey, generateSignedFileUrl } from '../lib/crypto';
 import type { Env } from '../index';
 import type { Database } from '../db';
 
-type SignEnv = Pick<Env['Bindings'], 'APP_ORIGIN' | 'INTERNAL_API_KEY'>;
+export type SignEnv = Pick<Env['Bindings'], 'APP_ORIGIN' | 'INTERNAL_API_KEY'>;
 
 type UserEnv = Env & { Variables: { db: Database; userId: string } };
 
@@ -41,7 +41,7 @@ const safeUserColumns = {
 };
 
 /** avatarUrl（R2キー）を署名付きURLに変換する */
-async function resolveAvatarUrl<T extends { avatarUrl: string | null }>(
+export async function resolveAvatarUrl<T extends { avatarUrl: string | null }>(
   user: T,
   env: SignEnv,
   cryptoKey?: CryptoKey
@@ -273,11 +273,11 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
     .where(eq(users.email, email));
 
   if (existing) {
-    // 無効化されたユーザーなら再有効化
+    // 無効化されたユーザーなら再有効化（既存roleは保持。role変更が必要なら別途 PUT /:id で）
     if (!existing.isAllowed) {
       await db
         .update(users)
-        .set({ isAllowed: true, role, updatedAt: new Date() })
+        .set({ isAllowed: true, updatedAt: new Date() })
         .where(eq(users.id, existing.id));
       return c.json({ success: true, restored: true });
     }

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -293,6 +293,13 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       500
     );
   }
+  // APP_ORIGIN がプロトコル抜け等の不正 URL だと Clerk 側で 400 になるため、ここで弾く
+  try {
+    new URL(appOrigin);
+  } catch {
+    console.error('[invite] APP_ORIGIN is not a valid URL', { appOrigin });
+    return c.json({ error: 'サーバー設定エラー: APP_ORIGIN の形式が不正です' }, 500);
+  }
 
   // DBにプレースホルダーユーザーを先に作成（整合性確保）
   const invitedId = `invited_${crypto.randomUUID()}`;
@@ -325,8 +332,10 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       errors?: Array<{ message?: string; long_message?: string; code?: string }>;
     };
     const clerkErrors = Array.isArray(clerkErr.errors) ? clerkErr.errors : [];
+    // PII を生で残さないようメアドはマスクしてログ
+    const maskedEmail = email.replace(/(^.).*(@.*$)/, '$1***$2');
     console.error('[invite] Clerk invitation failed', {
-      email,
+      email: maskedEmail,
       role,
       redirectUrl: `${appOrigin}/login`,
       status: clerkErr.status,
@@ -334,18 +343,17 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       raw: e instanceof Error ? e.message : String(e),
     });
 
-    // 4xx は Clerk が返した詳細メッセージをそのまま返し、500 は汎用メッセージで返す
-    const detail = clerkErrors
-      .map((err) => err.long_message || err.message || '')
-      .filter(Boolean)
-      .join(' / ');
-    const fallback = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
-    const message = detail || fallback;
+    // 4xx は Clerk が返した詳細メッセージをそのまま返す。5xx は内部情報露出を避けて固定文言
     const status = clerkErr.status;
     if (status && status >= 400 && status < 500) {
-      return c.json({ error: message }, 400);
+      const detail = clerkErrors
+        .map((err) => err.long_message || err.message || '')
+        .filter(Boolean)
+        .join(' / ');
+      const fallback = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+      return c.json({ error: detail || fallback }, 400);
     }
-    return c.json({ error: message }, 500);
+    return c.json({ error: '招待の送信に失敗しました。時間をおいて再試行してください。' }, 500);
   }
 
   return c.json({ success: true });

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -284,6 +284,16 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
     return c.json({ error: 'このメールアドレスは既に登録されています' }, 409);
   }
 
+  // APP_ORIGIN が未設定だと Clerk が redirectUrl を弾いて Bad Request になるため、事前に検知する
+  const appOrigin = c.env.APP_ORIGIN;
+  if (!appOrigin) {
+    console.error('[invite] APP_ORIGIN is not configured');
+    return c.json(
+      { error: 'サーバー設定エラー: APP_ORIGIN が未設定のため招待を送信できません' },
+      500
+    );
+  }
+
   // DBにプレースホルダーユーザーを先に作成（整合性確保）
   const invitedId = `invited_${crypto.randomUUID()}`;
   await db.insert(users).values({
@@ -296,7 +306,6 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
 
   // Clerk 招待送信（DB insert 成功後）
   const clerkClient = createClerkClient({ secretKey: c.env.CLERK_SECRET_KEY });
-  const appOrigin = c.env.APP_ORIGIN;
 
   try {
     await clerkClient.invitations.createInvitation({
@@ -309,7 +318,33 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       .delete(users)
       .where(eq(users.id, invitedId))
       .catch(() => {});
-    const message = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+
+    // Clerk SDK の例外から詳細を取り出し、構造化ログに残す
+    const clerkErr = e as {
+      status?: number;
+      errors?: Array<{ message?: string; long_message?: string; code?: string }>;
+    };
+    const clerkErrors = Array.isArray(clerkErr.errors) ? clerkErr.errors : [];
+    console.error('[invite] Clerk invitation failed', {
+      email,
+      role,
+      redirectUrl: `${appOrigin}/login`,
+      status: clerkErr.status,
+      errors: clerkErrors,
+      raw: e instanceof Error ? e.message : String(e),
+    });
+
+    // 4xx は Clerk が返した詳細メッセージをそのまま返し、500 は汎用メッセージで返す
+    const detail = clerkErrors
+      .map((err) => err.long_message || err.message || '')
+      .filter(Boolean)
+      .join(' / ');
+    const fallback = e instanceof Error ? e.message : 'Clerk招待に失敗しました';
+    const message = detail || fallback;
+    const status = clerkErr.status;
+    if (status && status >= 400 && status < 500) {
+      return c.json({ error: message }, 400);
+    }
     return c.json({ error: message }, 500);
   }
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -293,11 +293,18 @@ app.post('/invite', zValidator('json', inviteSchema), async (c) => {
       500
     );
   }
-  // APP_ORIGIN がプロトコル抜け等の不正 URL だと Clerk 側で 400 になるため、ここで弾く
+  // APP_ORIGIN がプロトコル抜け等の不正 URL だと Clerk 側で 400 になるため、ここで弾く。
+  // new URL('localhost:3000') は throw しない（'localhost:' をスキーマ扱いする）ので
+  // http(s) であることまで明示的に検証する。
+  let isValidHttpUrl = false;
   try {
-    new URL(appOrigin);
+    const parsed = new URL(appOrigin);
+    isValidHttpUrl = parsed.protocol === 'http:' || parsed.protocol === 'https:';
   } catch {
-    console.error('[invite] APP_ORIGIN is not a valid URL', { appOrigin });
+    isValidHttpUrl = false;
+  }
+  if (!isValidHttpUrl) {
+    console.error('[invite] APP_ORIGIN is not a valid http(s) URL', { appOrigin });
     return c.json({ error: 'サーバー設定エラー: APP_ORIGIN の形式が不正です' }, 500);
   }
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useAuth } from '../../hooks/useAuth';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { usePreviewMode } from '../../hooks/usePreviewMode';
+import { ROLE_LABELS_JA } from '../../lib/roleLabels';
 
 const NAV_ITEMS = [
   { path: '/dashboard', label: 'ダッシュボード', icon: <LayoutDashboard size={20} /> },
@@ -25,11 +26,6 @@ const NAV_ITEMS = [
   { path: '/report', label: 'レポート', icon: <BarChart3 size={20} /> },
   { path: '/contact', label: 'お問い合わせ', icon: <MessageSquare size={20} /> },
 ];
-
-const ROLE_LABELS: Record<string, string> = {
-  admin: '管理者',
-  member: 'メンバー',
-};
 
 export function Sidebar() {
   const { theme, toggleTheme } = useTheme();
@@ -40,7 +36,7 @@ export function Sidebar() {
   const displayName =
     currentUser?.displayName ?? clerkUser?.fullName ?? (isPreview ? 'プレビューユーザー' : '');
   const displayRole = currentUser?.role
-    ? (ROLE_LABELS[currentUser.role] ?? currentUser.role)
+    ? (ROLE_LABELS_JA[currentUser.role] ?? currentUser.role)
     : isPreview
       ? 'プレビュー'
       : '';

--- a/frontend/src/components/shared/UserSectionHeader.tsx
+++ b/frontend/src/components/shared/UserSectionHeader.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import { Avatar } from '../ui/Avatar';
+
+interface UserSectionHeaderProps {
+  /** ユーザー名 */
+  displayName: string;
+  /** ロール等の補助ラベル（例: 'リーダー' / 'パートナー'） */
+  roleLabel: string;
+  /** アバター画像URL（未指定なら colorName ベースの初期表示） */
+  avatarUrl?: string | null;
+  avatarColor?: string | null;
+  /** 件数バッジに表示する値（数値）。未指定なら非表示 */
+  count?: number;
+  /** 件数バッジの単位（例: '件' / '人'） */
+  countUnit?: string;
+  /** 右端に追加表示するノード（合計時間など） */
+  rightSlot?: ReactNode;
+}
+
+/**
+ * メンバー / パートナー一覧で共通利用するセクションヘッダー
+ * Avatar + 名前 + ロールラベル + 件数バッジ + 右端スロット
+ */
+export function UserSectionHeader({
+  displayName,
+  roleLabel,
+  avatarUrl,
+  avatarColor,
+  count,
+  countUnit = '件',
+  rightSlot,
+}: UserSectionHeaderProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <Avatar name={displayName} imageUrl={avatarUrl ?? undefined} colorName={avatarColor} />
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-bold text-text-primary">{displayName}</span>
+        <span className="text-xs text-text-tertiary">{roleLabel}</span>
+      </div>
+      <div className="flex-1" />
+      {count !== undefined && (
+        <span className="inline-flex items-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
+          {count}
+          {countUnit}
+        </span>
+      )}
+      {rightSlot}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useInviteUser.ts
+++ b/frontend/src/hooks/useInviteUser.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../lib/api';
 import { queryKeys } from '../lib/queryKeys';
+import type { UserRole } from '../types';
 import { useAuth } from './useAuth';
 
 /**
@@ -12,7 +13,7 @@ export function useInviteUser() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ email, role }: { email: string; role: 'admin' | 'member' }) =>
+    mutationFn: ({ email, role }: { email: string; role: UserRole }) =>
       apiClient<{ success: boolean; restored?: boolean }>('/api/users/invite', {
         method: 'POST',
         body: { email, role },

--- a/frontend/src/hooks/usePartnerReport.ts
+++ b/frontend/src/hooks/usePartnerReport.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../lib/api';
+import { queryKeys } from '../lib/queryKeys';
+import { useAuth } from './useAuth';
+
+export interface PartnerReportTask {
+  taskId: string;
+  title: string;
+  projectType: string;
+  durationSec: number;
+}
+
+export interface PartnerReportItem {
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  avatarColor: string | null;
+  totalDurationSec: number;
+  tasks: PartnerReportTask[];
+}
+
+interface PartnerReportResponse {
+  partners: PartnerReportItem[];
+  grandTotalDurationSec: number;
+}
+
+/**
+ * パートナー稼働時間レポートを取得
+ * GET /api/reports/time/partners?from=YYYY-MM-DD&to=YYYY-MM-DD
+ */
+export function usePartnerReport(fromDate: string, toDate: string, enabled = true) {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.partnerReport(fromDate, toDate),
+    queryFn: () =>
+      apiClient<PartnerReportResponse>(`/api/reports/time/partners?from=${fromDate}&to=${toDate}`, {
+        getToken,
+      }),
+    enabled: enabled && isSignedIn && !!fromDate && !!toDate,
+  });
+}

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -21,9 +21,13 @@ export type { ReportItem };
 
 /**
  * レポートデータを取得
- * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg
+ * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg|faq_imp
  */
-export function useReportData(type: 'normal' | 'brg', fromDate: string, toDate: string) {
+export function useReportData(
+  type: 'normal' | 'brg' | 'faq_imp',
+  fromDate: string,
+  toDate: string
+) {
   const { getToken, isSignedIn } = useAuth();
 
   return useQuery({
@@ -40,7 +44,7 @@ export function useReportData(type: 'normal' | 'brg', fromDate: string, toDate: 
  * レポートCSVをダウンロード
  */
 export async function downloadReportCsv(
-  type: 'normal' | 'brg',
+  type: 'normal' | 'brg' | 'faq_imp',
   fromDate: string,
   toDate: string,
   getToken: () => Promise<string | null>

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -24,7 +24,7 @@ export type { ReportItem };
  * レポートデータを取得
  * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg|faq_imp
  */
-export function useReportData(type: ReportType, fromDate: string, toDate: string) {
+export function useReportData(type: ReportType, fromDate: string, toDate: string, enabled = true) {
   const { getToken, isSignedIn } = useAuth();
 
   return useQuery({
@@ -33,7 +33,7 @@ export function useReportData(type: ReportType, fromDate: string, toDate: string
       apiClient<ReportResponse>(`/api/reports/time?from=${fromDate}&to=${toDate}&type=${type}`, {
         getToken,
       }),
-    enabled: isSignedIn && !!fromDate && !!toDate,
+    enabled: enabled && isSignedIn && !!fromDate && !!toDate,
   });
 }
 

--- a/frontend/src/hooks/useReportData.ts
+++ b/frontend/src/hooks/useReportData.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../lib/api';
 import { queryKeys } from '../lib/queryKeys';
 import { useAuth } from './useAuth';
+import type { ReportType } from '../types';
 
 interface ReportItem {
   title: string;
@@ -23,11 +24,7 @@ export type { ReportItem };
  * レポートデータを取得
  * GET /api/reports/time?from=YYYY-MM-DD&to=YYYY-MM-DD&type=normal|brg|faq_imp
  */
-export function useReportData(
-  type: 'normal' | 'brg' | 'faq_imp',
-  fromDate: string,
-  toDate: string
-) {
+export function useReportData(type: ReportType, fromDate: string, toDate: string) {
   const { getToken, isSignedIn } = useAuth();
 
   return useQuery({
@@ -44,7 +41,7 @@ export function useReportData(
  * レポートCSVをダウンロード
  */
 export async function downloadReportCsv(
-  type: 'normal' | 'brg' | 'faq_imp',
+  type: ReportType,
   fromDate: string,
   toDate: string,
   getToken: () => Promise<string | null>

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -35,6 +35,7 @@ export const queryKeys = {
 
   // Reports
   reports: (type: string, from: string, to: string) => ['reports', type, from, to] as const,
+  partnerReport: (from: string, to: string) => ['reports', 'partners', from, to] as const,
 
   // Contacts
   contacts: (status?: string) =>

--- a/frontend/src/lib/roleLabels.ts
+++ b/frontend/src/lib/roleLabels.ts
@@ -1,0 +1,27 @@
+import type { UserRole } from '../types';
+
+/** ロール表示ラベル（日本語・一般用途／設定・サイドバー等） */
+export const ROLE_LABELS_JA: Record<UserRole, string> = {
+  admin: '管理者',
+  member: 'メンバー',
+  partner: 'パートナー',
+};
+
+/** ロール表示ラベル（日本語・タスク一覧 / レポート列見出し用）
+ *  admin を「リーダー」と表記する慣習に合わせる
+ */
+export const ROLE_LABELS_TASK_JA: Record<UserRole, string> = {
+  admin: 'リーダー',
+  member: 'メンバー',
+  partner: 'パートナー',
+};
+
+/** ロール表示ラベル（英語・設定画面のドロップダウン用） */
+export const ROLE_LABELS_EN: Record<UserRole, string> = {
+  admin: 'Admin',
+  member: 'Member',
+  partner: 'Partner',
+};
+
+/** UserRole の全候補（フォーム選択肢など） */
+export const USER_ROLES: readonly UserRole[] = ['admin', 'member', 'partner'];

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -174,9 +174,10 @@ export function ReportPage() {
     setActiveTab(key as ReportTabId);
   };
 
-  const handlePartnerTaskClick = (taskId: string) => {
-    // partnerデータから該当タスクを引いてReportEntry形式に変換し、ReportDetailTabで詳細を出す
-    const task = partnerData?.partners.flatMap((p) => p.tasks).find((t) => t.taskId === taskId);
+  const handlePartnerTaskClick = (partnerId: string, taskId: string) => {
+    // 同一 taskId が複数 partner に存在しうるため、partnerId で対象を限定してから引く
+    const partner = partnerData?.partners.find((p) => p.userId === partnerId);
+    const task = partner?.tasks.find((t) => t.taskId === taskId);
     if (!task) return;
 
     setSelectedTask({

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -222,6 +222,7 @@ export function ReportPage() {
           <TabList>
             <Tab id="all">通常</Tab>
             <Tab id="brg">BRG</Tab>
+            <Tab id="faq_imp">FAQ_IMP</Tab>
           </TabList>
 
           <div className="mt-6 space-y-6">
@@ -249,6 +250,9 @@ export function ReportPage() {
                   <ReportTable entries={entries} onRowClick={handleRowClick} />
                 </TabPanel>
                 <TabPanel id="brg">
+                  <ReportTable entries={entries} onRowClick={handleRowClick} />
+                </TabPanel>
+                <TabPanel id="faq_imp">
                   <ReportTable entries={entries} onRowClick={handleRowClick} />
                 </TabPanel>
               </>

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -18,6 +18,12 @@ import { useToast } from '../../hooks/useToast';
 import { HttpError } from '../../lib/api';
 import type { ReportEntry, ReportType, TaskSession } from '../../types';
 
+const REPORT_TABS: { id: ReportType | 'all'; label: string }[] = [
+  { id: 'all', label: '通常' },
+  { id: 'brg', label: 'BRG' },
+  { id: 'faq_imp', label: 'FAQ_IMP' },
+];
+
 function getLastDayOfMonth(year: number, month: number): number {
   return new Date(year, month, 0).getDate();
 }
@@ -220,9 +226,11 @@ export function ReportPage() {
 
         <Tabs selectedKey={activeTab} onSelectionChange={handleTabChange}>
           <TabList>
-            <Tab id="all">通常</Tab>
-            <Tab id="brg">BRG</Tab>
-            <Tab id="faq_imp">FAQ_IMP</Tab>
+            {REPORT_TABS.map((t) => (
+              <Tab key={t.id} id={t.id}>
+                {t.label}
+              </Tab>
+            ))}
           </TabList>
 
           <div className="mt-6 space-y-6">
@@ -245,17 +253,11 @@ export function ReportPage() {
                 レポートの取得に失敗しました: {error.message}
               </div>
             ) : (
-              <>
-                <TabPanel id="all">
+              REPORT_TABS.map((t) => (
+                <TabPanel key={t.id} id={t.id}>
                   <ReportTable entries={entries} onRowClick={handleRowClick} />
                 </TabPanel>
-                <TabPanel id="brg">
-                  <ReportTable entries={entries} onRowClick={handleRowClick} />
-                </TabPanel>
-                <TabPanel id="faq_imp">
-                  <ReportTable entries={entries} onRowClick={handleRowClick} />
-                </TabPanel>
-              </>
+              ))
             )}
           </div>
         </Tabs>

--- a/frontend/src/pages/reports/ReportPage.tsx
+++ b/frontend/src/pages/reports/ReportPage.tsx
@@ -11,17 +11,22 @@ import { ReportToolbar } from './components/ReportToolbar';
 import { DateRangeRow } from './components/DateRangeRow';
 import { SummaryRow } from './components/SummaryRow';
 import { ReportTable } from './components/ReportTable';
+import { PartnerReportList } from './components/PartnerReportList';
 import { SessionEditModalContent } from './components/SessionEditModalContent';
 import { useReportData } from '../../hooks/useReportData';
+import { usePartnerReport } from '../../hooks/usePartnerReport';
 import { useExportToSheets } from '../../hooks/useExportToSheets';
 import { useToast } from '../../hooks/useToast';
 import { HttpError } from '../../lib/api';
 import type { ReportEntry, ReportType, TaskSession } from '../../types';
 
-const REPORT_TABS: { id: ReportType | 'all'; label: string }[] = [
+type ReportTabId = ReportType | 'all' | 'partner';
+
+const REPORT_TABS: { id: ReportTabId; label: string }[] = [
   { id: 'all', label: '通常' },
   { id: 'brg', label: 'BRG' },
   { id: 'faq_imp', label: 'FAQ_IMP' },
+  { id: 'partner', label: 'パートナー' },
 ];
 
 function getLastDayOfMonth(year: number, month: number): number {
@@ -47,7 +52,8 @@ export function ReportPage() {
   const [month, setMonth] = useState(now.getMonth() + 1);
 
   // タブ状態
-  const [activeTab, setActiveTab] = useState<ReportType | 'all'>('all');
+  const [activeTab, setActiveTab] = useState<ReportTabId>('all');
+  const isPartnerTab = activeTab === 'partner';
 
   // 上書き確認モーダル
   const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
@@ -62,18 +68,40 @@ export function ReportPage() {
     session: TaskSession;
   } | null>(null);
 
-  // ドロワー状態
-  const [selectedEntry, setSelectedEntry] = useState<ReportEntry | null>(null);
+  // ドロワー状態（kind は今後の編集権限制御等の拡張用に保持）
+  const [selectedTask, setSelectedTask] = useState<{
+    kind: 'report' | 'partner';
+    entry: ReportEntry;
+  } | null>(null);
+
+  const selectedEntry = selectedTask?.entry ?? null;
+  const selectedTaskId = selectedEntry?.taskId ?? null;
 
   // API用の日付
   const fromDate = formatDateISO(year, month, 1);
   const toDate = formatDateISO(year, month, getLastDayOfMonth(year, month));
 
-  // レポートデータ取得
-  const reportType = activeTab === 'all' ? 'normal' : activeTab;
-  const { data, isLoading, error } = useReportData(reportType, fromDate, toDate);
+  // レポートデータ取得（パートナータブ以外）
+  const reportType: ReportType =
+    activeTab === 'partner' || activeTab === 'all' ? 'normal' : activeTab;
+  const {
+    data,
+    isLoading: isTaskReportLoading,
+    error: taskReportError,
+  } = useReportData(reportType, fromDate, toDate, !isPartnerTab);
 
-  const totalDurationSec = data?.totalDurationSec ?? 0;
+  // パートナー稼働時間レポート取得
+  const {
+    data: partnerData,
+    isLoading: isPartnerLoading,
+    error: partnerError,
+  } = usePartnerReport(fromDate, toDate, isPartnerTab);
+
+  const isLoading = isPartnerTab ? isPartnerLoading : isTaskReportLoading;
+  const error = isPartnerTab ? partnerError : taskReportError;
+  const totalDurationSec = isPartnerTab
+    ? (partnerData?.grandTotalDurationSec ?? 0)
+    : (data?.totalDurationSec ?? 0);
 
   // API ReportItem → フロント ReportEntry にマッピング（メモ化）
   const entries = useMemo<ReportEntry[]>(
@@ -135,7 +163,7 @@ export function ReportPage() {
   }, []);
 
   const handleRowClick = (entry: ReportEntry) => {
-    setSelectedEntry(entry);
+    setSelectedTask({ kind: 'report', entry });
   };
 
   const handleEditSession = (entry: ReportEntry, session: TaskSession) => {
@@ -143,7 +171,28 @@ export function ReportPage() {
   };
 
   const handleTabChange = (key: React.Key) => {
-    setActiveTab(key as ReportType | 'all');
+    setActiveTab(key as ReportTabId);
+  };
+
+  const handlePartnerTaskClick = (taskId: string) => {
+    // partnerデータから該当タスクを引いてReportEntry形式に変換し、ReportDetailTabで詳細を出す
+    const task = partnerData?.partners.flatMap((p) => p.tasks).find((t) => t.taskId === taskId);
+    if (!task) return;
+
+    setSelectedTask({
+      kind: 'partner',
+      entry: {
+        id: taskId,
+        taskId,
+        title: task.title,
+        type: 'normal',
+        projectType: task.projectType,
+        totalDurationSec: task.durationSec,
+        sessions: [],
+        date: new Date(year, month - 1, 1),
+        currentUserUnrecorded: false,
+      },
+    });
   };
 
   const handleExportError = useCallback(
@@ -213,6 +262,7 @@ export function ReportPage() {
           isExporting={isProcessing}
           showDateRange={showDateRange}
           onToggleDateRange={() => setShowDateRange((v) => !v)}
+          isExportDisabled={isPartnerTab}
         />
 
         {showDateRange && (
@@ -234,9 +284,13 @@ export function ReportPage() {
           </TabList>
 
           <div className="mt-6 space-y-6">
-            <SummaryRow totalDurationSec={totalDurationSec} entryCount={entries.length} />
+            <SummaryRow
+              totalDurationSec={totalDurationSec}
+              entryCount={isPartnerTab ? (partnerData?.partners.length ?? 0) : entries.length}
+              countUnit={isPartnerTab ? '人' : '件'}
+            />
 
-            {entries.some((e) => e.currentUserUnrecorded) && (
+            {!isPartnerTab && entries.some((e) => e.currentUserUnrecorded) && (
               <div className="flex items-center gap-3">
                 <span className="inline-flex items-center rounded-full bg-error-bg px-3 py-1 text-xs font-medium text-error-text">
                   セッション未記録
@@ -255,7 +309,14 @@ export function ReportPage() {
             ) : (
               REPORT_TABS.map((t) => (
                 <TabPanel key={t.id} id={t.id}>
-                  <ReportTable entries={entries} onRowClick={handleRowClick} />
+                  {t.id === 'partner' ? (
+                    <PartnerReportList
+                      partners={partnerData?.partners ?? []}
+                      onTaskClick={handlePartnerTaskClick}
+                    />
+                  ) : (
+                    <ReportTable entries={entries} onRowClick={handleRowClick} />
+                  )}
                 </TabPanel>
               ))
             )}
@@ -264,14 +325,14 @@ export function ReportPage() {
       </div>
 
       <TaskDrawer
-        taskId={selectedEntry?.taskId ?? null}
-        onClose={() => setSelectedEntry(null)}
+        taskId={selectedTaskId}
+        onClose={() => setSelectedTask(null)}
         detailTabLabel="レポート詳細"
         detailPadding={false}
         detailContent={
           selectedEntry ? (
             <ReportDetailTab entry={selectedEntry} onEditSession={handleEditSession} />
-          ) : null
+          ) : undefined
         }
       />
 

--- a/frontend/src/pages/reports/components/PartnerReportList.tsx
+++ b/frontend/src/pages/reports/components/PartnerReportList.tsx
@@ -1,0 +1,79 @@
+import { UserSectionHeader } from '../../../components/shared/UserSectionHeader';
+import { formatDuration } from '../../../lib/taskUtils';
+import { ROLE_LABELS_JA } from '../../../lib/roleLabels';
+import type { PartnerReportItem } from '../../../hooks/usePartnerReport';
+
+interface PartnerReportListProps {
+  partners: PartnerReportItem[];
+  onTaskClick: (taskId: string) => void;
+}
+
+export function PartnerReportList({ partners, onTaskClick }: PartnerReportListProps) {
+  if (partners.length === 0) {
+    return (
+      <div className="rounded-xl border border-border-default bg-bg-primary px-4 py-8 text-center text-sm text-text-tertiary">
+        パートナーの稼働データがありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {partners.map((partner) => (
+        <PartnerSection key={partner.userId} partner={partner} onTaskClick={onTaskClick} />
+      ))}
+    </div>
+  );
+}
+
+interface PartnerSectionProps {
+  partner: PartnerReportItem;
+  onTaskClick: (taskId: string) => void;
+}
+
+function PartnerSection({ partner, onTaskClick }: PartnerSectionProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border-default bg-bg-primary">
+      <div className="border-b border-border-default">
+        <UserSectionHeader
+          displayName={partner.displayName}
+          roleLabel={ROLE_LABELS_JA.partner}
+          avatarUrl={partner.avatarUrl}
+          avatarColor={partner.avatarColor}
+          count={partner.tasks.length}
+          rightSlot={
+            <span className="text-sm font-bold text-text-primary">
+              {formatDuration(partner.totalDurationSec)}
+            </span>
+          }
+        />
+      </div>
+
+      {/* タスクテーブル */}
+      <div className="flex items-center gap-2 border-b border-border-default px-4 py-2">
+        <span className="flex-1 text-xs font-medium text-primary-default">タイトル</span>
+        <span className="w-[120px] text-xs font-medium text-primary-default">区分</span>
+        <span className="w-[120px] text-center text-xs font-medium text-primary-default">時間</span>
+      </div>
+
+      {partner.tasks.map((task, i) => (
+        <div key={task.taskId}>
+          {i > 0 && <div className="h-px bg-border-default" />}
+          <button
+            type="button"
+            onClick={() => onTaskClick(task.taskId)}
+            className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-bg-secondary"
+          >
+            <span className="flex-1 truncate text-sm text-text-primary">{task.title}</span>
+            <span className="w-[120px] truncate text-xs text-text-secondary">
+              {task.projectType}
+            </span>
+            <span className="w-[120px] text-center text-sm text-text-secondary">
+              {formatDuration(task.durationSec)}
+            </span>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/reports/components/PartnerReportList.tsx
+++ b/frontend/src/pages/reports/components/PartnerReportList.tsx
@@ -5,7 +5,8 @@ import type { PartnerReportItem } from '../../../hooks/usePartnerReport';
 
 interface PartnerReportListProps {
   partners: PartnerReportItem[];
-  onTaskClick: (taskId: string) => void;
+  /** クリックされたパートナーIDとタスクIDを返す（同一taskIdが複数partnerに存在しうるため両方必要） */
+  onTaskClick: (partnerId: string, taskId: string) => void;
 }
 
 export function PartnerReportList({ partners, onTaskClick }: PartnerReportListProps) {
@@ -28,7 +29,7 @@ export function PartnerReportList({ partners, onTaskClick }: PartnerReportListPr
 
 interface PartnerSectionProps {
   partner: PartnerReportItem;
-  onTaskClick: (taskId: string) => void;
+  onTaskClick: (partnerId: string, taskId: string) => void;
 }
 
 function PartnerSection({ partner, onTaskClick }: PartnerSectionProps) {
@@ -61,7 +62,7 @@ function PartnerSection({ partner, onTaskClick }: PartnerSectionProps) {
           {i > 0 && <div className="h-px bg-border-default" />}
           <button
             type="button"
-            onClick={() => onTaskClick(task.taskId)}
+            onClick={() => onTaskClick(partner.userId, task.taskId)}
             className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-bg-secondary"
           >
             <span className="flex-1 truncate text-sm text-text-primary">{task.title}</span>

--- a/frontend/src/pages/reports/components/ReportToolbar.tsx
+++ b/frontend/src/pages/reports/components/ReportToolbar.tsx
@@ -16,6 +16,8 @@ interface ReportToolbarProps {
   isExporting?: boolean;
   showDateRange?: boolean;
   onToggleDateRange?: () => void;
+  /** 出力ボタンを無効化する（パートナータブはスプレッドシート未対応） */
+  isExportDisabled?: boolean;
 }
 
 export function ReportToolbar({
@@ -27,6 +29,7 @@ export function ReportToolbar({
   isExporting = false,
   showDateRange = false,
   onToggleDateRange,
+  isExportDisabled = false,
 }: ReportToolbarProps) {
   const { isPreview } = usePreviewMode();
   const { addToast } = useToast();
@@ -89,7 +92,7 @@ export function ReportToolbar({
           variant="primary"
           size="sm"
           onPress={isPreview ? handlePreviewBlock : onExport}
-          isDisabled={isExporting}
+          isDisabled={isExporting || isExportDisabled}
         >
           {isExporting ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
           {isExporting ? '出力中...' : 'スプレッドシートに出力'}

--- a/frontend/src/pages/reports/components/SummaryRow.tsx
+++ b/frontend/src/pages/reports/components/SummaryRow.tsx
@@ -3,9 +3,11 @@ import { formatDuration } from '../../../lib/taskUtils';
 interface SummaryRowProps {
   totalDurationSec: number;
   entryCount: number;
+  /** カウントの単位（デフォルト: '件'）。パートナータブでは '人' を渡す */
+  countUnit?: string;
 }
 
-export function SummaryRow({ totalDurationSec, entryCount }: SummaryRowProps) {
+export function SummaryRow({ totalDurationSec, entryCount, countUnit = '件' }: SummaryRowProps) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-base font-medium text-text-secondary">合計:</span>
@@ -13,7 +15,8 @@ export function SummaryRow({ totalDurationSec, entryCount }: SummaryRowProps) {
         {formatDuration(totalDurationSec)}
       </span>
       <span className="inline-flex rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
-        {entryCount}件
+        {entryCount}
+        {countUnit}
       </span>
     </div>
   );

--- a/frontend/src/pages/settings/components/AddMemberModal.tsx
+++ b/frontend/src/pages/settings/components/AddMemberModal.tsx
@@ -2,16 +2,18 @@ import { useState } from 'react';
 import { Plus, ChevronDown } from 'lucide-react';
 import { Modal } from '../../../components/ui/Modal';
 import { Button } from '../../../components/ui/Button';
+import { ROLE_LABELS_EN, USER_ROLES } from '../../../lib/roleLabels';
+import type { UserRole } from '../../../types';
 
 interface AddMemberModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAdd: (email: string, role: 'Admin' | 'Member') => void;
+  onAdd: (email: string, role: UserRole) => void;
 }
 
 export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) {
   const [email, setEmail] = useState('');
-  const [role, setRole] = useState<'Admin' | 'Member'>('Member');
+  const [role, setRole] = useState<UserRole>('member');
   const [roleOpen, setRoleOpen] = useState(false);
 
   const handleAdd = () => {
@@ -20,12 +22,12 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) return;
     onAdd(trimmedEmail, role);
     setEmail('');
-    setRole('Member');
+    setRole('member');
   };
 
   const handleClose = () => {
     setEmail('');
-    setRole('Member');
+    setRole('member');
     setRoleOpen(false);
     onClose();
   };
@@ -77,7 +79,7 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
               aria-labelledby="member-role-label"
               className="flex h-10 w-full items-center justify-between rounded-md border border-border-default px-3 text-sm text-text-primary transition-colors hover:bg-bg-secondary"
             >
-              <span>{role}</span>
+              <span>{ROLE_LABELS_EN[role]}</span>
               <ChevronDown size={16} className="text-text-secondary" />
             </button>
             {roleOpen && (
@@ -88,7 +90,7 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
                   aria-labelledby="member-role-label"
                   className="absolute left-0 top-full z-20 mt-1 w-full overflow-hidden rounded-md border border-border-default bg-bg-primary shadow-lg"
                 >
-                  {(['Admin', 'Member'] as const).map((r) => (
+                  {USER_ROLES.map((r) => (
                     <button
                       key={r}
                       type="button"
@@ -100,7 +102,7 @@ export function AddMemberModal({ isOpen, onClose, onAdd }: AddMemberModalProps) 
                       }}
                       className="flex h-10 w-full items-center px-3 text-sm text-text-primary transition-colors hover:bg-bg-secondary"
                     >
-                      {r}
+                      {ROLE_LABELS_EN[r]}
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/settings/components/AdminTab.tsx
+++ b/frontend/src/pages/settings/components/AdminTab.tsx
@@ -11,7 +11,8 @@ import { useUpdateUser } from '../../../hooks/useUpdateUser';
 import { useInviteUser } from '../../../hooks/useInviteUser';
 import { usePreviewMode } from '../../../hooks/usePreviewMode';
 import { useToast } from '../../../hooks/useToast';
-import type { User } from '../../../types';
+import { ROLE_LABELS_EN, USER_ROLES } from '../../../lib/roleLabels';
+import type { User, UserRole } from '../../../types';
 
 const TABLE_COLUMNS = [
   { label: 'メンバー', width: 'w-[230px]' },
@@ -22,14 +23,14 @@ const TABLE_COLUMNS = [
 ];
 
 interface RoleDropdownProps {
-  value: 'admin' | 'member';
-  onChange: (role: 'admin' | 'member') => void;
+  value: UserRole;
+  onChange: (role: UserRole) => void;
   disabled?: boolean;
 }
 
 function RoleDropdown({ value, onChange, disabled }: RoleDropdownProps) {
   const [open, setOpen] = useState(false);
-  const displayValue = value === 'admin' ? 'Admin' : 'Member';
+  const displayValue = ROLE_LABELS_EN[value];
 
   return (
     <div className="relative">
@@ -50,8 +51,8 @@ function RoleDropdown({ value, onChange, disabled }: RoleDropdownProps) {
         <>
           <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
           <div className="absolute right-0 top-full z-20 mt-1 w-[120px] overflow-hidden rounded-md border border-border-default bg-bg-primary shadow-lg">
-            {(['admin', 'member'] as const).map((role) => {
-              const label = role === 'admin' ? 'Admin' : 'Member';
+            {USER_ROLES.map((role) => {
+              const label = ROLE_LABELS_EN[role];
               return (
                 <button
                   key={role}
@@ -93,14 +94,14 @@ export function AdminTab() {
     text: string;
   } | null>(null);
 
-  const handleRoleChange = (userId: string, role: 'admin' | 'member') => {
+  const handleRoleChange = (userId: string, role: UserRole) => {
     if (userId === currentUser?.id) return;
     updateUser.mutate({ userId, data: { role } });
   };
 
-  const handleAddMember = (email: string, role: 'Admin' | 'Member') => {
+  const handleAddMember = (email: string, role: UserRole) => {
     inviteUser.mutate(
-      { email, role: role.toLowerCase() as 'admin' | 'member' },
+      { email, role },
       {
         onSuccess: (data) => {
           setAddModalOpen(false);

--- a/frontend/src/pages/tasks/components/MemberCardSection.tsx
+++ b/frontend/src/pages/tasks/components/MemberCardSection.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
-import { Avatar } from '../../../components/ui/Avatar';
+import { UserSectionHeader } from '../../../components/shared/UserSectionHeader';
 import { CardSectionHeader } from './CardSectionHeader';
 import { TaskCard } from './TaskCard';
 import { FLOW_STATUS_ORDER, FLOW_STATUS_LABELS } from '../../../lib/constants';
+import { ROLE_LABELS_TASK_JA } from '../../../lib/roleLabels';
 import type { Task, User, FlowStatus } from '../../../types';
 
 interface MemberCardSectionProps {
@@ -12,8 +13,6 @@ interface MemberCardSectionProps {
 }
 
 export function MemberCardSection({ member, tasks, onTaskClick }: MemberCardSectionProps) {
-  const roleLabel = member.role === 'admin' ? 'リーダー' : 'メンバー';
-
   const columns = useMemo(() => {
     const grouped = new Map<FlowStatus, Task[]>();
     for (const status of FLOW_STATUS_ORDER) {
@@ -30,22 +29,13 @@ export function MemberCardSection({ member, tasks, onTaskClick }: MemberCardSect
 
   return (
     <div className="overflow-hidden rounded-lg border border-border-default bg-bg-primary">
-      {/* メンバーヘッダー */}
-      <div className="flex items-center gap-3 px-4 py-3">
-        <Avatar
-          name={member.displayName}
-          imageUrl={member.avatarUrl ?? undefined}
-          colorName={member.avatarColor}
-        />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-bold text-text-primary">{member.displayName}</span>
-          <span className="text-xs text-text-tertiary">{roleLabel}</span>
-        </div>
-        <div className="flex-1" />
-        <span className="inline-flex items-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
-          {tasks.length}件
-        </span>
-      </div>
+      <UserSectionHeader
+        displayName={member.displayName}
+        roleLabel={ROLE_LABELS_TASK_JA[member.role]}
+        avatarUrl={member.avatarUrl}
+        avatarColor={member.avatarColor}
+        count={tasks.length}
+      />
 
       {/* カンバンカラム */}
       <div className="flex gap-3 px-4 pb-4 pt-3">

--- a/frontend/src/pages/tasks/components/MemberSection.tsx
+++ b/frontend/src/pages/tasks/components/MemberSection.tsx
@@ -1,6 +1,7 @@
-import { Avatar } from '../../../components/ui/Avatar';
+import { UserSectionHeader } from '../../../components/shared/UserSectionHeader';
 import { TaskTableHeader } from './TaskTableHeader';
 import { TaskTableRow } from './TaskTableRow';
+import { ROLE_LABELS_TASK_JA } from '../../../lib/roleLabels';
 import type { Task, User } from '../../../types';
 
 interface MemberSectionProps {
@@ -10,26 +11,15 @@ interface MemberSectionProps {
 }
 
 export function MemberSection({ member, tasks, onTaskClick }: MemberSectionProps) {
-  const roleLabel = member.role === 'admin' ? 'リーダー' : 'メンバー';
-
   return (
     <div className="overflow-hidden rounded-lg border border-border-default bg-bg-primary">
-      {/* メンバーヘッダー */}
-      <div className="flex items-center gap-3 px-4 py-3">
-        <Avatar
-          name={member.displayName}
-          imageUrl={member.avatarUrl ?? undefined}
-          colorName={member.avatarColor}
-        />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-bold text-text-primary">{member.displayName}</span>
-          <span className="text-xs text-text-tertiary">{roleLabel}</span>
-        </div>
-        <div className="flex-1" />
-        <span className="inline-flex items-center rounded-full bg-bg-brand-subtle px-2 py-0.5 text-xs font-medium text-primary-default">
-          {tasks.length}件
-        </span>
-      </div>
+      <UserSectionHeader
+        displayName={member.displayName}
+        roleLabel={ROLE_LABELS_TASK_JA[member.role]}
+        avatarUrl={member.avatarUrl}
+        avatarColor={member.avatarColor}
+        count={tasks.length}
+      />
 
       {/* テーブル */}
       <TaskTableHeader />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -213,7 +213,7 @@ export interface AppNotification {
   createdAt: string;
 }
 
-export type ReportType = 'normal' | 'brg';
+export type ReportType = 'normal' | 'brg' | 'faq_imp';
 
 export interface ReportEntry {
   id: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,7 @@ export const PROJECT_TYPES = [
   'DMREG2',
   'monosus',
   'PRREG',
+  'FAQ_IMP',
 ] as const;
 
 export type ProjectType = (typeof PROJECT_TYPES)[number];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,7 +16,7 @@ export const PROJECT_TYPES = [
 
 export type ProjectType = (typeof PROJECT_TYPES)[number];
 
-export type UserRole = 'admin' | 'member';
+export type UserRole = 'admin' | 'member' | 'partner';
 
 export type FlowStatus =
   | '未着手'


### PR DESCRIPTION
## 概要

develop → main の本番リリースPR（24コミット / PR 4本分）。

## 含まれる変更

| PR | 内容 |
|---|---|
| #152 | 🐛 Backlog課題更新Webhookで日付が反映されない問題を修正（changes差分パース対応 + 日付null上書き防止） |
| #150 | ✨ partner ロール追加（レポート画面パートナータブ、稼働時間レポートAPI） |
| #149 / #148 | 🐛 メンバー招待のエラーハンドリング強化（Clerk失敗分岐、APP_ORIGIN検証） |
| #147 | ✨ プロジェクト区分 FAQ_IMP 追加（※現本番はFAQ_IMPチケットのWebhookを unknown projectType で拒否中 → 本リリースで解消） |

DBマイグレーション2本を含む: `project_type` に `FAQ_IMP`、`user_role` に `partner`（enum追加）

## デプロイの流れ

**マージすると GitHub Actions（Deploy Production）が自動実行**: テスト → DBマイグレーション適用 → Workers本番デプロイ

### マージ後の手動作業

1. Actions の **Deploy Production が成功したのを確認**
2. Backlog管理画面 → Webhook設定 → 通知イベントに **「課題の更新」** を追加（対象: REG2017 / BRGREG / PRREG / DMREG2）
   - ⚠️ デプロイ完了前にやると旧コードが日付をnull上書きするので、必ずActions成功後に実施
3. 動作確認: BacklogでチケットのＩＴ予定日を変更 → Chumoに反映確認 + Workers Logs で `changesCount` / `no date fields matched in changes` をチェック

## テスト

- [x] backend: 164件全パス
- [x] lint / type-check クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ff1qnrQ3nrBtz3JPUXEe