### PR TITLE
🐛 fix(backlog): VUP後の属性ID・日付形式対応と複製タスク防止

### DIFF
--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -73,6 +73,14 @@ describe('Backlog ユーティリティ', () => {
       expect(parseDateString('2025/13/01')).toBeNull();
     });
 
+    it('ISO日時形式（Backlog VUP後の日付属性値）をパースする', () => {
+      const date = parseDateString('2026-07-15T00:00:00Z');
+      expect(date).not.toBeNull();
+      expect(date!.getFullYear()).toBe(2026);
+      expect(date!.getMonth()).toBe(6);
+      expect(date!.getDate()).toBe(15);
+    });
+
     it('自動調整される日付 → null', () => {
       expect(parseDateString('2025/02/30')).toBeNull();
     });
@@ -205,7 +213,7 @@ describe('Backlog ユーティリティ', () => {
       const changes = [
         {
           field: 'ＩＴ予定日',
-          new_value: '2026-07-15T00:00:00Z',
+          new_value: '2026年7月15日',
           old_value: '',
           type: 'custom',
         },
@@ -221,13 +229,31 @@ describe('Backlog ユーティリティ', () => {
         resolveCustomDateField(customFields, undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
       ).toBeUndefined();
     });
+
+    it('IDが不一致でも属性名+日付型でフォールバック照合できる', () => {
+      // Backlog VUPでIDが振り直された想定: 設定ID(25)と実ID(999)が不一致
+      const customFields = [
+        { id: 999, fieldTypeId: 4, name: 'ＩＴ予定日', value: '2026-07-15T00:00:00Z' },
+        { id: 998, fieldTypeId: 5, name: 'リリース日の重要度', value: { name: '変更可' } },
+      ];
+      const date = resolveCustomDateField(customFields, undefined, 25, IT_UP_DATE_FIELD_NAMES);
+      expect(date).toBeInstanceOf(Date);
+      expect(date!.getDate()).toBe(15);
+    });
+
+    it('属性名が一致しても日付型でなければフォールバックしない', () => {
+      const customFields = [{ id: 999, fieldTypeId: 1, name: 'ＩＴ予定日', value: 'テキスト値' }];
+      expect(
+        resolveCustomDateField(customFields, undefined, 25, IT_UP_DATE_FIELD_NAMES)
+      ).toBeUndefined();
+    });
   });
 
   describe('getCustomFieldConfig', () => {
     it('REG2017のカスタムフィールドIDを返す', () => {
       const config = getCustomFieldConfig('REG2017');
-      expect(config.itUpDate).toBe(1073783169);
-      expect(config.releaseDate).toBe(1073783170);
+      expect(config.itUpDate).toBe(25);
+      expect(config.releaseDate).toBe(30);
     });
 
     it('MONOは空オブジェクトを返す', () => {

--- a/backend/src/lib/backlog.test.ts
+++ b/backend/src/lib/backlog.test.ts
@@ -106,13 +106,9 @@ describe('Backlog ユーティリティ', () => {
       );
     });
 
-    it('ID文字列でマッチする', () => {
-      const changes = [
-        { field: '1073783169', new_value: '2026/07/15', old_value: '', type: 'custom' },
-      ];
-      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
-        '2026/07/15'
-      );
+    it('裸のID文字列にはマッチしない（小さいIDの誤マッチ防止）', () => {
+      const changes = [{ field: '25', new_value: '2026/07/15', old_value: '', type: 'custom' }];
+      expect(getChangedCustomFieldValue(changes, 25, IT_UP_DATE_FIELD_NAMES)).toBeUndefined();
     });
 
     it('対象フィールドの変更が無い → undefined', () => {
@@ -133,15 +129,6 @@ describe('Backlog ユーティリティ', () => {
       expect(
         getChangedCustomFieldValue(undefined, 1073783169, IT_UP_DATE_FIELD_NAMES)
       ).toBeUndefined();
-    });
-
-    it('fieldが数値でもマッチする（外部JSONの型ゆらぎ対策）', () => {
-      const changes = [
-        { field: 1073783169 as unknown as string, new_value: '2026/07/15', old_value: '' },
-      ];
-      expect(getChangedCustomFieldValue(changes, 1073783169, IT_UP_DATE_FIELD_NAMES)).toBe(
-        '2026/07/15'
-      );
     });
 
     it('new_valueがnull → 空文字（クリア扱い）', () => {

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -199,7 +199,8 @@ export function getChangedCustomFieldValue(
   if (!Array.isArray(changes)) return undefined;
 
   // TODO: 実ペイロードで field の表記が確定したら候補を絞る（route側の unmatched ログで確認可能）
-  const candidates = new Set<string>([`customField_${fieldId}`, String(fieldId), ...fieldNames]);
+  // 裸のID文字列は候補にしない: 新BacklogのIDは小さい整数（"25"等）で誤マッチのリスクがある
+  const candidates = new Set<string>([`customField_${fieldId}`, ...fieldNames]);
   const change = changes.find((c) => c.field != null && candidates.has(String(c.field).trim()));
   if (!change) return undefined;
 
@@ -226,16 +227,15 @@ export function resolveCustomDateField(
   if (!fieldId) return undefined;
 
   if (Array.isArray(customFields)) {
-    // ID一致を優先し、不一致なら属性名 + 日付型で照合
-    // （BacklogのバージョンアップでIDが振り直されても名前で追従できるようにする）
+    // 属性名 + 日付型での照合を優先し、name が無いペイロードでは ID で照合
+    // （BacklogのバージョンアップでIDが振り直し・再割当されても名前で正しく追従できるようにする）
     const field =
-      customFields.find((f) => f.id === fieldId) ??
       customFields.find(
         (f) =>
           f.fieldTypeId === FIELD_TYPE_DATE &&
           typeof f.name === 'string' &&
           fieldNames.includes(f.name.trim())
-      );
+      ) ?? customFields.find((f) => f.id === fieldId);
     if (field) return parseDateValue(extractCustomFieldValue(field));
   }
 

--- a/backend/src/lib/backlog.ts
+++ b/backend/src/lib/backlog.ts
@@ -16,15 +16,21 @@ interface BacklogCustomFieldConfig {
   releaseDate?: number;
 }
 
+/**
+ * プロジェクトごとの日付カスタム属性ID。
+ * 2026年5月のBacklogバージョンアップで全プロジェクトのIDが振り直されたため、
+ * ID不一致の場合でも属性名（ＩＴ予定日/本番リリース予定日）+ 日付型で照合するフォールバックがある。
+ * IDの確認方法: GET /backlog/api/v2/projects/:projectKey/customFields
+ */
 const BACKLOG_CUSTOM_FIELDS: Record<ProjectType, BacklogCustomFieldConfig> = {
-  REG2017: { itUpDate: 1073783169, releaseDate: 1073783170 },
-  BRGREG: { itUpDate: 1073754985, releaseDate: 1073754988 },
-  PRREG: { itUpDate: 1073748055, releaseDate: 1073747940 },
+  REG2017: { itUpDate: 25, releaseDate: 30 },
+  BRGREG: { itUpDate: 4, releaseDate: 5 },
+  PRREG: { itUpDate: 32, releaseDate: 36 },
   MONO: {},
   MONO_ADMIN: {},
   DES_FIRE: {},
   DesignSystem: {},
-  DMREG2: { itUpDate: 1073767877, releaseDate: 1073767878 },
+  DMREG2: { itUpDate: 16, releaseDate: 15 },
   monosus: {},
   FAQ_IMP: {},
 };
@@ -46,9 +52,14 @@ export const RELEASE_DATE_FIELD_NAMES = ['本番リリース予定日', 'リリ�
 export interface BacklogCustomField {
   id: number;
   field?: string;
+  /** カスタム属性名（例: "ＩＴ予定日"） */
+  name?: string;
   value: string | { name?: string; value?: string } | null;
   fieldTypeId: number;
 }
+
+/** Backlogカスタム属性の日付型を表す fieldTypeId */
+const FIELD_TYPE_DATE = 4;
 
 /** 課題更新 Webhook の content.changes の1エントリ */
 export interface BacklogChange {
@@ -118,12 +129,15 @@ export function generateBacklogUrl(issueKey: string): string {
 }
 
 /**
- * 日付文字列（YYYY/MM/DD or YYYY-MM-DD）をDateに変換
+ * 日付文字列をDateに変換
+ * 対応形式: YYYY/MM/DD、YYYY-MM-DD、ISO日時（例: 2026-07-15T00:00:00Z ※日付部分のみ使用）
  */
 export function parseDateString(dateString: string | null | undefined): Date | null {
   if (!dateString || typeof dateString !== 'string') return null;
 
-  const match = dateString.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/);
+  // ISO日時形式は日付部分のみを対象にする（Backlog VUP後の日付属性はこの形式で届く）
+  const datePart = dateString.split('T')[0];
+  const match = datePart.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/);
   if (!match) return null;
 
   const [, year, month, day] = match;
@@ -212,7 +226,16 @@ export function resolveCustomDateField(
   if (!fieldId) return undefined;
 
   if (Array.isArray(customFields)) {
-    const field = customFields.find((f) => f.id === fieldId);
+    // ID一致を優先し、不一致なら属性名 + 日付型で照合
+    // （BacklogのバージョンアップでIDが振り直されても名前で追従できるようにする）
+    const field =
+      customFields.find((f) => f.id === fieldId) ??
+      customFields.find(
+        (f) =>
+          f.fieldTypeId === FIELD_TYPE_DATE &&
+          typeof f.name === 'string' &&
+          fieldNames.includes(f.name.trim())
+      );
     if (field) return parseDateValue(extractCustomFieldValue(field));
   }
 

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -116,7 +116,7 @@ describe('Backlog API', () => {
       expect(body.projectType).toBe('MONO');
     });
 
-    it('カスタムフィールドから日付を抽出できる', async () => {
+    it('カスタムフィールドから日付を抽出できる（実ペイロード形式）', async () => {
       const res = await postWebhook({
         project: { projectKey: 'REG2017' },
         content: {
@@ -124,8 +124,8 @@ describe('Backlog API', () => {
           key_id: 200,
           summary: '日付テスト',
           customFields: [
-            { id: 1073783169, value: '2025/07/15', fieldTypeId: 4 },
-            { id: 1073783170, value: { name: '2025/08/01' }, fieldTypeId: 4 },
+            { id: 25, fieldTypeId: 4, name: 'ＩＴ予定日', value: '2026-07-15T00:00:00Z' },
+            { id: 30, fieldTypeId: 4, name: '本番リリース予定日', value: '2026-07-31T00:00:00Z' },
           ],
         },
       });
@@ -138,6 +138,27 @@ describe('Backlog API', () => {
       expect(task.releaseDate).not.toBeNull();
     });
 
+    it('設定IDと不一致でも属性名で日付を抽出できる（ID振り直し耐性）', async () => {
+      const res = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 201,
+          key_id: 201,
+          summary: 'IDずれテスト',
+          customFields: [
+            { id: 12345, fieldTypeId: 4, name: 'ＩＴ予定日', value: '2026-07-15T00:00:00Z' },
+          ],
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, body.taskId));
+      expect(task.itUpDate).not.toBeNull();
+      expect(task.releaseDate).toBeNull();
+    });
+
     it('更新イベント（customFieldsなし）でも既存の日付を消さない', async () => {
       // 作成: 日付あり
       const res1 = await postWebhook({
@@ -147,8 +168,8 @@ describe('Backlog API', () => {
           key_id: 300,
           summary: '日付保持テスト',
           customFields: [
-            { id: 1073783169, value: '2026/07/15', fieldTypeId: 4 },
-            { id: 1073783170, value: '2026/08/01', fieldTypeId: 4 },
+            { id: 25, fieldTypeId: 4, name: 'ＩＴ予定日', value: '2026/07/15' },
+            { id: 30, fieldTypeId: 4, name: '本番リリース予定日', value: '2026/08/01' },
           ],
         },
       });
@@ -222,7 +243,7 @@ describe('Backlog API', () => {
           summary: 'ID形式テスト',
           changes: [
             {
-              field: 'customField_1073754985',
+              field: 'customField_4',
               new_value: '2026/07/22',
               old_value: '',
               type: 'custom',
@@ -245,7 +266,7 @@ describe('Backlog API', () => {
           id: 303,
           key_id: 303,
           summary: '日付クリアテスト',
-          customFields: [{ id: 1073783169, value: '2026/07/15', fieldTypeId: 4 }],
+          customFields: [{ id: 25, fieldTypeId: 4, name: 'ＩＴ予定日', value: '2026/07/15' }],
         },
       });
       const body1 = (await res1.json()) as any;

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -259,6 +259,97 @@ describe('Backlog API', () => {
       expect(task.releaseDate).toBeNull();
     });
 
+    it('外部連携なしの手動作成タスクに複製を作らずリンクして更新する', async () => {
+      // 手動作成タスク（task_externals なし・日付は手入力済み）
+      const manualTaskId = 'manual-task-00000001';
+      await db.insert(schema.tasks).values({
+        id: manualTaskId,
+        projectType: 'REG2017',
+        title: 'REG2017-900 手動作成タスク',
+        flowStatus: '対応中',
+        assigneeIds: [],
+        itUpDate: new Date('2026-07-13'),
+        releaseDate: new Date('2026-07-31'),
+        kubunLabelId: '',
+        order: 1,
+        createdBy: 'user_test',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // 同じ課題番号の更新イベント（日付情報なし）
+      const res = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: {
+          id: 900,
+          key_id: 900,
+          summary: '手動作成タスク（Backlog側タイトル）',
+          changes: [
+            { field: 'assigner', new_value: 'user2', old_value: 'user1', type: 'standard' },
+          ],
+        },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+
+      // 複製されず手動タスクにリンクされる
+      expect(body.taskId).toBe(manualTaskId);
+      expect(body.updated).toBe(true);
+      expect(body.linked).toBe(true);
+
+      const allTasks = await db
+        .select()
+        .from(schema.tasks)
+        .where(eq(schema.tasks.projectType, 'REG2017'));
+      expect(allTasks).toHaveLength(1);
+
+      // 外部連携が作成され、手入力の日付は保持される
+      const [ext] = await db
+        .select()
+        .from(schema.taskExternals)
+        .where(eq(schema.taskExternals.taskId, manualTaskId));
+      expect(ext.issueKey).toBe('REG2017-900');
+      const [task] = await db.select().from(schema.tasks).where(eq(schema.tasks.id, manualTaskId));
+      expect(task.title).toBe('REG2017-900 手動作成タスク（Backlog側タイトル）');
+      expect(task.itUpDate).not.toBeNull();
+      expect(task.releaseDate).not.toBeNull();
+
+      // 2回目のイベントでも同じタスクが更新される（冪等）
+      const res2 = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 900, key_id: 900, summary: '再更新' },
+      });
+      const body2 = (await res2.json()) as any;
+      expect(body2.taskId).toBe(manualTaskId);
+      expect(body2.linked).toBeUndefined();
+    });
+
+    it('課題番号が前方一致するだけの別タスクにはリンクしない', async () => {
+      // REG2017-90 のタスク（REG2017-900 とは別課題）
+      await db.insert(schema.tasks).values({
+        id: 'manual-task-00000002',
+        projectType: 'REG2017',
+        title: 'REG2017-90 別のタスク',
+        flowStatus: '対応中',
+        assigneeIds: [],
+        kubunLabelId: '',
+        order: 1,
+        createdBy: 'user_test',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await postWebhook({
+        project: { projectKey: 'REG2017' },
+        content: { id: 900, key_id: 900, summary: '新規課題' },
+      });
+      const body = (await res.json()) as any;
+
+      // リンクされず新規作成される
+      expect(body.taskId).not.toBe('manual-task-00000002');
+      expect(body.linked).toBeUndefined();
+    });
+
     it('更新イベントで日付がクリアされたらnullにする', async () => {
       const res1 = await postWebhook({
         project: { projectKey: 'REG2017' },

--- a/backend/src/routes/backlog.test.ts
+++ b/backend/src/routes/backlog.test.ts
@@ -324,6 +324,45 @@ describe('Backlog API', () => {
       expect(body2.linked).toBeUndefined();
     });
 
+    it('同一課題の同時配信でも500にならず片方のタスクに収束する', async () => {
+      // 未リンクの手動作成タスク
+      await db.insert(schema.tasks).values({
+        id: 'manual-task-00000003',
+        projectType: 'REG2017',
+        title: 'REG2017-901 同時配信テスト',
+        flowStatus: '対応中',
+        assigneeIds: [],
+        kubunLabelId: '',
+        order: 1,
+        createdBy: 'user_test',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // 同じイベントの重複配信を並行実行
+      const payload = {
+        project: { projectKey: 'REG2017' },
+        content: { id: 901, key_id: 901, summary: '同時配信テスト' },
+      };
+      const [res1, res2] = await Promise.all([postWebhook(payload), postWebhook(payload)]);
+
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+
+      // タスクは増えず、リンクは1本だけ
+      const allTasks = await db
+        .select()
+        .from(schema.tasks)
+        .where(eq(schema.tasks.projectType, 'REG2017'));
+      expect(allTasks).toHaveLength(1);
+      const exts = await db
+        .select()
+        .from(schema.taskExternals)
+        .where(eq(schema.taskExternals.issueKey, 'REG2017-901'));
+      expect(exts).toHaveLength(1);
+      expect(exts[0].taskId).toBe('manual-task-00000003');
+    });
+
     it('課題番号が前方一致するだけの別タスクにはリンクしない', async () => {
       // REG2017-90 のタスク（REG2017-900 とは別課題）
       await db.insert(schema.tasks).values({

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -131,22 +131,37 @@ app.post('/webhook', async (c) => {
       .limit(1);
 
     if (unlinkedTask) {
-      await db.insert(taskExternals).values({
-        id: generateId(),
-        taskId: unlinkedTask.id,
-        source: 'backlog',
-        issueId: finalIssueId,
-        issueKey,
-        url,
-        lastSyncedAt: now,
-        syncStatus: 'ok',
-      });
-      existingTaskId = unlinkedTask.id;
-      linked = true;
-      console.info('[backlog/webhook] linked unlinked task by title', {
-        taskId: unlinkedTask.id,
-        issueKey,
-      });
+      try {
+        await db.insert(taskExternals).values({
+          id: generateId(),
+          taskId: unlinkedTask.id,
+          source: 'backlog',
+          issueId: finalIssueId,
+          issueKey,
+          url,
+          lastSyncedAt: now,
+          syncStatus: 'ok',
+        });
+        existingTaskId = unlinkedTask.id;
+        linked = true;
+        console.info('[backlog/webhook] linked unlinked task by title', {
+          taskId: unlinkedTask.id,
+          issueKey,
+        });
+      } catch (err) {
+        // Webhookの重複配信で別リクエストが先にリンクした場合（UNIQUE制約違反）は
+        // 既存リンクへフォールバックして通常の更新フローに乗せる
+        const [raceExternal] = await db
+          .select({ taskId: taskExternals.taskId })
+          .from(taskExternals)
+          .where(eq(taskExternals.issueKey, issueKey));
+        if (!raceExternal) throw err;
+        existingTaskId = raceExternal.taskId;
+        console.info('[backlog/webhook] link race detected, fell back to existing link', {
+          taskId: raceExternal.taskId,
+          issueKey,
+        });
+      }
     }
   }
 

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -165,21 +165,23 @@ app.post('/webhook', async (c) => {
       })
       .where(eq(tasks.id, existingTaskId));
 
-    await db
-      .update(taskExternals)
-      .set({
-        issueId: finalIssueId,
-        url,
-        lastSyncedAt: now,
-        syncStatus: 'ok',
-      })
-      .where(eq(taskExternals.taskId, existingTaskId));
+    // リンク直後は insert したばかりの値と同一なので更新不要
+    if (!linked) {
+      await db
+        .update(taskExternals)
+        .set({
+          issueId: finalIssueId,
+          url,
+          lastSyncedAt: now,
+          syncStatus: 'ok',
+        })
+        .where(eq(taskExternals.taskId, existingTaskId));
+    }
 
     console.info('[backlog/webhook] updated task', {
       taskId: existingTaskId,
       issueKey,
       projectType,
-      linked,
     });
 
     return c.json({

--- a/backend/src/routes/backlog.ts
+++ b/backend/src/routes/backlog.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod/v4';
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
+import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 import { tasks, taskExternals } from '../db/schema';
 import { generateId } from '../lib/id';
 import {
@@ -115,8 +115,42 @@ app.post('/webhook', async (c) => {
     .where(eq(taskExternals.issueKey, issueKey));
 
   const now = new Date();
+  let existingTaskId = existingExternal?.taskId ?? null;
+  let linked = false;
 
-  if (existingExternal) {
+  // 外部連携が無い場合、タイトル先頭の課題番号が一致する未リンクタスクを探してリンクする
+  // （Webhook停止期間などに手動作成されたタスクへの重複作成を防ぐ）
+  if (!existingTaskId) {
+    const titlePattern = `^${issueKey}([ 　]|$)`;
+    const [unlinkedTask] = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .leftJoin(taskExternals, eq(taskExternals.taskId, tasks.id))
+      .where(and(isNull(taskExternals.id), sql`${tasks.title} ~ ${titlePattern}`))
+      .orderBy(asc(tasks.createdAt))
+      .limit(1);
+
+    if (unlinkedTask) {
+      await db.insert(taskExternals).values({
+        id: generateId(),
+        taskId: unlinkedTask.id,
+        source: 'backlog',
+        issueId: finalIssueId,
+        issueKey,
+        url,
+        lastSyncedAt: now,
+        syncStatus: 'ok',
+      });
+      existingTaskId = unlinkedTask.id;
+      linked = true;
+      console.info('[backlog/webhook] linked unlinked task by title', {
+        taskId: unlinkedTask.id,
+        issueKey,
+      });
+    }
+  }
+
+  if (existingTaskId) {
     // 更新
     await db
       .update(tasks)
@@ -126,9 +160,10 @@ app.post('/webhook', async (c) => {
         projectType: projectType as (typeof tasks.projectType.enumValues)[number],
         ...(itUpDate !== undefined && { itUpDate }),
         ...(releaseDate !== undefined && { releaseDate }),
+        ...(linked && { backlogUrl: url }),
         updatedAt: now,
       })
-      .where(eq(tasks.id, existingExternal.taskId));
+      .where(eq(tasks.id, existingTaskId));
 
     await db
       .update(taskExternals)
@@ -138,20 +173,22 @@ app.post('/webhook', async (c) => {
         lastSyncedAt: now,
         syncStatus: 'ok',
       })
-      .where(eq(taskExternals.taskId, existingExternal.taskId));
+      .where(eq(taskExternals.taskId, existingTaskId));
 
     console.info('[backlog/webhook] updated task', {
-      taskId: existingExternal.taskId,
+      taskId: existingTaskId,
       issueKey,
       projectType,
+      linked,
     });
 
     return c.json({
       success: true,
-      taskId: existingExternal.taskId,
+      taskId: existingTaskId,
       projectType,
       issueKey,
       updated: true,
+      ...(linked && { linked: true }),
     });
   }
 


### PR DESCRIPTION
## 概要

Backlog 2026年5月バージョンアップ起因の日付同期全滅と、手動作成タスクへの複製量産の2バグを修正。

## 背景（調査で確定した事実）

1. **VUPで全プロジェクトのカスタム属性IDが振り直された**（例: REG2017のＩＴ予定日 1073783169 → 25）。旧ID前提の設定のため、VUP以降は全プロジェクトで日付同期が機能していなかった（同期できていたように見えたタスクは全てChumo側での手入力）
2. **日付属性の値形式も変更**: `2026/07/15` → `2026-07-15T00:00:00Z`（ISO日時）
3. **手動作成タスク約96件が task_externals 未リンク**のため、課題の更新イベントが届くたびに複製タスクが作成されていた（REG2017-2355 では削除→別の更新で再作成まで発生）

裏付け: Backlog API `GET /api/v2/projects/:key/customFields` の実データ、Workers Logs、本番DBの照合による。

## 修正内容

### 日付同期（`6536b9a`）
- カスタム属性IDを新Backlogの値に更新（REG2017: 25/30、BRGREG: 4/5、PRREG: 32/36、DMREG2: 16/15）
- 属性名「ＩＴ予定日」「本番リリース予定日」+ 日付型での照合を優先し、name の無いペイロードはIDで照合（次回のID振り直し・再割当にも耐性）
- `parseDateString` にISO日時形式対応を追加

### 複製防止（`996170e`）
- 外部連携が無い場合、タイトル先頭の課題番号が一致する未リンクタスクを検索し、複製を作らずリンク+更新
- 課題番号の照合は境界チェック付き（`REG2017-235` が `REG2017-2355` に誤マッチしない）
- 未リンクの手動作成タスクは、次のWebhookイベント受信時に自動でリンクされ以後同期対象になる（自己修復）

### simplify整理（`c37bb11`）
- changes照合から裸のID文字列候補を削除（小さい新IDでの誤マッチ防止）
- 自動リンク直後の二重書き込み解消、ログ整理

## テスト

- [x] backend: 169件全パス（実ペイロード形式のテストを含む）
- [x] lint / type-check クリーン

## マージ後の確認

1. GitHub Actions（Deploy Production ※mainへのリリース時）完了後、Backlogで任意のチケットのＩＴ予定日を変更 → Chumo反映を確認
2. Workers Logs で `no date fields matched in changes` が出ていないか確認（出た場合は `changeFields` に実際の表記が記録される）

※ 既存の複製タスク（REG2017-2355 / PRREG-1396 のsystem作成分）は手動削除で対応予定。複製側が連携を握っているため、削除後の次イベントで手動タスク側に自動リンクされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ff1qnrQ3nrBtz3JPUXEe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * バックログ連携で、日付カスタム項目の判定がより柔軟になりました。IDが変わっても、項目名と日付形式で正しく関連付けできるケースが増えています。
  * 更新イベントで、既存の未リンクタスクを見つけてリンクし、そのまま更新できるようになりました。

* **バグ修正**
  * 日付文字列の解釈を改善し、ISO形式の日時入力にも対応しました。
  * 誤った項目への一致や、日付が消えてしまう問題を抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->